### PR TITLE
tsuba: Bound how much memory is allowed to be outstanding for writes

### DIFF
--- a/libtsuba/include/tsuba/FileFrame.h
+++ b/libtsuba/include/tsuba/FileFrame.h
@@ -66,6 +66,8 @@ public:
   katana::Result<void> Persist();
   std::future<katana::Result<void>> PersistAsync();
 
+  uint64_t map_size() const { return map_size_; }
+
   template <typename T>
   katana::Result<T*> ptr() const {
     return reinterpret_cast<T*>(map_start_); /* NOLINT */

--- a/libtsuba/include/tsuba/WriteGroup.h
+++ b/libtsuba/include/tsuba/WriteGroup.h
@@ -17,18 +17,32 @@ class WriteGroup {
   struct AsyncOp {
     std::future<katana::Result<void>> result;
     std::string location;
+    uint64_t accounted_size;
   };
 
   std::string tag_;
   std::list<AsyncOp> pending_ops_;
+  uint64_t outstanding_size_{0};
+  uint64_t errors_{0};
+  uint64_t total_{0};
+  katana::Result<void> last_error_{katana::ResultSuccess()};
 
   WriteGroup(std::string tag) : tag_(std::move(tag)){};
 
   /// Add future to the list of futures this descriptor will wait for, note
-  /// the file name for debugging
-  void AddOp(std::future<katana::Result<void>> future, std::string file);
+  /// the file name for debugging. If the operation is associated with a file
+  /// frame that we are responsible for, note the size
+  void AddOp(
+      std::future<katana::Result<void>> future, std::string file,
+      uint64_t accounted_size = 0);
+
+  /// Wait for the next op if there is one, account errors. Returns true if
+  /// there was a next op
+  bool Drain();
 
 public:
+  static constexpr uint64_t kMaxOutstandingSize = 10ULL << 30;  // 10 GB
+
   /// Build a descriptor with a tag. If running with multiple hosts, Make should
   /// be Called BSP style and all hosts will have the same tag
   static katana::Result<std::unique_ptr<WriteGroup>> Make();


### PR DESCRIPTION
I needed some rate limiting to be able to write things out when memory is closer to full.
Not sure if this is the right bound or not.

Along the way: Patched support for `LargeStringArrays` (dumb bandaid for now since it looks like it
was fixed upstream). Will create an issue to track that.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>