### PR TITLE
Use C++11 attribute syntax for KATANA_EXPORT

### DIFF
--- a/libgalois/include/katana/NumaMem.h
+++ b/libgalois/include/katana/NumaMem.h
@@ -47,7 +47,7 @@ KATANA_EXPORT LAptr largeMallocBlocked(size_t bytes, unsigned numThreads);
 
 // fault in specified regions for each thread (threadRanges)
 template <typename RangeArrayTy>
-LAptr largeMallocSpecified(
+KATANA_EXPORT LAptr largeMallocSpecified(
     size_t bytes, uint32_t numThreads, RangeArrayTy& threadRanges,
     size_t elementSize);
 

--- a/libgalois/include/katana/PropertyViews.h
+++ b/libgalois/include/katana/PropertyViews.h
@@ -8,7 +8,7 @@ namespace katana::internal {
 
 /// ExtractArrays returns the array for each column of a table. It returns an
 /// error if there is more than one array for any column.
-Result<std::vector<arrow::Array*>> KATANA_EXPORT ExtractArrays(
+KATANA_EXPORT Result<std::vector<arrow::Array*>> ExtractArrays(
     const arrow::Table* table, const std::vector<std::string>& properties);
 
 template <typename PropTuple>

--- a/libgalois/include/katana/analytics/betweenness_centrality/betweenness_centrality.h
+++ b/libgalois/include/katana/analytics/betweenness_centrality/betweenness_centrality.h
@@ -65,7 +65,7 @@ using BetweennessCentralitySources =
     std::variant<std::vector<uint32_t>, uint32_t>;
 
 /// Use all sources instead of a subset.
-extern KATANA_EXPORT const BetweennessCentralitySources
+KATANA_EXPORT extern const BetweennessCentralitySources
     kBetweennessCentralityAllNodes;
 
 /**

--- a/libgalois/src/NumaMem.cpp
+++ b/libgalois/src/NumaMem.cpp
@@ -221,7 +221,7 @@ katana::largeMallocBlocked(size_t bytes, unsigned numThreads) {
  * @returns The allocated memory along with a freer object
  */
 template <typename RangeArrayTy>
-LAptr
+KATANA_EXPORT LAptr
 katana::largeMallocSpecified(
     size_t bytes, uint32_t numThreads, RangeArrayTy& threadRanges,
     size_t elementSize) {
@@ -239,11 +239,9 @@ katana::largeMallocSpecified(
 }
 // Explicit template declarations since the template is defined in the .h
 // file
-template LAptr KATANA_EXPORT
-katana::largeMallocSpecified<std::vector<uint32_t>>(
+template LAptr katana::largeMallocSpecified<std::vector<uint32_t>>(
     size_t bytes, uint32_t numThreads, std::vector<uint32_t>& threadRanges,
     size_t elementSize);
-template LAptr KATANA_EXPORT
-katana::largeMallocSpecified<std::vector<uint64_t>>(
+template LAptr katana::largeMallocSpecified<std::vector<uint64_t>>(
     size_t bytes, uint32_t numThreads, std::vector<uint64_t>& threadRanges,
     size_t elementSize);

--- a/libsupport/include/katana/JSON.h
+++ b/libsupport/include/katana/JSON.h
@@ -36,7 +36,7 @@ JsonParse(U& obj, T* val) {
 }
 
 /// Dump to string, but catch errors
-katana::Result<std::string> KATANA_EXPORT JsonDump(const nlohmann::json& obj);
+KATANA_EXPORT katana::Result<std::string> JsonDump(const nlohmann::json& obj);
 
 template <typename T>
 katana::Result<std::string>

--- a/libsupport/include/katana/Uri.h
+++ b/libsupport/include/katana/Uri.h
@@ -52,11 +52,12 @@ public:
   /// XXXX is a random alpha numeric string
   Uri RandFile(std::string_view prefix) const;
 
-  KATANA_EXPORT friend Uri operator+(const Uri& lhs, char rhs);
+  friend Uri operator+(const Uri& lhs, char rhs);
 };
 
 KATANA_EXPORT bool operator==(const Uri& lhs, const Uri& rhs);
 KATANA_EXPORT bool operator!=(const Uri& lhs, const Uri& rhs);
+KATANA_EXPORT Uri operator+(const Uri& lhs, char rhs);
 
 }  // namespace katana
 

--- a/libsupport/include/katana/config.h.in
+++ b/libsupport/include/katana/config.h.in
@@ -73,11 +73,11 @@
 #endif
 #else
 // Not Windows
-#define KATANA_NO_EXPORT __attribute__((visibility("hidden")))
+#define KATANA_NO_EXPORT [[gnu::visibility("hidden")]]
 #if defined(KATANA_STATIC_LIB)
 #define KATANA_EXPORT
 #else
-#define KATANA_EXPORT __attribute__((visibility("default")))
+#define KATANA_EXPORT [[gnu::visibility("default")]]
 #endif
 #endif
 


### PR DESCRIPTION
Both gcc and mvcc on Windows support mixing __attribute__((foo)) and
[[foo]] syntax, but on Linux, at least gcc-7 cannot cannot. Both gcc and
clang do support [[gnu::visibility]] as an alternative. Switch to using
this to allow declarations with multiple attributes.

A issue when switching to standard attribute syntax is that the C++
standard is more restrictive in attribute placement. This means that
attributes must appear before return values in function declarations and
after class/struct in type definitions.

A subtle case is attributes with friend. Attributes may only appear with
friend on a function definition and not a declaration.