### PR TITLE
Avoid weak vtables

### DIFF
--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -83,19 +83,7 @@ target_link_libraries(katana_galois PUBLIC tsuba)
 target_link_libraries(katana_galois PRIVATE Threads::Threads)
 target_link_libraries(katana_galois PUBLIC katana_support)
 
-# Some careful defines and build directives to ensure things work on Windows
-# (see config.h):
-#
-# 1. When we build our shared library, KATANA_EXPORT => dllexport
-# 2. When someone uses our shared library, KATANA_EXPORT => dllimport
-# 3. When we build a static library, KATANA_EXPORT => ""
-#
-# In the world of ELF, 1 and 2 can both be handled with visibility("default")
-if(BUILD_SHARED_LIBS)
-  target_compile_definitions(katana_galois PRIVATE KATANA_SHARED_LIB_BUILDING)
-else()
-  target_compile_definitions(katana_galois PRIVATE KATANA_STATIC_LIB)
-endif()
+set_common_katana_library_options(katana_galois)
 
 if(SCHED_SETAFFINITY_FOUND)
   target_compile_definitions(katana_galois PRIVATE KATANA_USE_SCHED_SETAFFINITY)

--- a/libgalois/src/Deterministic.cpp
+++ b/libgalois/src/Deterministic.cpp
@@ -20,3 +20,9 @@
 #include "katana/Executor_Deterministic.h"
 
 thread_local katana::SizedHeapFactory::SizedHeap* katana::internal::dagListHeap;
+
+katana::internal::FirstPassBase::~FirstPassBase() = default;
+
+katana::internal::HasIntentToReadContext::~HasIntentToReadContext() = default;
+
+katana::internal::ReaderContext::~ReaderContext() = default;

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -11,6 +11,7 @@ configure_file(include/katana/config.h.in include/katana/config.h)
 
 set(sources
         src/Backtrace.cpp
+        src/CommBackend.cpp
         src/Env.cpp
         src/ErrorCode.cpp
         src/Http.cpp
@@ -29,11 +30,7 @@ target_include_directories(katana_support PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-if(BUILD_SHARED_LIBS)
-  target_compile_definitions(katana_support PRIVATE KATANA_SHARED_LIB_BUILDING)
-else()
-  target_compile_definitions(katana_support PRIVATE KATANA_STATIC_LIB)
-endif()
+set_common_katana_library_options(katana_support)
 
 find_package(nlohmann_json 3.7.3 REQUIRED)
 target_link_libraries(katana_support PUBLIC nlohmann_json::nlohmann_json)

--- a/libsupport/include/katana/CommBackend.h
+++ b/libsupport/include/katana/CommBackend.h
@@ -10,14 +10,14 @@
 
 namespace katana {
 
-class CommBackend {
+class KATANA_EXPORT CommBackend {
 public:
   CommBackend() = default;
   CommBackend(const CommBackend& other) = delete;
   CommBackend(CommBackend&& other) = delete;
   CommBackend& operator=(const CommBackend& other) = delete;
   CommBackend& operator=(CommBackend&& other) = delete;
-  virtual ~CommBackend() = default;
+  virtual ~CommBackend();
 
   /// Wait for all tasks to call Barrier
   virtual void Barrier() = 0;
@@ -39,10 +39,10 @@ public:
   uint32_t ID{0};
 };
 
-class NullCommBackend : public CommBackend {
+class KATANA_EXPORT NullCommBackend : public CommBackend {
 public:
   void Barrier() override {}
-  void NotifyFailure() override {}
+  void NotifyFailure() override;
   bool Broadcast([[maybe_unused]] uint32_t root, bool val) override {
     return val;
   };

--- a/libsupport/include/katana/ErrorCode.h
+++ b/libsupport/include/katana/ErrorCode.h
@@ -33,6 +33,8 @@ namespace katana::internal {
 
 class KATANA_EXPORT ErrorCodeCategory : public std::error_category {
 public:
+  ~ErrorCodeCategory() override;
+
   const char* name() const noexcept final { return "GaloisError"; }
 
   std::string message(int c) const final {

--- a/libsupport/src/CommBackend.cpp
+++ b/libsupport/src/CommBackend.cpp
@@ -1,0 +1,8 @@
+#include "katana/CommBackend.h"
+
+// Anchor vtables
+
+katana::CommBackend::~CommBackend() = default;
+
+void
+katana::NullCommBackend::NotifyFailure() {}

--- a/libsupport/src/ErrorCode.cpp
+++ b/libsupport/src/ErrorCode.cpp
@@ -1,5 +1,7 @@
 #include "katana/ErrorCode.h"
 
+katana::internal::ErrorCodeCategory::~ErrorCodeCategory() = default;
+
 const katana::internal::ErrorCodeCategory&
 katana::internal::GetErrorCodeCategory() {
   static ErrorCodeCategory c;

--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -44,7 +44,7 @@ foreach(target tsuba tsuba-preload)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  target_compile_definitions(${target} PRIVATE KATANA_SHARED_LIB_BUILDING)
+  set_common_katana_library_options(${target} ALWAYS_SHARED)
 endforeach()
 
 target_link_libraries(tsuba-preload PUBLIC katana_support)

--- a/libtsuba/include/tsuba/Errors.h
+++ b/libtsuba/include/tsuba/Errors.h
@@ -37,6 +37,8 @@ namespace tsuba::internal {
 
 class KATANA_EXPORT ErrorCodeCategory : public std::error_category {
 public:
+  ~ErrorCodeCategory() override;
+
   const char* name() const noexcept final { return "TsubaError"; }
 
   std::string message(int c) const final {

--- a/libtsuba/include/tsuba/FileStorage.h
+++ b/libtsuba/include/tsuba/FileStorage.h
@@ -25,7 +25,7 @@ public:
   FileStorage(FileStorage&& no_move) = delete;
   FileStorage& operator=(const FileStorage& no_copy) = delete;
   FileStorage& operator=(FileStorage&& no_move) = delete;
-  virtual ~FileStorage() = default;
+  virtual ~FileStorage();
 
   std::string_view uri_scheme() const { return uri_scheme_; }
   virtual katana::Result<void> Init() = 0;

--- a/libtsuba/include/tsuba/NameServerClient.h
+++ b/libtsuba/include/tsuba/NameServerClient.h
@@ -15,7 +15,7 @@ public:
   NameServerClient& operator=(NameServerClient&& no_move) = delete;
   NameServerClient(const NameServerClient& no_copy) = delete;
   NameServerClient& operator=(const NameServerClient& no_copy) = delete;
-  virtual ~NameServerClient() = default;
+  virtual ~NameServerClient();
 
   virtual katana::Result<RDGMeta> Get(const katana::Uri& rdg_name) = 0;
 

--- a/libtsuba/src/Errors.cpp
+++ b/libtsuba/src/Errors.cpp
@@ -2,6 +2,8 @@
 
 #include "katana/Logging.h"
 
+tsuba::internal::ErrorCodeCategory::~ErrorCodeCategory() = default;
+
 const tsuba::internal::ErrorCodeCategory&
 tsuba::internal::GetErrorCodeCategory() {
   static ErrorCodeCategory c;

--- a/libtsuba/src/FileStorage.cpp
+++ b/libtsuba/src/FileStorage.cpp
@@ -2,6 +2,8 @@
 
 #include "FileStorage_internal.h"
 
+tsuba::FileStorage::~FileStorage() = default;
+
 std::vector<tsuba::FileStorage*>&
 tsuba::GetRegisteredFileStorages() {
   static std::vector<FileStorage*> fs;

--- a/libtsuba/src/NameServerClient.cpp
+++ b/libtsuba/src/NameServerClient.cpp
@@ -2,6 +2,8 @@
 
 #include "GlobalState.h"
 
+tsuba::NameServerClient::~NameServerClient() = default;
+
 void
 tsuba::SetMakeNameServerClientCB(
     std::function<katana::Result<std::unique_ptr<tsuba::NameServerClient>>()>


### PR DESCRIPTION
If a virtual class has no out-of-line definitions, its vtable is emitted
in each translation unit it is referenced. RTTI tables follow the same
pattern so if we want consistent type info across users of a library
like libgalois, we should avoid having multiple vtables for the same
class.

Only clang has a diagnostic for this issue.

I also considered applying this throughout the codebase but it turns out
some external dependencies do not compile with -Wweak-vtable at all.