### PR TITLE
Make libsupport shared always

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
       - include/katana/**
       - include/tsuba/**
       - lib/libkatana_galois.so*
-      - lib/libkatana_support.a
+      - lib/libkatana_support.so*
       - lib/libtsuba.so*
       - lib/libtsuba-preload.so
       - lib/cmake/Katana/**

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(KATANA_FORCE_NON_STATIC)
-  add_library(katana_support)
-else()
-  add_library(katana_support STATIC)
-endif()
+add_library(katana_support SHARED)
 add_library(Katana::support ALIAS katana_support)
 set_target_properties(katana_support PROPERTIES EXPORT_NAME support)
 add_dependencies(lib katana_support)
@@ -32,7 +28,7 @@ target_include_directories(katana_support PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-set_common_katana_library_options(katana_support)
+set_common_katana_library_options(katana_support ALWAYS_SHARED)
 
 find_package(Arrow REQUIRED)
 if(TARGET arrow::arrow)

--- a/libtsuba/src/RDGMeta.cpp
+++ b/libtsuba/src/RDGMeta.cpp
@@ -44,7 +44,7 @@ RDGMeta::MakeFromStorage(const katana::Uri& uri) {
   tsuba::RDGMeta meta(uri.DirName());
   auto meta_res = katana::JsonParse<tsuba::RDGMeta>(fv, &meta);
   if (!meta_res) {
-    return meta_res.error().WithContext("cannon parse {}", uri.string());
+    return meta_res.error().WithContext("cannot parse {}", uri.string());
   }
   return meta;
 }


### PR DESCRIPTION
```
While debugging an assertion failure in Result.cpp, I noticed that is
possible for a program to have multiple definitions of libsupport. For
example,

  my-lib.so -> libsupport.a
  application -> ... -> libsupport.a
  application -> my-lib.so

While previously this was benign though duplicative; now it can create
more serious issues because katana::Result uses a thread-local buffer to
maintain additional error information. If this buffer can be defined
multiple times, error context information can be accumulated in
different places depending on which version of libsupport a caller
referenced.

Given that, at the end of the day, the purpose of libsupport is to
provide a place for common functionality, it seems simpler to just make
libsupport always a shared library, so there will only be one version of
it for any application.
```