### PR TITLE
Small improvements to DynamicBitset

### DIFF
--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -182,13 +182,14 @@ public:
 
   /**
    * Check a bit to see if it is currently set.
-   * Using this is recommeneded only if set() and reset()
+   * Using this is recommended only if set() and reset()
    * are not being used in that parallel section/phase
    *
    * @param index Bit to check to see if set
    * @returns true if index is set
    */
   bool test(size_t index) const {
+    assert(index < num_bits);
     size_t bit_index = index / bits_uint64;
     uint64_t bit_offset = 1;
     bit_offset <<= (index % bits_uint64);
@@ -240,6 +241,9 @@ public:
 
   // assumes bit_vector is not updated (set) in parallel
   void bitwise_or(const DynamicBitset& other);
+
+  // assumes bit_vector is not updated (set) in parallel
+  void bitwise_not();
 
   // assumes bit_vector is not updated (set) in parallel
 

--- a/libgalois/src/DynamicBitset.cpp
+++ b/libgalois/src/DynamicBitset.cpp
@@ -37,6 +37,13 @@ katana::DynamicBitset::bitwise_or(const DynamicBitset& other) {
 }
 
 void
+katana::DynamicBitset::bitwise_not() {
+  katana::do_all(
+      katana::iterate(size_t{0}, bitvec.size()),
+      [&](size_t i) { bitvec[i] = ~bitvec[i]; }, katana::no_stats());
+}
+
+void
 katana::DynamicBitset::bitwise_and(const DynamicBitset& other) {
   assert(size() == other.size());
   const auto& other_bitvec = other.get_vec();


### PR DESCRIPTION
`bitwise_not` seems like a logical inclusion given that there is already `bitwise_{or,xor,and}`. And I added an assert to `DynamicBitset::test()` because I have been bitten by that before.