### PR TITLE
tsuba: return NotFound instead of InvalidArgument

### DIFF
--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -64,7 +64,7 @@ FindLatestMetaFile(const katana::Uri& name) {
   }
   if (found_meta.empty()) {
     KATANA_LOG_DEBUG("failed: could not find meta file in {}", name);
-    return tsuba::ErrorCode::InvalidArgument;
+    return tsuba::ErrorCode::NotFound;
   }
   return name.Join(found_meta);
 }


### PR DESCRIPTION
Worth being more informative to allow callers to test for non-existence

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>