### PR TITLE
support: add interfaces to use custom seeds

### DIFF
--- a/libgalois/src/analytics/Utils.cpp
+++ b/libgalois/src/analytics/Utils.cpp
@@ -24,8 +24,10 @@
 uint32_t
 katana::analytics::SourcePicker::PickNext() {
   uint32_t source;
+  auto& gen = GetGenerator();
+  std::uniform_int_distribution dist({}, graph.size() - 1);
   do {
-    source = RandomUniformInt(graph.size());
+    source = dist(gen);
   } while (graph.edges(source).empty());
   KATANA_LOG_DEBUG_ASSERT(graph.edges(source));
   return source;

--- a/libgalois/test/TestTypedPropertyGraph.h
+++ b/libgalois/test/TestTypedPropertyGraph.h
@@ -48,8 +48,10 @@ public:
   std::vector<uint32_t> GenerateNeighbors(
       [[maybe_unused]] size_t node_id, size_t num_nodes) override {
     std::vector<uint32_t> r;
+    auto& gen = katana::GetGenerator();
+    std::uniform_int_distribution dist({}, num_nodes - 1);
     for (size_t i = 0; i < width_; ++i) {
-      size_t neighbor = katana::RandomUniformInt(num_nodes);
+      size_t neighbor = dist(gen);
       r.emplace_back(neighbor);
     }
     return r;

--- a/libsupport/include/katana/Random.h
+++ b/libsupport/include/katana/Random.h
@@ -8,15 +8,18 @@
 
 namespace katana {
 
-KATANA_EXPORT std::string RandomAlphanumericString(uint64_t len);
-// Range 0..len-1, inclusive
-KATANA_EXPORT int64_t RandomUniformInt(int64_t len);
-// Range min+1..max-1, inclusive
-KATANA_EXPORT int64_t RandomUniformInt(int64_t min, int64_t max);
-// Range 0.0f..max, inclusive
-KATANA_EXPORT float RandomUniformFloat(float max);
+using RandGenerator = std::mt19937;
 
-KATANA_EXPORT std::mt19937& GetGenerator();
+/// Generate a random alphanumeric string of length \param len using
+/// \param gen if provided. If no generator is specified, use the output of
+/// GetGenerator
+KATANA_EXPORT std::string RandomAlphanumericString(
+    uint64_t len, RandGenerator* gen = nullptr);
+
+/// \returns a random number generator seeded with randomness from the platform.
+/// The generator is local to the calling thread so uses of it are thread safe.
+/// Useful for things like `std::uniform_int_distribution`
+KATANA_EXPORT RandGenerator& GetGenerator();
 
 }  // namespace katana
 

--- a/libsupport/test/random.cpp
+++ b/libsupport/test/random.cpp
@@ -7,6 +7,7 @@
 
 int
 main() {
+  // test to make sure we have enough randomness
   std::vector<std::thread> threads;
   for (int i = 0; i < 128; ++i) {
     threads.emplace_back([]() {
@@ -17,6 +18,34 @@ main() {
 
   for (std::thread& t : threads) {
     t.join();
+  }
+  threads.clear();
+
+  // test to make sure seeded generators are deterministic
+  std::vector<katana::RandGenerator> generators;
+  generators.reserve(128);
+  for (int i = 0; i < 128; ++i) {
+    generators.emplace_back(katana::RandGenerator(8675309));
+  }
+
+  std::vector<std::string> results(128);
+  for (int i = 0; i < 128; ++i) {
+    threads.emplace_back([&generators, &results, i]() {
+      results[i] = katana::RandomAlphanumericString(12, &generators[i]);
+    });
+  }
+
+  for (std::thread& t : threads) {
+    t.join();
+  }
+
+  std::string first_val = results.front();
+  for (const auto& val : results) {
+    KATANA_LOG_VASSERT(
+        val == first_val,
+        "seeded rngs should output the same values, "
+        "got \"{}\" and \"{}\"",
+        first_val, val);
   }
 
   return 0;

--- a/libtsuba/src/FaultTest.cpp
+++ b/libtsuba/src/FaultTest.cpp
@@ -45,9 +45,11 @@ tsuba::internal::FaultTestInit(
   } break;
   case tsuba::internal::FaultMode::UniformOverRun: {
     KATANA_LOG_VASSERT(
-        run_length > 0,
-        "For UniformOverRun, max run length must be larger than 0");
-    fault_run_length_ = katana::RandomUniformInt(1, run_length);
+        run_length > 2,
+        "For UniformOverRun, max run length must be larger than 2");
+
+    std::uniform_int_distribution<uint64_t> dist(2, run_length - 1);
+    fault_run_length_ = dist(katana::GetGenerator());
     fmt::print(
         "FaultTest UniformOverRun {:d} ({:d})\n", fault_run_length_,
         run_length_);
@@ -86,7 +88,9 @@ tsuba::internal::PtP(
       // Do nothing
       break;
     }
-    if (katana::RandomUniformFloat(1.0f) < threshold) {
+    std::uniform_real_distribution<float> dist(
+        0, std::nextafter(1.0F, std::numeric_limits<float>::max()));
+    if (dist(katana::GetGenerator()) < threshold) {
       fmt::print("  PtP count {:d}\n", ptp_count_);
       die_now(file, line);
     }


### PR DESCRIPTION
Call `GetGenerator(seed)` to get a randomness generator with your seed
of choice. This can then be passed back to the other utils as the last
parameter. If omitted, utils behave as before.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>