### PR TITLE
Add options struct for loading RDGs

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -202,7 +202,7 @@ public:
 
   /// Make a property graph from an RDG name.
   static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name, const struct tsuba::RDGLoadOptions& opts);
+      const std::string& rdg_name, const tsuba::RDGLoadOptions& opts);
 
   /// \return A copy of this with the same set of properties. The copy shares no
   ///       state with this.

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -200,39 +200,9 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg);
 
-  /// Make a property graph from an RDG name. Load the default partition and all
-  /// properties.
+  /// Make a property graph from an RDG name.
   static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name);
-
-  /// Make a property graph from an RDG name. Load the requested partition and
-  /// all properties.
-  ///
-  /// This is probably not the Make you are looking for. This is used by the
-  /// partitioner, which makes its living manipulating graph representation
-  /// internals.
-  static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name, uint32_t host_to_load);
-
-  /// Make a property graph from an RDG name. Load the default partition and the
-  /// named node and edge properties.
-  static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name,
-      const std::vector<std::string>& node_properties,
-      const std::vector<std::string>& edge_properties);
-
-  /// Full strength PropertyGraph::Make. Make a property graph from an RDG name.
-  /// Optionally specify a partition to load. Optionally specify properties to
-  /// load. If node_properties is null, all node properties will be
-  /// loaded. Likewise for edge_properties.
-  ///
-  /// This is probably not the Make you are looking for. This is used by the
-  /// partitioner, which makes its living manipulating graph representation
-  /// internals.
-  static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name, std::optional<uint32_t> host_to_load,
-      const std::vector<std::string>* node_properties,
-      const std::vector<std::string>* edge_properties);
+      const std::string& rdg_name, const struct tsuba::RDGLoadOptions& opts);
 
   /// \return A copy of this with the same set of properties. The copy shares no
   ///       state with this.
@@ -248,7 +218,7 @@ public:
 
   const std::string& rdg_dir() const { return rdg_.rdg_dir().string(); }
 
-  uint32_t partition_number() const { return rdg_.partition_number(); }
+  uint32_t partition_id() const { return rdg_.partition_id(); }
 
   // Accessors for information in partition_metadata.
   GraphTopology::nodes_range masters() const {

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -202,7 +202,8 @@ public:
 
   /// Make a property graph from an RDG name.
   static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name, const tsuba::RDGLoadOptions& opts);
+      const std::string& rdg_name,
+      const tsuba::RDGLoadOptions& opts = tsuba::RDGLoadOptions());
 
   /// \return A copy of this with the same set of properties. The copy shares no
   ///       state with this.

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -132,11 +132,8 @@ WriteTopology(const katana::GraphTopology& topology) {
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 MakePropertyGraph(
     std::unique_ptr<tsuba::RDGFile> rdg_file,
-    std::optional<uint32_t> host_to_load,
-    const std::vector<std::string>* node_properties,
-    const std::vector<std::string>* edge_properties) {
-  auto rdg_result = tsuba::RDG::Make(
-      *rdg_file, host_to_load, node_properties, edge_properties);
+    const struct tsuba::RDGLoadOptions& opts) {
+  auto rdg_result = tsuba::RDG::Make(*rdg_file, opts);
   if (!rdg_result) {
     return rdg_result.error();
   }
@@ -200,37 +197,15 @@ katana::PropertyGraph::Make(
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Make(const std::string& rdg_name) {
-  return Make(rdg_name, std::nullopt, nullptr, nullptr);
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
-    const std::string& rdg_name, uint32_t host_to_load) {
-  return Make(rdg_name, host_to_load, nullptr, nullptr);
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Make(
-    const std::string& rdg_name,
-    const std::vector<std::string>& node_properties,
-    const std::vector<std::string>& edge_properties) {
-  return Make(rdg_name, std::nullopt, &node_properties, &edge_properties);
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Make(
-    const std::string& rdg_name, std::optional<uint32_t> host_to_load,
-    const std::vector<std::string>* node_properties,
-    const std::vector<std::string>* edge_properties) {
+    const std::string& rdg_name, const struct tsuba::RDGLoadOptions& opts) {
   auto handle = tsuba::Open(rdg_name, tsuba::kReadWrite);
   if (!handle) {
     return handle.error();
   }
 
   return MakePropertyGraph(
-      std::make_unique<tsuba::RDGFile>(handle.value()), host_to_load,
-      node_properties, edge_properties);
+      std::make_unique<tsuba::RDGFile>(handle.value()), opts);
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
@@ -243,8 +218,12 @@ katana::PropertyGraph::Copy(
     const std::vector<std::string>& node_properties,
     const std::vector<std::string>& edge_properties) const {
   // TODO(gill): This should copy the RDG in memory without reloading from storage.
-  return Make(
-      rdg_dir(), partition_number(), &node_properties, &edge_properties);
+  tsuba::RDGLoadOptions opts;
+  opts.partition_id_to_load = partition_id();
+  opts.node_properties = &node_properties;
+  opts.edge_properties = &edge_properties;
+
+  return Make(rdg_dir(), opts);
 }
 
 katana::Result<void>

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -132,7 +132,7 @@ WriteTopology(const katana::GraphTopology& topology) {
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 MakePropertyGraph(
     std::unique_ptr<tsuba::RDGFile> rdg_file,
-    const struct tsuba::RDGLoadOptions& opts) {
+    const tsuba::RDGLoadOptions& opts) {
   auto rdg_result = tsuba::RDG::Make(*rdg_file, opts);
   if (!rdg_result) {
     return rdg_result.error();
@@ -198,7 +198,7 @@ katana::PropertyGraph::Make(
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
-    const std::string& rdg_name, const struct tsuba::RDGLoadOptions& opts) {
+    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
   auto handle = tsuba::Open(rdg_name, tsuba::kReadWrite);
   if (!handle) {
     return handle.error();

--- a/libgalois/test/graph-predicates.cpp
+++ b/libgalois/test/graph-predicates.cpp
@@ -5,6 +5,7 @@
 #include "katana/PropertyGraph.h"
 #include "katana/SharedMemSys.h"
 #include "katana/analytics/Utils.h"
+#include "tsuba/RDG.h"
 
 namespace cll = llvm::cl;
 
@@ -24,7 +25,8 @@ TestIsApproximateDegreeDistributionPowerLaw() {
         !katana::analytics::IsApproximateDegreeDistributionPowerLaw(*g.get()));
   }
   {
-    auto g = katana::PropertyGraph::Make(rmat10InputFile);
+    auto g =
+        katana::PropertyGraph::Make(rmat10InputFile, tsuba::RDGLoadOptions());
     KATANA_LOG_ASSERT(
         katana::analytics::IsApproximateDegreeDistributionPowerLaw(
             *g.assume_value().get()));

--- a/libgalois/test/property-file-graph.cpp
+++ b/libgalois/test/property-file-graph.cpp
@@ -80,7 +80,7 @@ TestRoundTrip() {
   }
 
   katana::Result<std::unique_ptr<katana::PropertyGraph>> make_result =
-      katana::PropertyGraph::Make(rdg_dir);
+      katana::PropertyGraph::Make(rdg_dir, tsuba::RDGLoadOptions());
   fs::remove_all(rdg_dir);
   if (!make_result) {
     KATANA_LOG_FATAL("making result: {}", make_result.error());
@@ -143,7 +143,8 @@ TestGarbageMetadata() {
   out << "garbage to make the file non-empty";
   out.close();
 
-  auto no_dir_result = katana::PropertyGraph::Make(rdg_file);
+  auto no_dir_result =
+      katana::PropertyGraph::Make(rdg_file, tsuba::RDGLoadOptions());
   fs::remove_all(temp_dir);
   KATANA_LOG_ASSERT(!no_dir_result.has_value());
 }
@@ -205,7 +206,7 @@ TestSimplePGs() {
   KATANA_LOG_ASSERT(rdg_file.empty());
   rdg_file = MakePFGFile("n1");
   katana::Result<std::unique_ptr<katana::PropertyGraph>> make_result =
-      katana::PropertyGraph::Make(rdg_file);
+      katana::PropertyGraph::Make(rdg_file, tsuba::RDGLoadOptions());
   fs::remove_all(rdg_file);
   KATANA_LOG_ASSERT(make_result);
 }

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -82,8 +82,7 @@ public:
   void AddLineage(const std::string& command_line);
 
   /// Load the RDG described by the metadata in handle into memory.
-  static katana::Result<RDG> Make(
-      RDGHandle handle, const struct RDGLoadOptions& opts);
+  static katana::Result<RDG> Make(RDGHandle handle, const RDGLoadOptions& opts);
 
   katana::Result<void> UnbindTopologyFileStorage();
 
@@ -152,7 +151,7 @@ private:
   katana::Result<void> DoMake(const katana::Uri& metadata_dir);
 
   static katana::Result<RDG> Make(
-      const RDGMeta& meta, const struct RDGLoadOptions& opts);
+      const RDGMeta& meta, const RDGLoadOptions& opts);
 
   katana::Result<void> AddPartitionMetadataArray(
       const std::shared_ptr<arrow::Table>& props);

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -79,7 +79,7 @@ KATANA_EXPORT katana::Result<void> RegisterIfAbsent(const std::string& name);
 KATANA_EXPORT katana::Result<void> Forget(const std::string& name);
 
 struct KATANA_EXPORT RDGStat {
-  uint64_t num_hosts{0};
+  uint64_t num_partitions{0};
   uint32_t policy_id{0};
   bool transpose{false};
 };

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -538,7 +538,7 @@ tsuba::RDG::Equals(const RDG& other) const {
 }
 
 katana::Result<tsuba::RDG>
-tsuba::RDG::Make(RDGHandle handle, const struct RDGLoadOptions& opts) {
+tsuba::RDG::Make(RDGHandle handle, const RDGLoadOptions& opts) {
   if (!handle.impl_->AllowsRead()) {
     KATANA_LOG_DEBUG("failed: handle does not allow full read");
     return ErrorCode::InvalidArgument;

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -216,7 +216,7 @@ tsuba::Stat(const std::string& rdg_name) {
   if (!rdg_res) {
     if (rdg_res.error() == katana::ErrorCode::JsonParseFailed) {
       return RDGStat{
-          .num_hosts = 1,
+          .num_partitions = 1,
           .policy_id = 0,
           .transpose = false,
       };
@@ -226,7 +226,7 @@ tsuba::Stat(const std::string& rdg_name) {
 
   RDGMeta meta = rdg_res.value();
   return RDGStat{
-      .num_hosts = meta.num_hosts(),
+      .num_partitions = meta.num_hosts(),
       .policy_id = meta.policy_id(),
       .transpose = meta.transpose(),
   };

--- a/lonestar/liblonestar/include/Lonestar/Utils.h
+++ b/lonestar/liblonestar/include/Lonestar/Utils.h
@@ -26,6 +26,7 @@
 
 #include "katana/PropertyGraph.h"
 #include "katana/analytics/Utils.h"
+#include "tsuba/RDG.h"
 
 inline std::unique_ptr<katana::PropertyGraph>
 MakeFileGraph(
@@ -36,8 +37,10 @@ MakeFileGraph(
     edge_properties.emplace_back(edge_property_name);
   }
 
-  auto pfg_result =
-      katana::PropertyGraph::Make(rdg_name, node_properties, edge_properties);
+  tsuba::RDGLoadOptions opts;
+  opts.node_properties = &node_properties;
+  opts.edge_properties = &edge_properties;
+  auto pfg_result = katana::PropertyGraph::Make(rdg_name, opts);
   if (!pfg_result) {
     KATANA_LOG_FATAL("cannot make graph: {}", pfg_result.error());
   }

--- a/python/katana/cpp/libgalois/graphs/Graph.pxd
+++ b/python/katana/cpp/libgalois/graphs/Graph.pxd
@@ -3,8 +3,18 @@ from ..Galois cimport MethodFlag, NoDerefIterator, StandardRange
 from libcpp.memory cimport unique_ptr, shared_ptr
 from libcpp.vector cimport vector
 from libc.stdint cimport uint64_t
+from libc.stdint cimport uint32_t
 from katana.cpp.libstd.boost cimport std_result
+from katana.cpp.libstd.optional cimport optional
 from pyarrow.lib cimport CSchema, CChunkedArray, CArray, CTable, CUInt32Array, CUInt64Array
+
+# This is very similar to the block below, but needs to be in the tsuba namespace
+cdef extern from "tsuba/RDG.h" namespace "tsuba" nogil:
+    cdef struct RDGLoadOptions:
+        optional[uint32_t] partition_id_to_load
+        const vector[string]* node_properties
+        const vector[string]* edge_properties
+
 
 # Omit the exception specifications here to
 # allow returning lvalues.
@@ -110,9 +120,7 @@ cdef extern from "katana/Graph.h" namespace "katana" nogil:
     cppclass _PropertyGraph "katana::PropertyGraph":
         PropertyGraph()
         @staticmethod
-        std_result[unique_ptr[_PropertyGraph]] Make(string filename)
-        @staticmethod
-        std_result[unique_ptr[_PropertyGraph]] MakeWithProperties "Make" (string filename, vector[string] node_properties, vector[string] edge_properties)
+        std_result[unique_ptr[_PropertyGraph]] Make(string filename, RDGLoadOptions opts)
 
         std_result[void] Write(string path, string command_line)
         std_result[void] Commit(string command_line)

--- a/python/katana/cpp/libstd/optional.pxd
+++ b/python/katana/cpp/libstd/optional.pxd
@@ -1,0 +1,43 @@
+# This file is from an unmerged PR in the cython repo:
+# https://github.com/cython/cython/pull/3294
+#
+# Cython (and by extension the Cython fork this code was copied from) is
+# licensed under the Apache 2.0 license:
+# http://apache.org/licenses/LICENSE-2.0.txt
+#
+# If you have questions or cannot access the license above, please send an email
+# to <support@katanagraph.com>
+from libcpp cimport bool
+
+cdef extern from "<optional>" namespace "std" nogil:
+    cdef cppclass nullopt_t:
+        nullopt_t()
+
+    cdef nullopt_t nullopt
+
+    cdef cppclass optional[T]:
+        ctypedef T value_type
+        optional()
+        optional(nullopt_t)
+        optional(optional&) except +
+        optional(T&) except +
+        bool has_value()
+        T& value()
+        T& value_or[U](U& default_value)
+        void swap(optional&)
+        void reset()
+        T& emplace(...)
+        T& operator*()
+        #T* operator->() # Not Supported
+        optional& operator=(optional&)
+        optional& operator=[U](U&)
+        bool operator bool()
+        bool operator!()
+        bool operator==[U](optional&, U&)
+        bool operator!=[U](optional&, U&)
+        bool operator<[U](optional&, U&)
+        bool operator>[U](optional&, U&)
+        bool operator<=[U](optional&, U&)
+        bool operator>=[U](optional&, U&)
+
+    optional[T] make_optional[T](...) except +

--- a/python/katana/property_graph.pxd.jinja
+++ b/python/katana/property_graph.pxd.jinja
@@ -1,7 +1,7 @@
 # {{generated_banner()}}
 
 from libc.stdint cimport uint64_t
-from .cpp.libgalois.graphs.Graph cimport _PropertyGraph, GraphTopology
+from .cpp.libgalois.graphs.Graph cimport _PropertyGraph, GraphTopology, RDGLoadOptions
 from libcpp.memory cimport shared_ptr
 from pyarrow.lib cimport Schema
 

--- a/python/katana/property_graph.pyx.jinja
+++ b/python/katana/property_graph.pyx.jinja
@@ -5,6 +5,9 @@ from pyarrow.lib cimport to_shared, pyarrow_wrap_schema, pyarrow_wrap_chunked_ar
 from .cpp.libstd.boost cimport std_result, handle_result_void, raise_error_code
 from .numba_support._pyarrow_wrappers import unchunked
 from libcpp.memory cimport shared_ptr, unique_ptr
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libc.stdint cimport uint32_t
 
 {% import "numba_wrapper_support.jinja" as numba %}
 
@@ -28,27 +31,34 @@ cdef class PropertyGraph:
     """
     A property graph loaded into memory.
     """
-    def __init__(self, path, node_properties=None, edge_properties=None):
+    def __init__(self, path, partition_id_to_load=None, node_properties=None, edge_properties=None):
         """
-        __init__(self, path, node_properties=None, edge_properties=None)
+        __init__(self, path, partition_id_to_load=None, node_properties=None, edge_properties=None)
 
         Load a property graph.
 
         :param path: the path or URL from which to load the graph. This support local paths or s3 URLs.
         :type path: str
+        :param partition_id_to_load: An unsigned integer corresponding to a partition number in the graph being loaded. If this is None (default), then the partition corresponding to this host's network id will be loaded.
         :param node_properties: A list of node property names to load into memory. If this is None (default), then all properties are loaded.
         :param edge_properties: A list of edge property names to load into memory. If this is None (default), then all properties are loaded.
         """
-        if node_properties is not None or edge_properties is not None:
-            if node_properties is None or edge_properties is None:
-                raise ValueError("If either node_properties or edge_properties are provided, both must be provided.")
-            self.underlying = handle_result_value(
-                _PropertyGraph.MakeWithProperties(bytes(path, "utf-8"),
-                                                     _convert_string_list(node_properties),
-                                                     _convert_string_list(edge_properties)))
-        else:
-            self.underlying = handle_result_value(
-                _PropertyGraph.Make(bytes(path, "utf-8")))
+        cdef RDGLoadOptions opts
+        cdef vector[string] node_props
+        cdef vector[string] edge_props
+        # we need to generate a reference to a uint32_t in order to construct an
+        # optional[uint32_t] in opts
+        cdef uint32_t part_to_load
+        if partition_id_to_load is not None:
+            part_to_load = partition_id_to_load
+            opts.partition_id_to_load = part_to_load
+        if node_properties is not None:
+            node_props = _convert_string_list(node_properties)
+            opts.node_properties = &node_props
+        if edge_properties is not None:
+            edge_props = _convert_string_list(edge_properties)
+            opts.edge_properties = &edge_props
+        self.underlying = handle_result_value(_PropertyGraph.Make(bytes(path, "utf-8"), opts))
 
     def write(self, path, command_line) :
         """

--- a/tools/graph-convert/graph-properties-convert-main.cpp
+++ b/tools/graph-convert/graph-properties-convert-main.cpp
@@ -10,6 +10,7 @@
 #include "katana/Logging.h"
 #include "katana/Timer.h"
 #include "katana/config.h"
+#include "tsuba/RDG.h"
 
 #if defined(KATANA_MONGOC_FOUND)
 #include "graph-properties-convert-mongodb.h"
@@ -91,7 +92,7 @@ cll::opt<bool> export_graphml(
 
 katana::PropertyGraph
 ConvertKatana(const std::string& rdg_file) {
-  auto result = katana::PropertyGraph::Make(rdg_file);
+  auto result = katana::PropertyGraph::Make(rdg_file, tsuba::RDGLoadOptions());
   if (!result) {
     KATANA_LOG_FATAL("failed to load {}: {}", rdg_file, result.error());
   }

--- a/tools/graph-convert/graph-properties-convert-schema.cpp
+++ b/tools/graph-convert/graph-properties-convert-schema.cpp
@@ -5,6 +5,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include "tsuba/RDG.h"
+
 using katana::ImportDataType;
 using katana::LabelRule;
 using katana::PropertyKey;
@@ -369,7 +371,7 @@ InRange(uint32_t id, const std::pair<uint64_t, uint64_t>& interval) {
 
 void
 katana::ExportGraph(const std::string& outfile, const std::string& rdg_file) {
-  auto result = katana::PropertyGraph::Make(rdg_file);
+  auto result = katana::PropertyGraph::Make(rdg_file, tsuba::RDGLoadOptions());
   if (!result) {
     KATANA_LOG_FATAL("failed to load {}: {}", rdg_file, result.error());
   }


### PR DESCRIPTION
After some discussion in #77, I am adding a struct to define the options that affect loading a RDG from storage. I also changed the `num_hosts` field in `RDGStat` to `num_partitions`.

`RDG::Make` and `PropertyGraph::Make` now both require a `struct RDGLoadOptions`.