### PR TITLE
Rename NodeProperty/NodeTable to node_property

### DIFF
--- a/libgalois/include/katana/PropertyViews.h
+++ b/libgalois/include/katana/PropertyViews.h
@@ -44,7 +44,7 @@ template <typename PropTuple>
 static Result<katana::PropertyViewTuple<PropTuple>>
 MakeNodePropertyViews(
     const PropertyFileGraph* pfg, const std::vector<std::string>& properties) {
-  return MakePropertyViews<PropTuple>(pfg->node_table().get(), properties);
+  return MakePropertyViews<PropTuple>(pfg->node_properties().get(), properties);
 }
 
 /// MakeNodePropertyViews asserts a typed view on top of runtime properties.
@@ -68,7 +68,7 @@ template <typename PropTuple>
 static Result<katana::PropertyViewTuple<PropTuple>>
 MakeEdgePropertyViews(
     const PropertyFileGraph* pfg, const std::vector<std::string>& properties) {
-  return MakePropertyViews<PropTuple>(pfg->edge_table().get(), properties);
+  return MakePropertyViews<PropTuple>(pfg->edge_properties().get(), properties);
 }
 
 /// MakeEdgePropertyViews asserts a typed view on top of runtime properties.

--- a/libgalois/src/PropertyFileGraph.cpp
+++ b/libgalois/src/PropertyFileGraph.cpp
@@ -293,28 +293,28 @@ katana::PropertyFileGraph::Write(
 
 katana::Result<void>
 katana::PropertyFileGraph::AddNodeProperties(
-    const std::shared_ptr<arrow::Table>& table) {
+    const std::shared_ptr<arrow::Table>& props) {
   if (topology_.out_indices &&
-      topology_.out_indices->length() != table->num_rows()) {
+      topology_.out_indices->length() != props->num_rows()) {
     KATANA_LOG_DEBUG(
         "expected {} rows found {} instead", topology_.out_indices->length(),
-        table->num_rows());
+        props->num_rows());
     return ErrorCode::InvalidArgument;
   }
-  return rdg_.AddNodeProperties(table);
+  return rdg_.AddNodeProperties(props);
 }
 
 katana::Result<void>
 katana::PropertyFileGraph::AddEdgeProperties(
-    const std::shared_ptr<arrow::Table>& table) {
+    const std::shared_ptr<arrow::Table>& props) {
   if (topology_.out_dests &&
-      topology_.out_dests->length() != table->num_rows()) {
+      topology_.out_dests->length() != props->num_rows()) {
     KATANA_LOG_DEBUG(
         "expected {} rows found {} instead", topology_.out_dests->length(),
-        table->num_rows());
+        props->num_rows());
     return ErrorCode::InvalidArgument;
   }
-  return rdg_.AddEdgeProperties(table);
+  return rdg_.AddEdgeProperties(props);
 }
 
 katana::Result<void>

--- a/libgalois/src/analytics/betweenness_centrality/betweenness_centrality.cpp
+++ b/libgalois/src/analytics/betweenness_centrality/betweenness_centrality.cpp
@@ -56,7 +56,7 @@ BetweennessCentralityStatistics::Print(std::ostream& os) {
 katana::Result<BetweennessCentralityStatistics>
 BetweennessCentralityStatistics::Compute(
     katana::PropertyFileGraph* pfg, const std::string& output_property_name) {
-  auto values_result = pfg->NodePropertyTyped<float>(output_property_name);
+  auto values_result = pfg->GetNodePropertyTyped<float>(output_property_name);
   if (!values_result) {
     return values_result.error();
   }

--- a/libgalois/src/analytics/independent_set/independent_set.cpp
+++ b/libgalois/src/analytics/independent_set/independent_set.cpp
@@ -724,7 +724,7 @@ katana::analytics::IndependentSetStatistics::Print(std::ostream& os) const {
 katana::Result<IndependentSetStatistics>
 katana::analytics::IndependentSetStatistics::Compute(
     katana::PropertyFileGraph* pfg, const std::string& property_name) {
-  auto property_result = pfg->NodePropertyTyped<uint8_t>(property_name);
+  auto property_result = pfg->GetNodePropertyTyped<uint8_t>(property_name);
   if (!property_result) {
     return property_result.error();
   }

--- a/libgalois/src/analytics/sssp/sssp.cpp
+++ b/libgalois/src/analytics/sssp/sssp.cpp
@@ -395,7 +395,7 @@ SSSPWithWrap(
   if (!graph && graph.error() == katana::ErrorCode::TypeError) {
     KATANA_LOG_DEBUG(
         "Incorrect edge property type: {}",
-        pfg->edge_table()
+        pfg->edge_properties()
             ->GetColumnByName(edge_weight_property_name)
             ->type()
             ->ToString());
@@ -412,7 +412,7 @@ katana::analytics::Sssp(
     PropertyFileGraph* pfg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, SsspPlan plan) {
-  switch (pfg->EdgeProperty(edge_weight_property_name)->type()->id()) {
+  switch (pfg->GetEdgeProperty(edge_weight_property_name)->type()->id()) {
   case arrow::UInt32Type::type_id:
     return SSSPWithWrap<uint32_t>(
         pfg, start_node, edge_weight_property_name, output_property_name, plan);
@@ -473,7 +473,7 @@ katana::analytics::SsspAssertValid(
     katana::PropertyFileGraph* pfg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name) {
-  switch (pfg->NodeProperty(output_property_name)->type()->id()) {
+  switch (pfg->GetNodeProperty(output_property_name)->type()->id()) {
   case arrow::UInt32Type::type_id:
     return SsspValidateImpl<uint32_t>(
         pfg, start_node, edge_weight_property_name, output_property_name);
@@ -539,7 +539,7 @@ ComputeStatistics(
 katana::Result<SsspStatistics>
 SsspStatistics::Compute(
     PropertyFileGraph* pfg, const std::string& output_property_name) {
-  switch (pfg->NodeProperty(output_property_name)->type()->id()) {
+  switch (pfg->GetNodeProperty(output_property_name)->type()->id()) {
   case arrow::UInt32Type::type_id:
     return ComputeStatistics<uint32_t>(pfg, output_property_name);
   case arrow::Int32Type::type_id:

--- a/libgalois/test/TestPropertyGraph.h
+++ b/libgalois/test/TestPropertyGraph.h
@@ -126,9 +126,9 @@ BaselineIterate(katana::PropertyFileGraph* g, int num_properties) {
 
   for (int prop = 0; prop < num_properties; ++prop) {
     auto node_property = std::dynamic_pointer_cast<NodeProperty>(
-        g->NodeProperty(prop)->chunk(0));
+        g->GetNodeProperty(prop)->chunk(0));
     auto edge_property = std::dynamic_pointer_cast<EdgeProperty>(
-        g->EdgeProperty(prop)->chunk(0));
+        g->GetEdgeProperty(prop)->chunk(0));
 
     KATANA_LOG_ASSERT(node_property);
     KATANA_LOG_ASSERT(edge_property);

--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(tsuba SHARED)
 add_dependencies(lib tsuba tsuba-preload)
 
 set(sources
-  src/AddTables.cpp
+  src/AddProperties.cpp
   src/Errors.cpp
   src/FaultTest.cpp
   src/file.cpp

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -50,10 +50,10 @@ public:
       std::unique_ptr<FileFrame> ff = nullptr);
 
   katana::Result<void> AddNodeProperties(
-      const std::shared_ptr<arrow::Table>& table);
+      const std::shared_ptr<arrow::Table>& props);
 
   katana::Result<void> AddEdgeProperties(
-      const std::shared_ptr<arrow::Table>& table);
+      const std::shared_ptr<arrow::Table>& props);
 
   katana::Result<void> RemoveNodeProperty(uint32_t i);
   katana::Result<void> RemoveEdgeProperty(uint32_t i);
@@ -95,11 +95,11 @@ public:
   const katana::Uri& rdg_dir() const { return rdg_dir_; }
   void set_rdg_dir(const katana::Uri& rdg_dir) { rdg_dir_ = rdg_dir; }
 
-  /// The table of node properties
-  const std::shared_ptr<arrow::Table>& node_table() const;
+  /// The node properties
+  const std::shared_ptr<arrow::Table>& node_properties() const;
 
-  /// The table of edge properties
-  const std::shared_ptr<arrow::Table>& edge_table() const;
+  /// The edge properties
+  const std::shared_ptr<arrow::Table>& edge_properties() const;
 
   const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
       const {
@@ -141,7 +141,7 @@ private:
       const std::vector<std::string>* edge_props);
 
   katana::Result<void> AddPartitionMetadataArray(
-      const std::shared_ptr<arrow::Table>& table);
+      const std::shared_ptr<arrow::Table>& props);
 
   katana::Result<std::vector<tsuba::PropStorageInfo>> WritePartArrays(
       const katana::Uri& dir, tsuba::WriteGroup* desc);

--- a/libtsuba/include/tsuba/RDGSlice.h
+++ b/libtsuba/include/tsuba/RDGSlice.h
@@ -44,8 +44,8 @@ public:
       const std::vector<std::string>* node_props = nullptr,
       const std::vector<std::string>* edge_props = nullptr);
 
-  const std::shared_ptr<arrow::Table>& node_table() const;
-  const std::shared_ptr<arrow::Table>& edge_table() const;
+  const std::shared_ptr<arrow::Table>& node_properties() const;
+  const std::shared_ptr<arrow::Table>& edge_properties() const;
   const FileView& topology_file_storage() const;
 
 private:

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -1,4 +1,4 @@
-#include "AddTables.h"
+#include "AddProperties.h"
 
 #include "tsuba/Errors.h"
 #include "tsuba/FileView.h"
@@ -9,7 +9,8 @@ using Result = katana::Result<T>;
 namespace {
 
 Result<std::shared_ptr<arrow::Table>>
-DoLoadTable(const std::string& expected_name, const katana::Uri& file_path) {
+DoLoadProperties(
+    const std::string& expected_name, const katana::Uri& file_path) {
   auto fv = std::make_shared<tsuba::FileView>(tsuba::FileView());
   if (auto res = fv->Bind(file_path.string(), false); !res) {
     return res.error();
@@ -61,7 +62,7 @@ DoLoadTable(const std::string& expected_name, const katana::Uri& file_path) {
 }
 
 Result<std::shared_ptr<arrow::Table>>
-DoLoadTableSlice(
+DoLoadPropertySlice(
     const std::string& expected_name, const katana::Uri& file_path,
     int64_t offset, int64_t length) {
   if (offset < 0 || length < 0) {
@@ -140,10 +141,10 @@ DoLoadTableSlice(
 }  // namespace
 
 Result<std::shared_ptr<arrow::Table>>
-tsuba::LoadTable(
+tsuba::LoadProperties(
     const std::string& expected_name, const katana::Uri& file_path) {
   try {
-    return DoLoadTable(expected_name, file_path);
+    return DoLoadProperties(expected_name, file_path);
   } catch (const std::exception& exp) {
     KATANA_LOG_DEBUG("arrow exception: {}", exp.what());
     return tsuba::ErrorCode::ArrowError;
@@ -151,11 +152,11 @@ tsuba::LoadTable(
 }
 
 katana::Result<std::shared_ptr<arrow::Table>>
-tsuba::LoadTableSlice(
+tsuba::LoadPropertySlice(
     const std::string& expected_name, const katana::Uri& file_path,
     int64_t offset, int64_t length) {
   try {
-    return DoLoadTableSlice(expected_name, file_path, offset, length);
+    return DoLoadPropertySlice(expected_name, file_path, offset, length);
   } catch (const std::exception& exp) {
     KATANA_LOG_DEBUG("arrow exception: {}", exp.what());
     return ErrorCode::ArrowError;

--- a/libtsuba/src/AddProperties.h
+++ b/libtsuba/src/AddProperties.h
@@ -1,5 +1,5 @@
-#ifndef KATANA_LIBTSUBA_ADDTABLES_H_
-#define KATANA_LIBTSUBA_ADDTABLES_H_
+#ifndef KATANA_LIBTSUBA_ADDPROPERTIES_H_
+#define KATANA_LIBTSUBA_ADDPROPERTIES_H_
 
 #include <arrow/api.h>
 
@@ -9,29 +9,29 @@
 
 namespace tsuba {
 
-KATANA_EXPORT katana::Result<std::shared_ptr<arrow::Table>> LoadTable(
+KATANA_EXPORT katana::Result<std::shared_ptr<arrow::Table>> LoadProperties(
     const std::string& expected_name, const katana::Uri& file_path);
 
-KATANA_EXPORT katana::Result<std::shared_ptr<arrow::Table>> LoadTableSlice(
+KATANA_EXPORT katana::Result<std::shared_ptr<arrow::Table>> LoadPropertySlice(
     const std::string& expected_name, const katana::Uri& file_path,
     int64_t offset, int64_t length);
 
 template <typename AddFn>
 katana::Result<void>
-AddTables(
+AddProperties(
     const katana::Uri& uri,
     const std::vector<tsuba::PropStorageInfo>& properties, AddFn add_fn) {
   for (const tsuba::PropStorageInfo& properties : properties) {
     auto p_path = uri.Join(properties.path);
 
-    auto load_result = LoadTable(properties.name, p_path);
+    auto load_result = LoadProperties(properties.name, p_path);
     if (!load_result) {
       return load_result.error();
     }
 
-    std::shared_ptr<arrow::Table> table = load_result.value();
+    std::shared_ptr<arrow::Table> props = load_result.value();
 
-    auto add_result = add_fn(table);
+    auto add_result = add_fn(props);
     if (!add_result) {
       return add_result.error();
     }
@@ -42,22 +42,22 @@ AddTables(
 
 template <typename AddFn>
 katana::Result<void>
-AddTablesSlice(
+AddPropertySlice(
     const katana::Uri& dir,
     const std::vector<tsuba::PropStorageInfo>& properties,
     std::pair<uint64_t, uint64_t> range, AddFn add_fn) {
   for (const tsuba::PropStorageInfo& properties : properties) {
     katana::Uri p_path = dir.Join(properties.path);
 
-    auto load_result = LoadTableSlice(
+    auto load_result = LoadPropertySlice(
         properties.name, p_path, range.first, range.second - range.first);
     if (!load_result) {
       return load_result.error();
     }
 
-    std::shared_ptr<arrow::Table> table = load_result.value();
+    std::shared_ptr<arrow::Table> props = load_result.value();
 
-    auto add_result = add_fn(table);
+    auto add_result = add_fn(props);
     if (!add_result) {
       return add_result.error();
     }

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -13,19 +13,19 @@ namespace tsuba {
 
 class KATANA_EXPORT RDGCore {
 public:
-  RDGCore() { InitEmptyTables(); }
+  RDGCore() { InitEmptyProperties(); }
 
   RDGCore(RDGPartHeader&& part_header) : part_header_(std::move(part_header)) {
-    InitEmptyTables();
+    InitEmptyProperties();
   }
 
   bool Equals(const RDGCore& other) const;
 
   katana::Result<void> AddNodeProperties(
-      const std::shared_ptr<arrow::Table>& table);
+      const std::shared_ptr<arrow::Table>& props);
 
   katana::Result<void> AddEdgeProperties(
-      const std::shared_ptr<arrow::Table>& table);
+      const std::shared_ptr<arrow::Table>& props);
 
   katana::Result<void> RemoveNodeProperty(uint32_t i);
 
@@ -35,18 +35,18 @@ public:
   // Accessors and Mutators
   //
 
-  const std::shared_ptr<arrow::Table>& node_table() const {
-    return node_table_;
+  const std::shared_ptr<arrow::Table>& node_properties() const {
+    return node_properties_;
   }
-  void set_node_table(std::shared_ptr<arrow::Table>&& node_table) {
-    node_table_ = std::move(node_table);
+  void set_node_properties(std::shared_ptr<arrow::Table>&& node_properties) {
+    node_properties_ = std::move(node_properties);
   }
 
-  const std::shared_ptr<arrow::Table>& edge_table() const {
-    return edge_table_;
+  const std::shared_ptr<arrow::Table>& edge_properties() const {
+    return edge_properties_;
   }
-  void set_edge_table(std::shared_ptr<arrow::Table>&& edge_table) {
-    edge_table_ = std::move(edge_table);
+  void set_edge_properties(std::shared_ptr<arrow::Table>&& edge_properties) {
+    edge_properties_ = std::move(edge_properties);
   }
 
   const FileView& topology_file_storage() const {
@@ -69,14 +69,14 @@ public:
   }
 
 private:
-  void InitEmptyTables();
+  void InitEmptyProperties();
 
   //
   // Data
   //
 
-  std::shared_ptr<arrow::Table> node_table_;
-  std::shared_ptr<arrow::Table> edge_table_;
+  std::shared_ptr<arrow::Table> node_properties_;
+  std::shared_ptr<arrow::Table> edge_properties_;
 
   FileView topology_file_storage_;
 

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -1,15 +1,14 @@
 #include "tsuba/RDGSlice.h"
 
-#include "AddTables.h"
+#include "AddProperties.h"
 #include "RDGCore.h"
 #include "RDGHandleImpl.h"
 #include "katana/Logging.h"
 #include "tsuba/Errors.h"
 
-namespace tsuba {
-
 katana::Result<void>
-RDGSlice::DoMake(const katana::Uri& metadata_dir, const SliceArg& slice) {
+tsuba::RDGSlice::DoMake(
+    const katana::Uri& metadata_dir, const SliceArg& slice) {
   katana::Uri t_path = metadata_dir.Join(core_->part_header().topology_path());
 
   if (auto res = core_->topology_file_storage().Bind(
@@ -19,21 +18,21 @@ RDGSlice::DoMake(const katana::Uri& metadata_dir, const SliceArg& slice) {
     return res.error();
   }
 
-  auto node_result = AddTablesSlice(
+  auto node_result = AddPropertySlice(
       metadata_dir, core_->part_header().node_prop_info_list(),
       slice.node_range,
-      [rdg = this](const std::shared_ptr<arrow::Table>& table) {
-        return rdg->core_->AddNodeProperties(table);
+      [rdg = this](const std::shared_ptr<arrow::Table>& props) {
+        return rdg->core_->AddNodeProperties(props);
       });
   if (!node_result) {
     return node_result.error();
   }
 
-  auto edge_result = AddTablesSlice(
+  auto edge_result = AddPropertySlice(
       metadata_dir, core_->part_header().edge_prop_info_list(),
       slice.edge_range,
-      [rdg = this](const std::shared_ptr<arrow::Table>& table) {
-        return rdg->core_->AddEdgeProperties(table);
+      [rdg = this](const std::shared_ptr<arrow::Table>& props) {
+        return rdg->core_->AddEdgeProperties(props);
       });
   if (!edge_result) {
     return edge_result.error();
@@ -42,8 +41,8 @@ RDGSlice::DoMake(const katana::Uri& metadata_dir, const SliceArg& slice) {
   return katana::ResultSuccess();
 }
 
-katana::Result<RDGSlice>
-RDGSlice::Make(
+katana::Result<tsuba::RDGSlice>
+tsuba::RDGSlice::Make(
     RDGHandle handle, const SliceArg& slice,
     const std::vector<std::string>* node_props,
     const std::vector<std::string>* edge_props) {
@@ -79,24 +78,24 @@ RDGSlice::Make(
 }
 
 const std::shared_ptr<arrow::Table>&
-RDGSlice::node_table() const {
-  return core_->node_table();
+tsuba::RDGSlice::node_properties() const {
+  return core_->node_properties();
 }
 
 const std::shared_ptr<arrow::Table>&
-RDGSlice::edge_table() const {
-  return core_->edge_table();
+tsuba::RDGSlice::edge_properties() const {
+  return core_->edge_properties();
 }
 
-const FileView&
-RDGSlice::topology_file_storage() const {
+const tsuba::FileView&
+tsuba::RDGSlice::topology_file_storage() const {
   return core_->topology_file_storage();
 }
 
-RDGSlice::RDGSlice(std::unique_ptr<RDGCore>&& core) : core_(std::move(core)) {}
+tsuba::RDGSlice::RDGSlice(std::unique_ptr<RDGCore>&& core)
+    : core_(std::move(core)) {}
 
-RDGSlice::~RDGSlice() = default;
-RDGSlice::RDGSlice(RDGSlice&& other) noexcept = default;
-RDGSlice& RDGSlice::operator=(RDGSlice&& other) noexcept = default;
-
-}  // namespace tsuba
+tsuba::RDGSlice::~RDGSlice() = default;
+tsuba::RDGSlice::RDGSlice(RDGSlice&& other) noexcept = default;
+tsuba::RDGSlice& tsuba::RDGSlice::operator=(RDGSlice&& other) noexcept =
+    default;

--- a/lonestar/analytics/cpu/betweennesscentrality/betweenness_centrality_cli.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/betweenness_centrality_cli.cpp
@@ -118,7 +118,7 @@ main(int argc, char** argv) {
 
   if (output) {
     auto results_result =
-        pfg->NodePropertyTyped<float>("betweenness_centrality");
+        pfg->GetNodePropertyTyped<float>("betweenness_centrality");
     if (!results_result) {
       KATANA_LOG_FATAL("Failed to get results: {}", results_result.error());
     }

--- a/lonestar/analytics/cpu/bfs/bfs_cli.cpp
+++ b/lonestar/analytics/cpu/bfs/bfs_cli.cpp
@@ -139,7 +139,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    auto r = pfg->NodePropertyTyped<uint32_t>("level");
+    auto r = pfg->GetNodePropertyTyped<uint32_t>("level");
     if (!r) {
       KATANA_LOG_FATAL("Failed to get node property {}", r.error());
     }

--- a/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
+++ b/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
@@ -230,7 +230,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    auto r = pfg->NodePropertyTyped<uint64_t>("component");
+    auto r = pfg->GetNodePropertyTyped<uint64_t>("component");
     if (!r) {
       KATANA_LOG_FATAL("Failed to get node property {}", r.error());
     }

--- a/lonestar/analytics/cpu/independentset/independent_set_cli.cpp
+++ b/lonestar/analytics/cpu/independentset/independent_set_cli.cpp
@@ -109,7 +109,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    auto r = pfg->NodePropertyTyped<uint8_t>("indicator");
+    auto r = pfg->GetNodePropertyTyped<uint8_t>("indicator");
     if (!r) {
       KATANA_LOG_FATAL("Failed to get node property {}", r.error());
     }

--- a/lonestar/analytics/cpu/k-core/kcore_cli.cpp
+++ b/lonestar/analytics/cpu/k-core/kcore_cli.cpp
@@ -130,7 +130,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    auto r = pfg->NodePropertyTyped<uint32_t>("node-in-core");
+    auto r = pfg->GetNodePropertyTyped<uint32_t>("node-in-core");
     if (!r) {
       KATANA_LOG_FATAL("Failed to get node property {}", r.error());
     }

--- a/lonestar/analytics/cpu/k-truss/k_truss_cli.cpp
+++ b/lonestar/analytics/cpu/k-truss/k_truss_cli.cpp
@@ -134,7 +134,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    auto r = pfg->EdgePropertyTyped<uint32_t>("edge-alive");
+    auto r = pfg->GetEdgePropertyTyped<uint32_t>("edge-alive");
     if (!r) {
       KATANA_LOG_FATAL("Failed to get edge property {}", r.error());
     }

--- a/lonestar/analytics/cpu/pagerank/pagerank-cli.cpp
+++ b/lonestar/analytics/cpu/pagerank/pagerank-cli.cpp
@@ -107,7 +107,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    auto r = pfg->NodePropertyTyped<float>("rank");
+    auto r = pfg->GetNodePropertyTyped<float>("rank");
     if (!r) {
       KATANA_LOG_FATAL("Failed to get node property {}", r.error());
     }

--- a/lonestar/analytics/cpu/sssp/sssp_cli.cpp
+++ b/lonestar/analytics/cpu/sssp/sssp_cli.cpp
@@ -103,7 +103,7 @@ AlgorithmName(SsspPlan::Algorithm algorithm) {
 template <typename Weight>
 static void
 OutputResults(katana::PropertyFileGraph* pfg) {
-  auto r = pfg->NodePropertyTyped<Weight>("distance");
+  auto r = pfg->GetNodePropertyTyped<Weight>("distance");
   if (!r) {
     KATANA_LOG_FATAL("Error getting results: {}", r.error().message());
   }
@@ -216,7 +216,7 @@ main(int argc, char** argv) {
   }
 
   if (output) {
-    switch (pfg->NodeProperty("distance")->type()->id()) {
+    switch (pfg->GetNodeProperty("distance")->type()->id()) {
     case arrow::UInt32Type::type_id:
       OutputResults<uint32_t>(pfg.get());
       break;
@@ -237,7 +237,7 @@ main(int argc, char** argv) {
       break;
     default:
       KATANA_LOG_FATAL(
-          "Unsupported type: {}", pfg->NodeProperty("distance")->type());
+          "Unsupported type: {}", pfg->GetNodeProperty("distance")->type());
       break;
     }
   }

--- a/python/katana/cpp/libgalois/graphs/Graph.pxd
+++ b/python/katana/cpp/libgalois/graphs/Graph.pxd
@@ -122,11 +122,11 @@ cdef extern from "katana/Graph.h" namespace "katana" nogil:
         shared_ptr[CSchema] node_schema()
         shared_ptr[CSchema] edge_schema()
 
-        vector[shared_ptr[CChunkedArray]] NodeProperties()
-        vector[shared_ptr[CChunkedArray]] EdgeProperties()
+        shared_ptr[CTable] node_properties()
+        shared_ptr[CTable] edge_properties()
 
-        shared_ptr[CChunkedArray] NodeProperty(int i)
-        shared_ptr[CChunkedArray] EdgeProperty(int i)
+        shared_ptr[CChunkedArray] GetNodeProperty(int i)
+        shared_ptr[CChunkedArray] GetEdgeProperty(int i)
 
         std_result[void] AddNodeProperties(shared_ptr[CTable])
         std_result[void] AddEdgeProperties(shared_ptr[CTable])

--- a/python/katana/lonestar/analytics/_bfs_property_graph.pyx
+++ b/python/katana/lonestar/analytics/_bfs_property_graph.pyx
@@ -70,7 +70,7 @@ def verify_bfs(PropertyGraph graph, unsigned int source_i, unsigned int property
         shared_ptr[CUInt32Array] chunk
         uint64_t numNodes = graph.num_nodes()
         uint32_t start, end
-    chunk_array = graph.underlying.get().NodeProperty(0)
+    chunk_array = graph.underlying.get().GetNodeProperty(0)
 
     notVisited.store(0)
     ### Chunked arrays can have multiple chunks
@@ -143,8 +143,8 @@ cdef void bfs_sync_pg(PropertyGraph graph, uint32_t source, string propertyName)
     #
     # Append new property
     #
-    cdef shared_ptr[CTable] node_table = MakeTable(propertyName, distance)
-    graph.underlying.get().AddNodeProperties(node_table)
+    cdef shared_ptr[CTable] node_props = MakeTable(propertyName, distance)
+    graph.underlying.get().AddNodeProperties(node_props)
 
 #
 # Main callsite for Bfs

--- a/python/katana/property_graph.pyx.jinja
+++ b/python/katana/property_graph.pyx.jinja
@@ -188,7 +188,7 @@ cdef class PropertyGraph:
         `get_node_property` should be used unless a chunked array is explicitly needed as non-chunked arrays are much more efficient.
         """
         return pyarrow_wrap_chunked_array(
-            self.underlying.get().NodeProperty(PropertyGraph._property_name_to_id(prop, self.node_schema()))
+            self.underlying.get().GetNodeProperty(PropertyGraph._property_name_to_id(prop, self.node_schema()))
         )
 
     def get_edge_property(self, prop):
@@ -210,7 +210,7 @@ cdef class PropertyGraph:
         `get_edge_property` should be used unless a chunked array is explicitly needed as non-chunked arrays are much more efficient.
         """
         return pyarrow_wrap_chunked_array(
-            self.underlying.get().EdgeProperty(PropertyGraph._property_name_to_id(prop, self.edge_schema()))
+            self.underlying.get().GetEdgeProperty(PropertyGraph._property_name_to_id(prop, self.edge_schema()))
         )
 
     def add_node_property(self, table):

--- a/tools/graph-convert/graph-properties-convert-schema.h
+++ b/tools/graph-convert/graph-properties-convert-schema.h
@@ -46,7 +46,7 @@ ProcessSchemaMapping(const std::string& mapping);
 
 std::string TypeName(ImportDataType type);
 ImportDataType ParseType(const std::string& in);
-ImportDataType ParseType(std::shared_ptr<arrow::DataType> in);
+ImportDataType ParseType(const std::shared_ptr<arrow::DataType>& in);
 
 }  // namespace katana
 


### PR DESCRIPTION
Properties are tables but they are really a specific kind of table: one
where rows correspond to nodes or edges of a property graph. Match API
with this mental model.

I debated PropertyFileGraph::GetNodeProperty(int i) between
PropertyFileGraph::node_property(int i). On balance, I favored
GetNodeProperty(int i) because there is a corresponding
GetNodePropertyTyped method that is certainly not a field access and
thus isn't a good candidate to be named node_property_typed, and it
seemed reasonable to me to keep these two related accessors with the
same naming style.