### PR TITLE
Remove strict dependency on pkg-config.

### DIFF
--- a/cmake/Modules/KatanaBuildCommon.cmake
+++ b/cmake/Modules/KatanaBuildCommon.cmake
@@ -85,7 +85,7 @@ endif ()
 
 ###### Install dependencies ######
 
-find_package(PkgConfig REQUIRED)
+find_package(PkgConfig)
 
 if (KATANA_AUTO_CONAN)
   include(${CMAKE_CURRENT_LIST_DIR}/conan.cmake)


### PR DESCRIPTION
I added the pkg-config dependency in cmake, but didn't think about how some systems wouldn't have it. Make the dependency soft and only fail if the packages we need are not available using the usual cmake methods.