### PR TITLE
Refactor topology API to make it consistent

### DIFF
--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -44,6 +44,7 @@ set(sources
         src/Threads.cpp
         src/ThreadTimer.cpp
         src/Timer.cpp
+        src/analytics/Utils.cpp
         src/analytics/bfs/bfs.cpp
         src/analytics/sssp/sssp.cpp
         src/analytics/connected_components/connected_components.cpp

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -47,21 +47,22 @@ class PropertyGraph {
 public:
   using node_properties = NodeProps;
   using edge_properties = EdgeProps;
-  using node_iterator = boost::counting_iterator<uint32_t>;
-  using edge_iterator = boost::counting_iterator<uint64_t>;
-  using edges_iterator = StandardRange<NoDerefIterator<edge_iterator>>;
-  using iterator = node_iterator;
-  using Node = uint32_t;
+  using node_iterator = GraphTopology::node_iterator;
+  using edge_iterator = GraphTopology::edge_iterator;
+  using edges_range = GraphTopology::edges_range;
+  using iterator = GraphTopology::iterator;
+  using Node = GraphTopology::Node;
+  using Edge = GraphTopology::Edge;
 
   // Standard container concepts
 
-  node_iterator begin() const { return node_iterator(0); }
+  node_iterator begin() const { return pfg_->begin(); }
 
-  node_iterator end() const { return node_iterator(num_nodes()); }
+  node_iterator end() const { return pfg_->end(); }
 
-  size_t size() const { return num_nodes(); }
+  size_t size() const { return pfg_->size(); }
 
-  bool empty() const { return num_nodes() == 0; }
+  bool empty() const { return pfg_->empty(); }
 
   // Graph accessors
 
@@ -134,20 +135,25 @@ public:
     return node_iterator(node_id);
   }
 
-  uint64_t num_nodes() const { return pfg_->topology().num_nodes(); }
-  uint64_t num_edges() const { return pfg_->topology().num_edges(); }
+  uint64_t num_nodes() const { return pfg_->num_nodes(); }
+  uint64_t num_edges() const { return pfg_->num_edges(); }
 
   /**
    * Gets the edge range of some node.
    *
    * @param node node to get the edge range of
-   * @returns iterator to edges of node
+   * @returns iterable edge range for node.
    */
-  edges_iterator edges(const node_iterator& node) const {
-    auto [begin_edge, end_edge] = pfg_->topology().edge_range(*node);
-    return internal::make_no_deref_range(
-        edge_iterator(begin_edge), edge_iterator(end_edge));
-  }
+  edges_range edges(Node node) const { return pfg_->edges(node); }
+
+  /**
+   * Gets the edge range of some node.
+   *
+   * @param node node to get the edge range of
+   * @returns iterable edge range for node.
+   */
+  edges_range edges(node_iterator node) const { return pfg_->edges(*node); }
+  // TODO(amp): [[deprecated("use edges(Node node)")]]
 
   /**
    * Gets the first edge of some node.
@@ -155,7 +161,10 @@ public:
    * @param node node to get the edge of
    * @returns iterator to first edge of node
    */
-  edge_iterator edge_begin(Node node) const { return *edges(node).begin(); }
+  edge_iterator edge_begin(Node node) const {
+    return pfg_->edges(node).begin();
+  }
+  // TODO(amp): [[deprecated("use edges(node)")]]
 
   /**
    * Gets the end edge boundary of some node.
@@ -164,7 +173,8 @@ public:
    * @returns iterator to the end of the edges of node, i.e. the first edge of
    *     the next node (or an "end" iterator if there is no next node)
    */
-  edge_iterator edge_end(Node node) const { return *edges(node).end(); }
+  edge_iterator edge_end(Node node) const { return pfg_->edges(node).end(); }
+  // TODO(amp): [[deprecated("use edges(node)")]]
 
   /**
    * Accessor for the underlying PropertyFileGraph.

--- a/libgalois/include/katana/analytics/Utils.h
+++ b/libgalois/include/katana/analytics/Utils.h
@@ -10,60 +10,27 @@
 
 namespace katana::analytics {
 
+// TODO(amp): This file should be disbanded and it's functions moved to
+//  PropertyFileGraph.h or other more specific places.
+
 //! Used to pick random non-zero degree starting points for search algorithms
 //! This code has been copied from GAP benchmark suite
 //! (https://github.com/sbeamer/gapbs/blob/master/src/benchmark.h)
-template <typename Graph>
-class SourcePicker {
-  static const uint32_t kRandSeed;
-  std::mt19937 rng;
-  std::uniform_int_distribution<typename Graph::Node> udist;
-  const Graph& graph;
+class KATANA_EXPORT SourcePicker {
+  const PropertyFileGraph& graph;
 
 public:
-  explicit SourcePicker(const Graph& g)
-      : rng(kRandSeed), udist(0, g.size() - 1), graph(g) {}
+  explicit SourcePicker(const PropertyFileGraph& g) : graph(g) {}
 
-  auto PickNext() {
-    typename Graph::Node source;
-    do {
-      source = udist(rng);
-    } while (
-        std::distance(graph.edges(source).begin(), graph.edges(source).end()));
-    return source;
-  }
+  uint32_t PickNext();
 };
-
-template <typename Graph>
-const uint32_t SourcePicker<Graph>::kRandSeed = 27491095;
 
 //! Used to determine if a graph has power-law degree distribution or not
 //! by sampling some of the vertices in the graph randomly
 //! This code has been copied from GAP benchmark suite
 //! (https://github.com/sbeamer/gapbs/blob/master/src/tc.cc WorthRelabelling())
-template <typename Graph>
-bool
-isApproximateDegreeDistributionPowerLaw(const Graph& graph) {
-  uint32_t averageDegree = graph.num_edges() / graph.num_nodes();
-  if (averageDegree < 10)
-    return false;
-  SourcePicker<Graph> sp(graph);
-  uint32_t num_samples = 1000;
-  if (num_samples > graph.size())
-    num_samples = graph.size();
-  uint32_t sample_total = 0;
-  std::vector<uint32_t> samples(num_samples);
-  for (uint32_t trial = 0; trial < num_samples; trial++) {
-    typename Graph::Node node = sp.PickNext();
-    samples[trial] =
-        std::distance(graph.edges(node).begin(), graph.edges(node).end());
-    sample_total += samples[trial];
-  }
-  std::sort(samples.begin(), samples.end());
-  double sample_average = static_cast<double>(sample_total) / num_samples;
-  double sample_median = samples[num_samples / 2];
-  return sample_average / 1.3 > sample_median;
-}
+KATANA_EXPORT bool IsApproximateDegreeDistributionPowerLaw(
+    const PropertyFileGraph& graph);
 
 template <typename Props>
 std::vector<std::string>
@@ -80,10 +47,9 @@ DefaultPropertyNames() {
 template <typename NodeProps>
 inline katana::Result<void>
 ConstructNodeProperties(
-    katana::PropertyFileGraph* pfg,
+    PropertyFileGraph* pfg,
     const std::vector<std::string>& names = DefaultPropertyNames<NodeProps>()) {
-  auto res_table =
-      katana::AllocateTable<NodeProps>(pfg->topology().num_nodes(), names);
+  auto res_table = katana::AllocateTable<NodeProps>(pfg->num_nodes(), names);
   if (!res_table) {
     return res_table.error();
   }
@@ -94,7 +60,7 @@ ConstructNodeProperties(
 template <typename EdgeProps>
 inline katana::Result<void>
 ConstructEdgeProperties(
-    katana::PropertyFileGraph* pfg,
+    PropertyFileGraph* pfg,
     const std::vector<std::string>& names = DefaultPropertyNames<EdgeProps>()) {
   auto res_table =
       katana::AllocateTable<EdgeProps>(pfg->topology().num_edges(), names);

--- a/libgalois/include/katana/analytics/sssp/sssp.h
+++ b/libgalois/include/katana/analytics/sssp/sssp.h
@@ -53,18 +53,9 @@ public:
   SsspPlan() : SsspPlan{kCPU, kAutomatic, 0, 0} {}
 
   SsspPlan(const katana::PropertyFileGraph* pfg) : Plan(kCPU) {
-    // TODO(amp): We know we don't modify pfg, but there is no way to construct
-    //   a const PropertyGraph. https://github.com/KatanaGraph/katana/issues/23
-    auto graph = katana::PropertyGraph<std::tuple<>, std::tuple<>>::Make(
-        const_cast<katana::PropertyFileGraph*>(pfg), {}, {});
-    if (!graph) {
-      KATANA_LOG_FATAL(
-          "PropertyGraph should always be constructable here: {}",
-          graph.error());
-    }
     katana::StatTimer autoAlgoTimer("SSSP_Automatic_Algorithm_Selection");
     autoAlgoTimer.start();
-    bool isPowerLaw = isApproximateDegreeDistributionPowerLaw(graph.value());
+    bool isPowerLaw = IsApproximateDegreeDistributionPowerLaw(*pfg);
     autoAlgoTimer.stop();
     if (isPowerLaw) {
       *this = DeltaStep();

--- a/libgalois/src/PropertyFileGraph.cpp
+++ b/libgalois/src/PropertyFileGraph.cpp
@@ -368,10 +368,10 @@ katana::SortAllEdgesByDest(katana::PropertyFileGraph* pfg) {
   }
 }
 
-uint64_t
+katana::GraphTopology::Edge
 katana::FindEdgeSortedByDest(
-    const katana::PropertyFileGraph* graph, uint32_t node,
-    uint32_t node_to_find) {
+    const PropertyFileGraph* graph, GraphTopology::Node node,
+    GraphTopology::Node node_to_find) {
   auto view_result_dests =
       katana::ConstructPropertyView<katana::UInt32Property>(
           graph->topology().out_dests.get());

--- a/libgalois/src/analytics/Utils.cpp
+++ b/libgalois/src/analytics/Utils.cpp
@@ -1,0 +1,61 @@
+/*
+ * This file belongs to the Galois project, a C++ library for exploiting
+ * parallelism. The code is being released under the terms of the 3-Clause BSD
+ * License (a copy is located in LICENSE.txt at the top-level directory).
+ *
+ * Copyright (C) 2018, The University of Texas at Austin. All rights reserved.
+ * UNIVERSITY EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES CONCERNING THIS
+ * SOFTWARE AND DOCUMENTATION, INCLUDING ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR ANY PARTICULAR PURPOSE, NON-INFRINGEMENT AND WARRANTIES OF
+ * PERFORMANCE, AND ANY WARRANTY THAT MIGHT OTHERWISE ARISE FROM COURSE OF
+ * DEALING OR USAGE OF TRADE.  NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH
+ * RESPECT TO THE USE OF THE SOFTWARE OR DOCUMENTATION. Under no circumstances
+ * shall University be liable for incidental, special, indirect, direct or
+ * consequential damages or loss of profits, interruption of business, or
+ * related expenses which may arise from use of Software or Documentation,
+ * including but not limited to those resulting from defects in Software and/or
+ * Documentation, or loss or inaccuracy of data of any kind.
+ */
+
+#include "katana/analytics/Utils.h"
+
+#include <katana/Random.h>
+
+uint32_t
+katana::analytics::SourcePicker::PickNext() {
+  uint32_t source;
+  do {
+    source = RandomUniformInt(graph.size());
+  } while (
+      std::distance(graph.edges(source).begin(), graph.edges(source).end()));
+  return source;
+}
+
+bool
+katana::analytics::IsApproximateDegreeDistributionPowerLaw(
+    const PropertyFileGraph& graph) {
+  if (graph.num_nodes() < 10) {
+    return false;
+  }
+  uint32_t averageDegree = graph.num_edges() / graph.num_nodes();
+  if (averageDegree < 10) {
+    return false;
+  }
+  SourcePicker sp(graph);
+  uint32_t num_samples = 1000;
+  if (num_samples > graph.num_nodes()) {
+    num_samples = graph.num_nodes();
+  }
+  uint32_t sample_total = 0;
+  std::vector<uint32_t> samples(num_samples);
+  for (uint32_t trial = 0; trial < num_samples; trial++) {
+    auto node = sp.PickNext();
+    samples[trial] =
+        std::distance(graph.edges(node).begin(), graph.edges(node).end());
+    sample_total += samples[trial];
+  }
+  std::sort(samples.begin(), samples.end());
+  double sample_average = static_cast<double>(sample_total) / num_samples;
+  double sample_median = samples[num_samples / 2];
+  return sample_average / 1.3 > sample_median;
+}

--- a/libgalois/src/analytics/connected_components/connected_components.cpp
+++ b/libgalois/src/analytics/connected_components/connected_components.cpp
@@ -1183,7 +1183,7 @@ katana::analytics::ConnectedComponentsAssertValid(
         KATANA_LOG_DEBUG(
             "{} (component: {}) must be in same component as {} (component: "
             "{})",
-            uint32_t{*dest}, data, n, me);
+            *dest, data, n, me);
         return true;
       }
     }

--- a/libgalois/test/property-file-graph.cpp
+++ b/libgalois/test/property-file-graph.cpp
@@ -209,6 +209,33 @@ TestSimplePGs() {
   KATANA_LOG_ASSERT(make_result);
 }
 
+void
+TestTopologyAccess() {
+  RandomPolicy policy{3};
+  auto g = MakeFileGraph<uint32_t>(10, 1, &policy);
+
+  KATANA_LOG_ASSERT(g->size() == 10);
+  KATANA_LOG_ASSERT(g->num_nodes() == 10);
+  KATANA_LOG_ASSERT(g->num_edges() == 30);
+
+  for (int i = 0; i < 10; ++i) {
+    KATANA_LOG_ASSERT(
+        std::distance(g->edges(i).begin(), g->edges(i).end()) == 3);
+  }
+  int n_nodes = 0;
+  for (katana::PropertyFileGraph::Node i : *g) {
+    auto _ignore = g->NodeProperty(0)->chunk(0)->GetScalar(i);
+    n_nodes++;
+    int n_edges = 0;
+    for (auto e : g->edges(i)) {
+      auto __ignore = g->EdgeProperty(0)->chunk(0)->GetScalar(e);
+      n_edges++;
+    }
+    KATANA_LOG_ASSERT(n_edges == 3);
+  }
+  KATANA_LOG_ASSERT(n_nodes == 10);
+}
+
 int
 main(int argc, char** argv) {
   katana::SharedMemSys sys;
@@ -224,6 +251,7 @@ main(int argc, char** argv) {
   TestRoundTrip();
   TestGarbageMetadata();
   TestSimplePGs();
+  TestTopologyAccess();
 
   return 0;
 }

--- a/lonestar/analytics/cpu/triangle-counting/Triangles.cpp
+++ b/lonestar/analytics/cpu/triangle-counting/Triangles.cpp
@@ -372,7 +372,8 @@ main(int argc, char** argv) {
 
   if (!relabel) {
     timer_auto_algo.start();
-    relabel = katana::analytics::isApproximateDegreeDistributionPowerLaw(graph);
+    relabel = katana::analytics::IsApproximateDegreeDistributionPowerLaw(
+        graph.GetPropertyFileGraph());
     timer_auto_algo.stop();
   }
 


### PR DESCRIPTION
* Lift topology access implementations to only exist on `GraphTopology`
* Allow direct access to topology on `PropertyFileGraph` just like `PropertyGraph` (and the Python API)

I'm aware this isn't important. But I had it mostly done before I realized I was rat-holing. So I finished it.

This is not a review priority, but I would love to get it in.