### PR TITLE
Changes to OpLog.h to adapt to kafka oplog code in the enterprise repo.

### DIFF
--- a/libgalois/include/galois/OpLog.h
+++ b/libgalois/include/galois/OpLog.h
@@ -13,7 +13,7 @@ enum class DataTypes {
 };
 
 // https://neo4j.com/docs/cypher-manual/current/clauses/create/
-enum OpTypes {
+enum class OpTypes {
   kInvalid,
   kOpNodeAdd = 1,
   kOpNodeDel,
@@ -39,7 +39,7 @@ const char* const optypes_enum2str[] = {
 };
 
 class GALOIS_EXPORT Operation {
-  OpTypes opcode_{kInvalid};
+  OpTypes opcode_{0};
   galois::PropertyKey property_key_{
       "", false, false, "", galois::ImportDataType::kUnsupported, false};
   galois::ImportData data_{galois::ImportDataType::kUnsupported, false};

--- a/libgalois/include/galois/OpLog.h
+++ b/libgalois/include/galois/OpLog.h
@@ -6,8 +6,14 @@
 
 namespace galois {
 
+enum class DataTypes {
+  kEmpty,
+  kNode,
+  kEdge,
+};
+
 // https://neo4j.com/docs/cypher-manual/current/clauses/create/
-enum class OpTypes {
+enum OpTypes {
   kInvalid,
   kOpNodeAdd = 1,
   kOpNodeDel,
@@ -19,8 +25,21 @@ enum class OpTypes {
   kOpEdgePropVal,
 };
 
+const char* const optypes_enum2str[] = {
+    "Invalid",     /* kInvalid */
+    "NodeAdd",     /* kOpNodeAdd */
+    "NodeDel",     /* kOpNodeDel */
+    "EdgeAdd",     /* kOpEdgeAdd */
+    "EdgeDel",     /* kOpEdgeDel */
+    "NodePropDel", /* kOpNodePropDel */
+    "EdgePropDel", /* kOpEdgePropDel */
+    "NodePropVal", /* kOpNodePropVal */
+    "EdgePropVal", /* kOpEdgePropVal */
+    "Consumed",    /* kConsumed */
+};
+
 class GALOIS_EXPORT Operation {
-  OpTypes opcode_{0};
+  OpTypes opcode_{kInvalid};
   galois::PropertyKey property_key_{
       "", false, false, "", galois::ImportDataType::kUnsupported, false};
   galois::ImportData data_{galois::ImportDataType::kUnsupported, false};

--- a/libgalois/include/galois/OpLog.h
+++ b/libgalois/include/galois/OpLog.h
@@ -6,12 +6,6 @@
 
 namespace galois {
 
-enum class DataTypes {
-  kEmpty,
-  kNode,
-  kEdge,
-};
-
 // https://neo4j.com/docs/cypher-manual/current/clauses/create/
 enum class OpTypes {
   kInvalid,


### PR DESCRIPTION
Need to change OpTypes to plain enum (instead of enum class) so that it
can be implicitly casted to integers, since we want to use
optypes_enum2str[] for operation name printing.