### PR TITLE
Reuse OBJECT libraries when building true libraries

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -1,6 +1,11 @@
 name: C/C++ CI
 
-on: push
+on:
+  push:
+  pull_request:
+    types:
+    - created
+    - synchronize
 
 jobs:
   build_and_test:

--- a/libdist/CMakeLists.txt
+++ b/libdist/CMakeLists.txt
@@ -7,8 +7,21 @@ set(sources
         src/NetworkIOMPI.cpp
         src/NetworkLCI.cpp
 )
+
+add_library(galois_dist_async_obj OBJECT ${sources})
+target_include_directories(galois_dist_async_obj PUBLIC
+  ${CMAKE_SOURCE_DIR}/libllvm/include
+  ${CMAKE_SOURCE_DIR}/libgalois/include
+  ${CMAKE_SOURCE_DIR}/libdist/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+set_target_properties (galois_dist_async_obj PROPERTIES
+  INTERFACE_POSITION_INDEPENDENT_CODE On
+  POSITION_INDEPENDENT_CODE On
+)
+
 # new galois net library; link to shared memory galois
-add_library(galois_dist_async STATIC ${sources})
+add_library(galois_dist_async STATIC $<TARGET_OBJECTS:galois_dist_async_obj>)
 target_link_libraries(galois_dist_async galois_shmem gllvm)
 
 if (USE_BARE_MPI)
@@ -35,18 +48,6 @@ if (USE_LCI)
 endif()
 
 set_target_properties (galois_dist_async PROPERTIES
-  INTERFACE_POSITION_INDEPENDENT_CODE On
-  POSITION_INDEPENDENT_CODE On
-)
-
-add_library(galois_dist_async_obj OBJECT ${sources})
-target_include_directories(galois_dist_async_obj PUBLIC
-  ${CMAKE_SOURCE_DIR}/libllvm/include
-  ${CMAKE_SOURCE_DIR}/libgalois/include
-  ${CMAKE_SOURCE_DIR}/libdist/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
-set_target_properties (galois_dist_async_obj PROPERTIES
   INTERFACE_POSITION_INDEPENDENT_CODE On
   POSITION_INDEPENDENT_CODE On
 )

--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -52,7 +52,18 @@ else()
   list(APPEND sources src/HWTopoLinux.cpp)
 endif()
 
-add_library(galois_shmem ${sources})
+add_library(galois_shmem_obj OBJECT ${sources})
+target_include_directories(galois_shmem_obj PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/libtsuba/include>
+  $<INSTALL_INTERFACE:${RELATIVE_INCLUDE_FROM_INSTALL_PREFIX}>
+)
+set_target_properties (galois_shmem_obj PROPERTIES
+  INTERFACE_POSITION_INDEPENDENT_CODE On
+  POSITION_INDEPENDENT_CODE On
+)
+
+add_library(galois_shmem $<TARGET_OBJECTS:galois_shmem_obj>)
 target_include_directories(galois_shmem PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${GALOIS_RELATIVE_INCLUDE_DIR}>
@@ -82,17 +93,6 @@ if (VTune_FOUND)
   target_link_libraries(galois_shmem ${VTune_LIBRARIES})
   target_link_libraries(galois_shmem dl)
 endif()
-
-add_library(galois_shmem_obj OBJECT ${sources})
-target_include_directories(galois_shmem_obj PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/libtsuba/include>
-  $<INSTALL_INTERFACE:${RELATIVE_INCLUDE_FROM_INSTALL_PREFIX}>
-)
-set_target_properties (galois_shmem_obj PROPERTIES 
-  INTERFACE_POSITION_INDEPENDENT_CODE On 
-  POSITION_INDEPENDENT_CODE On
-)
 
 install(DIRECTORY include DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/.." COMPONENT dev
   FILES_MATCHING PATTERN "*.h"

--- a/libgalois/experimental/CMakeLists.txt
+++ b/libgalois/experimental/CMakeLists.txt
@@ -4,11 +4,6 @@ set(sources
         src/Queue.cpp
 )
 
-add_library(galois_exp STATIC ${sources})
-target_include_directories(galois_exp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-
-target_link_libraries(galois_exp galois_runtime gllvm)
-
 add_library(galois_exp_obj OBJECT ${sources})
 target_include_directories(galois_exp_obj PUBLIC 
   ${CMAKE_SOURCE_DIR}/libllvm/include
@@ -21,4 +16,9 @@ set_target_properties (galois_exp_obj PROPERTIES
   INTERFACE_POSITION_INDEPENDENT_CODE On 
   POSITION_INDEPENDENT_CODE On
 )
+
+add_library(galois_exp STATIC $<TARGET_OBJECTS:galois_exp_obj>)
+target_include_directories(galois_exp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_link_libraries(galois_exp galois_runtime gllvm)
 

--- a/libllvm/CMakeLists.txt
+++ b/libllvm/CMakeLists.txt
@@ -10,11 +10,6 @@ set(sources
                  src/Twine.cpp
 )
 
-add_library(gllvm STATIC ${sources})
-target_include_directories(gllvm BEFORE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(gllvm BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
-include(llvm-extras)
-
 add_library(gllvm_obj OBJECT ${sources})
 target_include_directories(gllvm_obj BEFORE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(gllvm_obj BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
@@ -22,4 +17,9 @@ set_target_properties (gllvm_obj PROPERTIES
   INTERFACE_POSITION_INDEPENDENT_CODE On 
   POSITION_INDEPENDENT_CODE On
 )
+
+add_library(gllvm STATIC $<TARGET_OBJECTS:gllvm_obj>)
+target_include_directories(gllvm BEFORE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(gllvm BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
+include(llvm-extras)
 


### PR DESCRIPTION
Several libraries build CMake OBJECT libraries to reuse compilation
results between different build artifacts, but they do not reuse them in
the common case of building their own main library artifact.

Adjust the build targets to reuse OBJECT libraries for standard
add_library targets.