### PR TITLE
RDG creates a valid local_to_global_id_

### DIFF
--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -283,6 +283,8 @@ KATANA_EXPORT std::shared_ptr<arrow::Array> Unchunk(
     const std::shared_ptr<arrow::ChunkedArray>& original);
 KATANA_EXPORT std::shared_ptr<arrow::ChunkedArray> Shuffle(
     const std::shared_ptr<arrow::ChunkedArray>& original);
+KATANA_EXPORT std::shared_ptr<arrow::ChunkedArray> EmptyChunkedArray(
+    const std::shared_ptr<arrow::DataType>& type, int64_t length);
 
 }  // namespace katana
 

--- a/libsupport/include/katana/ErrorCode.h
+++ b/libsupport/include/katana/ErrorCode.h
@@ -64,6 +64,7 @@ enum class ErrorCode {
   AlreadyExists = 10,
   TypeError = 11,
   AssertionFailed = 12,
+  GraphUpdateFailed = 13,
 };
 
 }  // namespace katana
@@ -102,6 +103,8 @@ public:
       return "type error";
     case ErrorCode::AssertionFailed:
       return "assertion failed";
+    case ErrorCode::GraphUpdateFailed:
+      return "graph update failed";
     default:
       return "unknown error";
     }
@@ -116,6 +119,7 @@ public:
     case ErrorCode::JsonDumpFailed:
     case ErrorCode::TypeError:
     case ErrorCode::AssertionFailed:
+    case ErrorCode::GraphUpdateFailed:
       return make_error_condition(std::errc::invalid_argument);
     case ErrorCode::AlreadyExists:
       return make_error_condition(std::errc::file_exists);

--- a/libsupport/src/ArrowInterchange.cpp
+++ b/libsupport/src/ArrowInterchange.cpp
@@ -57,3 +57,16 @@ katana::Shuffle(const std::shared_ptr<arrow::ChunkedArray>& original) {
   KATANA_LOG_ASSERT(res.ok());
   return IndexedTake(original, indices);
 }
+
+std::shared_ptr<arrow::ChunkedArray>
+katana::EmptyChunkedArray(
+    const std::shared_ptr<arrow::DataType>& type, int64_t length) {
+  auto maybe_array = arrow::MakeArrayOfNull(type, length);
+  if (!maybe_array.ok()) {
+    KATANA_LOG_ERROR(
+        "cannot create an empty arrow array: {}", maybe_array.status());
+    return nullptr;
+  }
+  std::vector<std::shared_ptr<arrow::Array>> chunks{maybe_array.ValueOrDie()};
+  return std::make_shared<arrow::ChunkedArray>(chunks);
+}

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -7,9 +7,6 @@
 #include <regex>
 #include <unordered_set>
 
-#include <arrow/array/array_binary.h>
-#include <arrow/array/builder_binary.h>
-#include <arrow/builder.h>
 #include <arrow/chunked_array.h>
 #include <arrow/filesystem/api.h>
 #include <arrow/memory_pool.h>
@@ -26,6 +23,7 @@
 #include "GlobalState.h"
 #include "RDGCore.h"
 #include "RDGHandleImpl.h"
+#include "katana/ArrowInterchange.h"
 #include "katana/Backtrace.h"
 #include "katana/JSON.h"
 #include "katana/Logging.h"
@@ -689,9 +687,15 @@ tsuba::RDG::SetTopologyFile(const katana::Uri& new_top) {
   return core_->RegisterTopologyFile(new_top.BaseName());
 }
 
-tsuba::RDG::RDG(std::unique_ptr<RDGCore>&& core) : core_(std::move(core)) {}
+tsuba::RDG::RDG(std::unique_ptr<RDGCore>&& core) : core_(std::move(core)) {
+  // Create an empty array, accessed by Distribution during loading
+  local_to_global_id_ = katana::EmptyChunkedArray(arrow::uint64(), 0);
+}
 
-tsuba::RDG::RDG() : core_(std::make_unique<RDGCore>()) {}
+tsuba::RDG::RDG() : core_(std::make_unique<RDGCore>()) {
+  // Create an empty array, accessed by Distribution during loading
+  local_to_global_id_ = katana::EmptyChunkedArray(arrow::uint64(), 0);
+}
 
 tsuba::RDG::~RDG() = default;
 tsuba::RDG::RDG(tsuba::RDG&& other) noexcept = default;


### PR DESCRIPTION
Small PR to support enterprise work.
 o RDG constructor should create a valid local_to_global_id_.  It does now.
 o Convenience function for creating an empty arrow chunked array.
 o New error code for failing a graph update.