### PR TITLE
support: Add string Join function

### DIFF
--- a/libsupport/include/galois/Strings.h
+++ b/libsupport/include/galois/Strings.h
@@ -1,7 +1,12 @@
 #ifndef GALOIS_LIBSUPPORT_GALOIS_STRINGS_H_
 #define GALOIS_LIBSUPPORT_GALOIS_STRINGS_H_
 
+#include <initializer_list>
 #include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
 
 #include "galois/config.h"
 
@@ -27,6 +32,31 @@ GALOIS_EXPORT std::string TrimSuffix(
     const std::string& s, const std::string& suffix);
 
 GALOIS_EXPORT bool HasSuffix(const std::string& s, const std::string& suffix);
+
+/// Join returns a string that is the concatenation of every object in
+/// \param items all separated by an instance of \param sep
+template <typename C>
+std::string
+Join(std::string_view sep, const C& items) {
+  if (items.empty()) {
+    return "";
+  }
+  fmt::memory_buffer buf;
+  auto last = --items.end();
+  for (auto it = items.begin(); it != last; ++it) {
+    fmt::format_to(buf, "{}{}", *it, sep);
+  }
+  fmt::format_to(buf, "{}", *last);
+  return to_string(buf);
+}
+
+/// Join returns a string that is the concatenation of every object in
+/// \param items all separated by an instance of \param sep
+template <typename T>
+std::string
+Join(std::string_view sep, const std::initializer_list<T> items) {
+  return Join(sep, std::vector<T>(items));
+}
 
 }  // namespace galois
 

--- a/libsupport/test/strings.cpp
+++ b/libsupport/test/strings.cpp
@@ -1,5 +1,7 @@
 #include "galois/Strings.h"
 
+#include <list>
+
 #include "galois/Logging.h"
 
 int
@@ -19,4 +21,15 @@ main() {
   GALOIS_LOG_ASSERT(galois::TrimPrefix("prefix.suffix", "prefix.") == "suffix");
   GALOIS_LOG_ASSERT(
       galois::TrimSuffix("prefix.suffix", "none") == "prefix.suffix");
+
+  GALOIS_LOG_ASSERT(
+      galois::Join(" ", {"list", "of", "strings"}) == "list of strings");
+  GALOIS_LOG_ASSERT(
+      galois::Join("", {"list", "of", "strings"}) == "listofstrings");
+  GALOIS_LOG_ASSERT(galois::Join(" ", {"string"}) == "string");
+  GALOIS_LOG_ASSERT(galois::Join(" ", std::vector<std::string>{}).empty());
+  GALOIS_LOG_ASSERT(
+      galois::Join(" ", {"list", "of", "", "strings"}) == "list of  strings");
+
+  GALOIS_LOG_ASSERT(galois::Join(" ", std::list<int>{1, 2, 3}) == "1 2 3");
 }


### PR DESCRIPTION
Takes a separator and a container of strings (or anything that can be
turned into a string by `fmt::format(...)`), returns a string that is
the list of strings concatenated but separated with the separator. If
the list is empty it returns the empty string.

Signed-off-by: Tyler Hunt thunt@katanagraph.com