### PR TITLE
Load arbitrary partitions from stored RDG

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -200,6 +200,14 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const std::string& rdg_name);
 
+  /// Make a property graph from an RDG name and a particular partition to load.
+  ///
+  /// These are not the droids you are looking for...
+  /// This flavor of Make is used by the partitioner and is intended for use
+  /// only by system components that manipulate graph representation internals
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      const std::string& rdg_name, uint32_t host_to_load);
+
   /// Make a property graph from an RDG but only load the named node and edge
   /// properties.
   ///

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -196,30 +196,39 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg);
 
-  /// Make a property graph from an RDG name.
+  /// Make a property graph from an RDG name. Load the default partition and all
+  /// properties.
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const std::string& rdg_name);
 
-  /// Make a property graph from an RDG name and a particular partition to load.
+  /// Make a property graph from an RDG name. Load the requested partition and
+  /// all properties.
   ///
-  /// These are not the droids you are looking for...
-  /// This flavor of Make is used by the partitioner and is intended for use
-  /// only by system components that manipulate graph representation internals
+  /// This is probably not the Make you are looking for. This is used by the
+  /// partitioner, which makes its living manipulating graph representation
+  /// internals.
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const std::string& rdg_name, uint32_t host_to_load);
 
-  /// Make a property graph from an RDG but only load the named node and edge
-  /// properties.
-  ///
-  /// The order of properties in the resulting graph will match the order of
-  /// given in the property arguments.
-  ///
-  /// \returns invalid_argument if any property is not found or if there
-  /// are multiple properties with the same name
+  /// Make a property graph from an RDG name. Load the default partition and the
+  /// named node and edge properties.
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const std::string& rdg_name,
       const std::vector<std::string>& node_properties,
       const std::vector<std::string>& edge_properties);
+
+  /// Full strength PropertyGraph::Make. Make a property graph from an RDG name.
+  /// Optionally specify a partition to load. Optionally specify properties to
+  /// load. If node_properties is null, all node properties will be
+  /// loaded. Likewise for edge_properties.
+  ///
+  /// This is probably not the Make you are looking for. This is used by the
+  /// partitioner, which makes its living manipulating graph representation
+  /// internals.
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      const std::string& rdg_name, std::optional<uint32_t> host_to_load,
+      const std::vector<std::string>* node_properties,
+      const std::vector<std::string>* edge_properties);
 
   /// \return A copy of this with the same set of properties. The copy shares no
   ///       state with this.
@@ -234,6 +243,8 @@ public:
       const std::vector<std::string>& edge_properties);
 
   const std::string& rdg_dir() const { return rdg_.rdg_dir().string(); }
+
+  uint32_t partition_number() const { return rdg_.partition_number(); }
 
   // Accessors for information in partition_metadata.
   GraphTopology::nodes_range masters() const {

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -155,6 +155,18 @@ MakePropertyGraph(std::unique_ptr<tsuba::RDGFile> rdg_file) {
       std::move(rdg_file), std::move(rdg_result.value()));
 }
 
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+MakePropertyGraph(
+    std::unique_ptr<tsuba::RDGFile> rdg_file, uint32_t host_to_load) {
+  auto rdg_result = tsuba::RDG::Make(*rdg_file, host_to_load);
+  if (!rdg_result) {
+    return rdg_result.error();
+  }
+
+  return katana::PropertyGraph::Make(
+      std::move(rdg_file), std::move(rdg_result.value()));
+}
+
 }  // namespace
 
 katana::PropertyGraph::PropertyGraph() = default;
@@ -217,6 +229,18 @@ katana::PropertyGraph::Make(const std::string& rdg_name) {
   }
 
   return MakePropertyGraph(std::make_unique<tsuba::RDGFile>(handle.value()));
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Make(
+    const std::string& rdg_name, uint32_t host_to_load) {
+  auto handle = tsuba::Open(rdg_name, tsuba::kReadWrite);
+  if (!handle) {
+    return handle.error();
+  }
+
+  return MakePropertyGraph(
+      std::make_unique<tsuba::RDGFile>(handle.value()), host_to_load);
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -68,7 +68,18 @@ public:
   /// Explain to graph how it is derived from previous version
   void AddLineage(const std::string& command_line);
 
-  /// Load the RDG described by the metadata in handle into memory
+  /// Full strength RDG::Make. Load the RDG described by the metadata in handle
+  /// into memory. Optionally specify a specific partition to load. Optionally
+  /// specify properties to load. If node_props is null, all node
+  /// properties will be loaded. Likewise for edge_props.
+  static katana::Result<RDG> Make(
+      RDGHandle handle, std::optional<uint32_t> host_to_load,
+      const std::vector<std::string>* node_props,
+      const std::vector<std::string>* edge_props);
+
+  /// Load the RDG described by the metadata in handle into memory. Optionally
+  /// specify properties to load. If node_props is null, all node
+  /// properties will be loaded. Likewise for edge_props.
   static katana::Result<RDG> Make(
       RDGHandle handle, const std::vector<std::string>* node_props = nullptr,
       const std::vector<std::string>* edge_props = nullptr);
@@ -94,6 +105,11 @@ public:
 
   const katana::Uri& rdg_dir() const { return rdg_dir_; }
   void set_rdg_dir(const katana::Uri& rdg_dir) { rdg_dir_ = rdg_dir; }
+
+  uint32_t partition_number() const { return partition_number_; }
+  void set_partition_number(uint32_t partition_number) {
+    partition_number_ = partition_number;
+  }
 
   /// The node properties
   const std::shared_ptr<arrow::Table>& node_properties() const;
@@ -140,6 +156,11 @@ private:
       const RDGMeta& meta, const std::vector<std::string>* node_props,
       const std::vector<std::string>* edge_props);
 
+  static katana::Result<RDG> Make(
+      const RDGMeta& meta, std::optional<uint32_t> host_to_load,
+      const std::vector<std::string>* node_props,
+      const std::vector<std::string>* edge_props);
+
   katana::Result<void> AddPartitionMetadataArray(
       const std::shared_ptr<arrow::Table>& props);
 
@@ -162,6 +183,8 @@ private:
 
   /// name of the graph that was used to load this RDG
   katana::Uri rdg_dir_;
+  /// which partition of the graph was loaded
+  uint32_t partition_number_{std::numeric_limits<uint32_t>::max()};
   // How this graph was derived from the previous version
   RDGLineage lineage_;
 };


### PR DESCRIPTION
In service of allowing us to load more partitions than we have hosts in the cluster and then partitioning down to the right number of partitions for the cluster, this PR modifies `PropertyGraph` and `RDG` to support loading an arbitrary partition from a stored RDG.

I opted for the following interface: all relevant `Make`s provide a "full" interface consisting of `std::string& rdg_name` (or other pointer to the RDG), `std::optional<uint32_t> host_to_load`, and `const vector<std::string>* {node,edge}_properties`. Additionally, all `Make`s are overloaded to provide a "only pass the parameters you care about" interface. But those overloads always call the "full" interface, so the logic is all in one place.