### PR TITLE
Impove error output

### DIFF
--- a/libsupport/src/Result.cpp
+++ b/libsupport/src/Result.cpp
@@ -55,6 +55,8 @@ public:
 
   int size() const { return header_.size; }
 
+  void reset() { header_.size = 0; }
+
 private:
   Header header_;
   std::array<char, kDataSize> data_;
@@ -73,7 +75,7 @@ static_assert(
     "libfmt buffer size is small relative to max ErrorInfo context size");
 
 void
-katana::ErrorInfo::Reclassify(const std::error_code& ec) {
+katana::ErrorInfo::SpillMessage() {
   KATANA_LOG_DEBUG_VASSERT(
       !context_.first || context_.first == &kContext,
       "ErrorInfo object does not match ErrorInfo data");
@@ -83,14 +85,10 @@ katana::ErrorInfo::Reclassify(const std::error_code& ec) {
       "ErrorInfo object does not match ErrorInfo data");
 
   if (!context_.first) {
-    // If there is no context besides the error code at least spill some
-    // context
     std::string msg = error_code_.message();
     const char* start = msg.c_str();
     Prepend(start, start + msg.size());
   }
-
-  error_code_ = ec;
 }
 
 void
@@ -108,6 +106,7 @@ katana::ErrorInfo::Prepend(const char* begin, const char* end) {
     context_.first->Prepend(kSep.begin(), kSep.end());
   } else {
     context_.first = &kContext;
+    context_.first->reset();
   }
 
   context_.first->Prepend(begin, end);

--- a/libsupport/test/result.cpp
+++ b/libsupport/test/result.cpp
@@ -34,31 +34,54 @@ ToString(const katana::ErrorInfo& ei) {
 
 void
 TestMessages() {
-  // Check printing
-  katana::Result<void> res = katana::ErrorCode::NotFound;
-
-  auto err = res.error();
-
-  std::string found = ToString(err);
-  KATANA_LOG_VASSERT(
-      found == "not found", "expected string 'not found' but found: {}", found);
+  katana::ErrorInfo err(katana::ErrorCode::NotFound, "0");
 
   err = err.WithContext("1");
-  found = ToString(err);
-  KATANA_LOG_VASSERT(found == "1", "expected string '1' but found: {}", found);
+  std::string found = ToString(err);
+  KATANA_LOG_VASSERT(
+      found == "1: 0", "expected string '1: 0' but found: {}", found);
 
   err = err.WithContext("2");
   found = ToString(err);
   KATANA_LOG_VASSERT(
-      found == "2: 1", "expected string '2: 1' but found: {}", found);
+      found == "2: 1: 0", "expected string '2: 1: 0' but found: {}", found);
 
   std::string long_string(2 * katana::ErrorInfo::kContextSize, 'x');
   long_string += "sentinel";
   err = err.WithContext(long_string);
   found = ToString(err);
   KATANA_LOG_VASSERT(
-      katana::HasSuffix(found, "sentinel: 2: 1"),
-      "expected string suffix 'sentinel: 2: 1' but found: {}", found);
+      katana::HasSuffix(found, "sentinel: 2: 1: 0"),
+      "expected string suffix 'sentinel: 2: 1: 0' but found: {}", found);
+}
+
+void
+TestResetBetweenInstances() {
+  katana::ErrorInfo err1(katana::ErrorCode::NotFound, "1");
+  err1 = err1.WithContext("one");
+  std::string found1 = ToString(err1);
+
+  katana::ErrorInfo err2(katana::ErrorCode::NotFound, "2");
+  err2 = err2.WithContext("two");
+  std::string found2 = ToString(err2);
+
+  KATANA_LOG_VASSERT(
+      found1 == "one: 1", "expected 'one: 1' but found {}", found1);
+  KATANA_LOG_VASSERT(
+      found2 == "two: 2", "expected 'two: 2' but found {}", found1);
+}
+
+void
+TestContextSpill() {
+  katana::ErrorInfo err = katana::ErrorCode::NotFound;
+  err = err.WithContext("more");
+  std::string found = ToString(err);
+
+  std::error_code ec = katana::ErrorCode::NotFound;
+  std::string expected = "more: " + ec.message();
+
+  KATANA_LOG_VASSERT(
+      found == expected, "expected {} but found {}", expected, found);
 }
 
 void
@@ -85,4 +108,6 @@ main() {
   TestConversions();
   TestMessages();
   TestFmt();
+  TestResetBetweenInstances();
+  TestContextSpill();
 }


### PR DESCRIPTION
Fix two bugs:

One, the error context is not reset upon creation of new errors, leading
to an accumulation of unrelated error messages. Instead, reset the state
of error info thread-local buffer when a new error info is created.

Two, when an error is created without a context and then a context is
added, e.g.,

  ErrorInfo ei = ErrorCode::InvalidArgument;
  ei = ei.WithContext("more");

the resulting message is simply "more". Instead prepend some
representation of the original error like "more: invalid argument".