### PR TITLE
Simplify backtrace and other nits

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -64,6 +64,10 @@ struct KATANA_EXPORT GraphTopology {
     auto [begin_edge, end_edge] = edge_range(node);
     return MakeStandardRange<edge_iterator>(begin_edge, end_edge);
   }
+  Node edge_dest(Edge eid) const {
+    KATANA_LOG_ASSERT(eid < static_cast<Edge>(out_dests->length()));
+    return out_dests->Value(eid);
+  }
 
   nodes_range nodes(Node begin, Node end) const {
     return MakeStandardRange<node_iterator>(begin, end);
@@ -493,7 +497,7 @@ public:
    * @returns node iterator to the edge destination
    */
   node_iterator GetEdgeDest(const edge_iterator& edge) const {
-    auto node_id = topology().out_dests->Value(*edge);
+    auto node_id = topology().edge_dest(*edge);
     return node_iterator(node_id);
   }
 };

--- a/libgalois/src/BuildGraph.cpp
+++ b/libgalois/src/BuildGraph.cpp
@@ -2002,9 +2002,6 @@ katana::ImportToArrow(
     const std::vector<katana::ImportData>& import_src) {
   std::shared_ptr<arrow::Array> array = nullptr;
 
-  if (import_src.empty()) {
-    return katana::ErrorCode::ArrowError;
-  }
   array = ToArrowArray(arrow_type, array, import_src);
 
   std::vector<std::shared_ptr<arrow::Array>> chunks;

--- a/libsupport/include/katana/Backtrace.h
+++ b/libsupport/include/katana/Backtrace.h
@@ -1,14 +1,12 @@
 #ifndef KATANA_LIBSUPPORT_KATANA_BACKTRACE_H_
 #define KATANA_LIBSUPPORT_KATANA_BACKTRACE_H_
 
-#include <stdint.h>
-
 #include "katana/config.h"
 
 namespace katana {
-// Passing an ID allows us to limit backtraces to a single process
-KATANA_EXPORT void InitBacktrace(uint32_t ID = 0);
+// Programmatic interface to print a backtrace
 KATANA_EXPORT void PrintBacktrace();
+KATANA_EXPORT void InitBacktrace();
 }  // end namespace katana
 
 #endif

--- a/libsupport/src/Backtrace.cpp
+++ b/libsupport/src/Backtrace.cpp
@@ -1,44 +1,28 @@
 // Backtrace information.  backward-cpp prints an informative backtrace on abrupt
-// termination, but also provide program interface.
+// termination, and provides a program interface.
 
 #include "katana/Backtrace.h"
 
-#include "katana/Logging.h"
-
-static uint32_t backtrace_id{0};
-
 #include <backward.hpp>
+
+#include "katana/Logging.h"
 // Install signal handlers
 backward::SignalHandling sh;
 
-static void
-default_signals() {
-  std::vector<int> posix_signals = sh.make_default_signals();
-  for (size_t i = 0; i < posix_signals.size(); ++i) {
-    int r = sigaction(posix_signals[i], nullptr, nullptr);
-    if (r < 0) {
-      KATANA_LOG_DEBUG(
-          "failed to revert signal handler to default: {}", posix_signals[i]);
-    }
-  }
-}
-
 KATANA_EXPORT void
 katana::PrintBacktrace() {
-  if (backtrace_id == 0) {
+  // Only have one thread print backtrace
+  static std::once_flag printed_start;
+  std::call_once(printed_start, [=]() {
     using namespace backward;
     StackTrace st;
     st.load_here(32);
     Printer p;
     p.print(st);
-  }
+  });
 }
 
 KATANA_EXPORT void
-katana::InitBacktrace(uint32_t ID) {
-  backtrace_id = ID;
-  // Only have one process print backtrace
-  if (backtrace_id != 0) {
-    default_signals();
-  }
+katana::InitBacktrace() {
+  // Set signal handlers
 }

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -72,6 +72,7 @@ DoLoadProperties(
     const std::string& expected_name, const katana::Uri& file_path) {
   auto fv = std::make_shared<tsuba::FileView>(tsuba::FileView());
   if (auto res = fv->Bind(file_path.string(), false); !res) {
+    KATANA_LOG_DEBUG("bind error: {}", res.error());
     return res.error();
   }
 

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -478,7 +478,7 @@ tsuba::RDG::DoMake(const katana::Uri& metadata_dir) {
           return rdg->AddPartitionMetadataArray(props);
         });
     if (!part_result) {
-      return edge_result.error();
+      return part_result.error();
     }
   }
 

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -250,7 +250,7 @@ tsuba::Init(katana::CommBackend* comm) {
     return client_res.error();
   }
   default_ns_client = std::move(client_res.value());
-  katana::InitBacktrace(comm->ID);
+  katana::InitBacktrace();
   return GlobalState::Init(comm, default_ns_client.get());
 }
 


### PR DESCRIPTION
This is a collection of small fixes.

BuildGraph: allow creation of empty Arrow arrays
 o It is useful to build empty Arrow arrays from empty vectors
cut and paste fix in RDG::DoMake
 o Simple bug fix to return the error from the checked variable
Simplify backtrace logic
 o Only have one thread print backtrace and eliminate useless code.  We could work harder to only print the backtrace on 1 host if all fail, but it dosn't quite seem worthwhile.
edge_dest is a valid operation on GraphTopology
 o Seemed like a useful operation worthy of a name.