### PR TITLE
Parameterize prunes in check_format

### DIFF
--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -16,7 +16,7 @@ fi
 
 ROOTS="$@"
 FAILED=
-PRUNE_PATHS="'*/external/cub' '*/external/bliss'"
+PRUNE_PATHS=${PRUNE_PATHS:-}
 PRUNE_NAMES="build*"
 
 emit_prunes() {
@@ -34,7 +34,7 @@ while read -d '' filename; do
       FAILED=1
     fi
   fi
-done < <(find ${ROOTS} $(emit_prunes) -name '*.cpp' -print0 -o -name '*.h' -print0)
+done < <(find ${ROOTS} $(emit_prunes) -name '*.cpp' -print0 -o -name '*.h' -print0 -o -name '*.cu' -print0 -o -name '*.cuh' -print0)
 
 if [ -n "${FAILED}" ]; then
   exit 1


### PR DESCRIPTION
Also add cu as a possible file extension. I didn't parameterize file
extensions for check_format (yet) because the set of viable extensions
for clang-format is small and probably well-known to check_format.sh
while the set of paths to exclude is context dependent.