### PR TITLE
Various fixes to versioning script to avoid failures that affect build

### DIFF
--- a/scripts/katana_version/__init__.py
+++ b/scripts/katana_version/__init__.py
@@ -1,14 +1,14 @@
 import logging
+from argparse import Namespace
 from os import environ
 from pathlib import Path
 from typing import Optional, Tuple, Union
-from argparse import Namespace
 
 from packaging.version import InvalidVersion, Version
 
 from . import git
 from .commands import CommandError
-from .git import GitURL
+from .git import GitURL, Repo
 
 logger = logging.getLogger(__name__)
 
@@ -33,29 +33,27 @@ SUBMODULE_PATH = Path("external") / "katana"
 
 
 class Configuration:
-    enterprise_origin_url: Optional[GitURL]
-    enterprise_upstream_url: Optional[GitURL]
+    version_from_environment_variable: Optional[Version]
+    github_access: Tuple[str, ...]
+    enterprise: Optional[Repo]
+    open: Optional[Repo]
     dry_run: bool
-    katana_enterprise_repo_path: Optional[Path]
-    katana_repo_path: Path
-    origin_remote: str
-    origin_url: GitURL
-    upstream_remote: str
-    upstream_url: GitURL
 
     def __init__(self, args=Namespace()):
         self.github_access = ()
         self.dry_run = getattr(args, "dry_run", True)
 
-        self.katana_repo_path, self.katana_enterprise_repo_path = Configuration._find_katana_repo_paths(args)
+        katana_repo_path, katana_enterprise_repo_path = Configuration._find_katana_repo_paths(args)
 
-        if not self.katana_repo_path:
+        if not katana_repo_path:
             raise ConfigurationError("The katana git repository must be available. Specify with --katana.")
 
         if getattr(args, "open", False):
-            self.katana_enterprise_repo_path = None
+            katana_enterprise_repo_path = None
+
         if getattr(args, "username", None) and getattr(args, "password", None):
             self.github_access = (args.username, args.password)
+
         if getattr(args, "access_token", None):
             self.github_access = (args.access_token,)
 
@@ -68,72 +66,81 @@ class Configuration:
                 f"Failed to parse version provided in environment variable KATANA_VERSION: {environ.get('KATANA_VERSION')}"
             )
 
-        self.upstream_remote = "upstream"
-        self.origin_remote = "origin"
-        self.upstream_url = None
-        self.origin_url = None
-        self.enterprise_upstream_url = None
-        self.enterprise_origin_url = None
+        self.open = None
+        self.enterprise = None
         try:
-            remotes = git.get_remotes(self.katana_repo_path)
-            if "KatanaGraph" in remotes or "katanagraph" in remotes:
-                logger.warning(
-                    "You have a remote that references the KatanaGraph organization. If that remote is your "
-                    "upstream, then rename it to 'upstream'."
-                )
-            if "upstream" in remotes:
-                logger.info(
-                    "Assuming a triangular workflow with pushes going to a personal fork and pulls coming from upstream."
-                )
-                self.upstream_remote = "upstream"
-                if "origin" not in remotes:
-                    raise ConfigurationError(
-                        "Missing origin remote. Why?! This script does not support your workflow. "
-                        "I'm sorry and confused."
-                    )
-                self.origin_remote = "origin"
-            elif "origin" in remotes:
-                logger.info("Assuming an in-repo workflow with pushes going to personal branches in the main repo.")
-                self.upstream_remote = "origin"
-                self.origin_remote = "origin"
-            self.upstream_url = git.get_remote_url(self.upstream_remote, self.katana_repo_path)
-            self.origin_url = git.get_remote_url(self.origin_remote, self.katana_repo_path)
+            self.open = self._find_katana_remotes(katana_repo_path)
 
-            if self.has_enterprise:
-                enterprise_remotes = git.get_remotes(self.katana_enterprise_repo_path)
-                if self.origin_remote not in enterprise_remotes or self.upstream_remote not in enterprise_remotes:
-                    raise ConfigurationError("Missing remotes in enterprise, they should match open.")
-                url = git.get_remote_url(self.upstream_remote, self.katana_enterprise_repo_path)
-                if url.username != self.upstream_url.username:
-                    raise ConfigurationError("Upstream remotes are not in the same user")
-
-                self.enterprise_upstream_url = git.get_remote_url(
-                    self.upstream_remote, self.katana_enterprise_repo_path
-                )
-                self.enterprise_origin_url = git.get_remote_url(self.origin_remote, self.katana_enterprise_repo_path)
-            else:
-                self.enterprise_upstream_url = None
-                self.enterprise_origin_url = None
+            if katana_enterprise_repo_path:
+                self.enterprise = self._find_katana_remotes(katana_enterprise_repo_path)
         except CommandError:
             if not self.version_from_environment_variable:
                 logger.warning(
-                    f"Failed to find git repository at {self.katana_repo_path}. "
+                    f"Failed to find git repository at {katana_repo_path}. "
                     f"Version information will be very limited."
+                )
+        except ConfigurationError as e:
+            if not self.version_from_environment_variable:
+                logger.warning(
+                    f"Failed to determine the repo structure. Ignoring git information. "
+                    f"Version information will be very limited.\n{e}",
                 )
 
     @staticmethod
+    def _find_katana_remotes(dir):
+        name = Path(dir).name
+        remotes = git.get_remotes(dir)
+        if "origin" not in remotes:
+            raise ConfigurationError(
+                f"{name}: Missing origin remote. Why?! This script does not support your workflow. "
+                "I'm sorry and confused."
+            )
+        if "KatanaGraph" in remotes or "katanagraph" in remotes:
+            logger.warning(
+                f"{name}: You have a remote that references the KatanaGraph organization. If that remote is your "
+                "upstream, then rename it to 'upstream'."
+            )
+        if "upstream" in remotes:
+            logger.info(
+                f"{name}: Assuming a triangular workflow with pushes going to a personal fork and pulls coming "
+                "from upstream."
+            )
+            upstream_remote = "upstream"
+            origin_remote = "origin"
+        else:
+            logger.info(
+                f"{name}: Assuming an in-repo workflow with pushes going to personal branches in " "the main repo."
+            )
+            upstream_remote = "origin"
+            origin_remote = "origin"
+        upstream_url = git.get_remote_url(upstream_remote, dir)
+        origin_url = git.get_remote_url(origin_remote, dir)
+        return Repo(dir, origin_remote, origin_url, upstream_remote, upstream_url)
+
+    @staticmethod
     def _find_katana_repo_paths(args) -> Tuple[Optional[Path], Optional[Path]]:
+        # Get command line paths if available
+        katana_repo_path = _maybe_path(getattr(args, "katana", None))
+        katana_enterprise_repo_path = _maybe_path(getattr(args, "katana_enterprise", None))
+
+        # Next try: Compute open path from enterprise
+        if not katana_repo_path and katana_enterprise_repo_path:
+            katana_repo_path = katana_enterprise_repo_path / SUBMODULE_PATH
+
+        # Next try: Compute open path based on current working directory
         cwd_katana_repo_path = Configuration._find_cwd_repo_path()
+        if not katana_repo_path and cwd_katana_repo_path:
+            katana_repo_path = cwd_katana_repo_path
 
-        katana_repo_path = (
-            _maybe_path(getattr(args, "katana", None))
-            or cwd_katana_repo_path
-            or Path(__file__).resolve().parent.parent.parent
-        )
-        katana_enterprise_repo_path = (
-            _maybe_path(getattr(args, "katana_enterprise", None)) or katana_repo_path.parent.parent
-        )
+        # Next try: Compute open path based on the location of this script
+        if not katana_repo_path:
+            katana_repo_path = Path(__file__).resolve().parent.parent.parent
 
+        # Compute enterprise path if needed based on open path
+        if not katana_enterprise_repo_path:
+            katana_enterprise_repo_path = katana_repo_path.parent.parent
+
+        # Check the enterprise path and discard it if it's not valid
         if not (katana_enterprise_repo_path / SUBMODULE_PATH) == katana_repo_path:
             katana_enterprise_repo_path = None
 
@@ -150,14 +157,14 @@ class Configuration:
             elif (cwd_repo_path / CONFIG_VERSION_PATH).is_file():
                 # We are in the open repo
                 katana_repo_path = cwd_repo_path
-            if (cwd_repo_path / CONFIG_VERSION_PATH).is_file():
+            if katana_repo_path and (katana_repo_path / CONFIG_VERSION_PATH).is_file():
                 return katana_repo_path
         return None
 
     @property
     def has_enterprise(self):
-        return self.katana_enterprise_repo_path is not None
+        return self.enterprise is not None
 
     @property
     def has_git(self):
-        return self.origin_url is not None
+        return self.open is not None

--- a/scripts/katana_version/commands.py
+++ b/scripts/katana_version/commands.py
@@ -7,8 +7,6 @@ import subprocess
 
 __all__ = ["capture_command", "predicate_command", "action_command", "CommandError"]
 
-from pprint import pprint
-
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/katana_version/version.py
+++ b/scripts/katana_version/version.py
@@ -1,13 +1,12 @@
 import logging
 import re
-from os import environ
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from packaging import version
 from packaging.version import Version
 
-from . import CONFIG_VERSION_PATH, Configuration, git, SUBMODULE_PATH
+from . import CONFIG_VERSION_PATH, Configuration, git, Repo, SUBMODULE_PATH
 from .commands import capture_command, CommandError
 
 __all__ = ["get_version", "format_version_pep440", "format_version_debian"]
@@ -30,8 +29,6 @@ def get_version(
     :return: The version of the Katana package.
     """
     config = config or Configuration()
-    katana_repo_path = config.katana_repo_path
-    katana_enterprise_repo_path = config.katana_enterprise_repo_path
 
     # Find commits in both repos.
     if commit is None:
@@ -41,19 +38,18 @@ def get_version(
     else:
         use_working_copy = False
         here = git.get_working_tree(Path.cwd())
-        if here == katana_repo_path:
-            k_commit = git.get_hash(commit, katana_repo_path, pretend_clean=True)
+        if here == config.open.dir:
+            k_commit = git.get_hash(commit, config.open, pretend_clean=True)
             if config.has_enterprise:
                 logger.warning(
                     f"Computing historic versions based on an {SUBMODULE_PATH} commit is limited. Producing "
                     "open-source build version."
                 )
-                katana_enterprise_repo_path = None
-                config.katana_enterprise_repo_path = None  # Make has_enterprise = False
+                config.enterprise = None
             ke_commit = None
-        elif here == katana_enterprise_repo_path:
+        elif here == config.enterprise.dir:
             ke_commit = commit
-            k_commit = git.submodule_commit_at(SUBMODULE_PATH, ke_commit, katana_enterprise_repo_path)
+            k_commit = git.submodule_commit_at(SUBMODULE_PATH, ke_commit, config.enterprise)
         else:
             raise ValueError(
                 "To specify a commit you must be in either katana or katana-enterprise to tell me which repo you want "
@@ -64,14 +60,14 @@ def get_version(
     ke_commit = ke_commit or "HEAD"
 
     if config.has_git:
-        k_commit = git.simplify_merge_commit(k_commit, katana_repo_path)
+        k_commit = git.simplify_merge_commit(k_commit, config.open)
         if config.has_enterprise:
-            ke_commit = git.simplify_merge_commit(ke_commit, katana_enterprise_repo_path)
+            ke_commit = git.simplify_merge_commit(ke_commit, config.enterprise)
 
-    k_explicit_version, variant = get_explicit_version(config, k_commit, use_working_copy, katana_repo_path, variant)
+    k_explicit_version, variant = get_explicit_version(k_commit, use_working_copy, config.open, variant)
     ke_tag_version = None
-    if config.has_enterprise and not git.is_dirty(katana_enterprise_repo_path):
-        ke_tag_version = get_tag_version(config, ke_commit or "HEAD", katana_enterprise_repo_path)
+    if config.has_enterprise and not git.is_dirty(config.enterprise):
+        ke_tag_version = get_tag_version(ke_commit or "HEAD", config.enterprise)
 
     if k_explicit_version.is_devrelease or (not ke_tag_version and config.has_enterprise):
         explicit_version = add_dev_to_version(k_explicit_version)
@@ -82,19 +78,21 @@ def get_version(
         pretend_clean = True
 
     if pretend_master:
-        core_branch = f"{config.upstream_remote}/master"
-        enterprise_core_branch = f"{config.upstream_remote}/master"
+        core_branch = f"{config.open.upstream_remote}/master"
+        enterprise_core_branch = None
+        if config.has_enterprise:
+            enterprise_core_branch = f"{config.enterprise.upstream_remote}/master"
         is_merged = True
     else:
         is_enterprise_merged = True
         enterprise_core_branch = None
         if config.has_enterprise:
-            enterprise_core_branch = git_find_closest_core_branch(config, ke_commit, katana_enterprise_repo_path)
+            enterprise_core_branch = git_find_closest_core_branch(ke_commit, config.enterprise)
             is_enterprise_merged = enterprise_core_branch and git.is_ancestor_of(
-                ke_commit, enterprise_core_branch, dir=katana_enterprise_repo_path
+                ke_commit, enterprise_core_branch, dir=config.enterprise
             )
-        core_branch = git_find_closest_core_branch(config, k_commit, katana_repo_path) or enterprise_core_branch
-        is_merged = core_branch and git.is_ancestor_of(k_commit, core_branch, dir=katana_repo_path)
+        core_branch = git_find_closest_core_branch(k_commit, config.open) or enterprise_core_branch
+        is_merged = core_branch and git.is_ancestor_of(k_commit, core_branch, dir=config.open)
         is_merged = is_enterprise_merged and is_merged
 
     k_count = None
@@ -102,34 +100,23 @@ def get_version(
     ke_count = None
     ke_hash = None
     if config.has_git:
-        k_last_version_commit = git.find_change(katana_repo_path / CONFIG_VERSION_PATH, k_commit, katana_repo_path)
-        k_count = compute_commit_count(
-            config, k_commit, k_last_version_commit, katana_repo_path, pretend_master, core_branch
-        )
-        k_hash = git.get_hash(k_commit, katana_repo_path, pretend_clean=pretend_clean, abbrev=6)
+        k_last_version_commit = git.find_change(config.open.dir / CONFIG_VERSION_PATH, k_commit, config.open)
+        k_count = compute_commit_count(k_commit, k_last_version_commit, config.open, pretend_master, core_branch)
+        k_hash = git.get_hash(k_commit, config.open, pretend_clean=pretend_clean, abbrev=6)
 
         if config.has_enterprise:
             ke_last_version_commit = git_find_super_commit(
-                k_last_version_commit, ke_commit, katana_enterprise_repo_path, katana_repo_path
+                k_last_version_commit, ke_commit, config.enterprise, config.open.dir
             )
             ke_count = (
                 compute_commit_count(
-                    config,
-                    ke_commit,
-                    ke_last_version_commit,
-                    katana_enterprise_repo_path,
-                    pretend_master,
-                    enterprise_core_branch,
+                    ke_commit, ke_last_version_commit, config.enterprise, pretend_master, enterprise_core_branch,
                 )
                 if ke_last_version_commit
                 else "xxx"
             )
             ke_hash = git.get_hash(
-                ke_commit,
-                katana_enterprise_repo_path,
-                pretend_clean=pretend_clean,
-                exclude_dirty=(SUBMODULE_PATH,),
-                abbrev=6,
+                ke_commit, config.enterprise, pretend_clean=pretend_clean, exclude_dirty=(SUBMODULE_PATH,), abbrev=6,
             )
 
     computed_version = katana_version(
@@ -156,34 +143,32 @@ def get_version(
         return computed_version
 
 
-def git_find_closest_core_branch(config, commit, repo_path):
-    if not config.has_git:
+def git_find_closest_core_branch(commit, repo: Repo):
+    if not repo:
         return None
 
     branch_patterns = [
-        f"{config.upstream_remote}/master",
-        f"{config.upstream_remote}/release/v*",
-        f"{config.upstream_remote}/variant/*",
+        f"{repo.upstream_remote}/master",
+        f"{repo.upstream_remote}/release/v*",
+        f"{repo.upstream_remote}/variant/*",
     ]
     branches = [
-        b for pat in branch_patterns for b in git.find_branches(pat, repo_path, prefix="remotes", sort="-creatordate")
+        b for pat in branch_patterns for b in git.find_branches(pat, repo, prefix="remotes", sort="-creatordate")
     ]
 
     if not branches:
         return None
 
     def branch_ahead_count(branch):
-        return git.get_commit_count(git.merge_base(commit, branch, repo_path), commit, repo_path)
+        return git.get_commit_count(git.merge_base(commit, branch, repo), commit, repo)
 
     nearest_branch = min(branches, key=branch_ahead_count)
     return nearest_branch
 
 
-def get_explicit_version(config, k_commit: str, use_working_copy: bool, katana_repo_path, variant=None, no_dev=False):
-    tag_version = get_tag_version(config, k_commit, katana_repo_path)
-    explicit_version = tag_version or get_config_version(
-        None if use_working_copy else k_commit, katana_repo_path, no_dev=no_dev
-    )
+def get_explicit_version(k_commit: str, use_working_copy: bool, repo, variant=None, no_dev=False):
+    tag_version = get_tag_version(k_commit, repo)
+    explicit_version = tag_version or get_config_version(None if use_working_copy else k_commit, repo, no_dev=no_dev)
     if explicit_version.local and variant and variant != explicit_version.local:
         logger.warning(
             f"You are overriding the repository variant {explicit_version.local} with build-time variant {variant}."
@@ -192,13 +177,11 @@ def get_explicit_version(config, k_commit: str, use_working_copy: bool, katana_r
     return explicit_version, variant
 
 
-def get_config_version(k_commit, katana_repo_path, no_dev=False) -> version.Version:
+def get_config_version(k_commit, repo: Repo, no_dev=False) -> version.Version:
     if k_commit:
-        version_str = capture_command(
-            "git", *git.dir_arg(katana_repo_path), "show", "-p", f"{k_commit}:{CONFIG_VERSION_PATH}"
-        )
+        version_str = capture_command("git", *git.dir_arg(repo), "show", "-p", f"{k_commit}:{CONFIG_VERSION_PATH}")
     else:
-        with open(katana_repo_path / CONFIG_VERSION_PATH, "rt") as version_file:
+        with open(repo.dir / CONFIG_VERSION_PATH, "rt") as version_file:
             version_str = version_file.read()
     ver = version.Version(version_str.strip())
 
@@ -208,11 +191,11 @@ def get_config_version(k_commit, katana_repo_path, no_dev=False) -> version.Vers
     return add_dev_to_version(ver)
 
 
-def get_tag_version(config, commit, repo_path):
-    if not config.has_git or not commit:
+def get_tag_version(commit, repo: Repo):
+    if not repo or not commit:
         return None
     tag_version = None
-    version_tags = [m for m in (VERSION_TAG_RE.match(t) for t in git.get_tags_of(commit, repo_path)) if m]
+    version_tags = [m for m in (VERSION_TAG_RE.match(t) for t in git.get_tags_of(commit, repo)) if m]
     if len(version_tags) > 1:
         logger.warning(f"There is more than one version tag at the given commit. Picking one arbitrarily.")
     if version_tags:
@@ -220,7 +203,7 @@ def get_tag_version(config, commit, repo_path):
     return tag_version
 
 
-def compute_commit_count(config, commit, last_version_commit, repo_path, pretend_master, core_branch):
+def compute_commit_count(commit, last_version_commit, repo_path, pretend_master, core_branch):
     if not pretend_master:
         if not core_branch:
             logger.warning(
@@ -235,7 +218,9 @@ def compute_commit_count(config, commit, last_version_commit, repo_path, pretend
     return git.get_commit_count(last_version_commit, last_core_commit, repo_path)
 
 
-def git_find_super_commit(submodule_commit_to_find, super_commit, super_repo_path, sub_repo_path):
+def git_find_super_commit(
+    submodule_commit_to_find, super_commit, super_repo_path: Repo, sub_repo_path: Union[Path, str]
+):
     """
     Find the super module commit which introduced the provided submodule commit.
 
@@ -256,7 +241,7 @@ def git_find_super_commit(submodule_commit_to_find, super_commit, super_repo_pat
                     f"versioning system was introduced fully."
                 )
                 return commit
-            logger.info(f"Encountered bad commit in {super_repo_path.name}. Skipping. Error: {e}")
+            logger.info(f"Encountered bad commit in {super_repo_path.dir.name}. Skipping. Error: {e}")
             continue
         # submodule_commit_to_find is not an ancestor of commit
         return submodule_changes[i - 1]

--- a/scripts/katana_version/version.py
+++ b/scripts/katana_version/version.py
@@ -129,7 +129,7 @@ def get_version(
         dev=explicit_version.is_devrelease,
         pre=explicit_version.pre,
         post=explicit_version.post,
-        is_merged=is_merged,
+        is_merged=is_merged and ke_hash != "DIRTY" and k_hash != "DIRTY",
     )
     if config.version_from_environment_variable:
         env_version = config.version_from_environment_variable


### PR DESCRIPTION
The goal is to fail "safe" in all cases. So *some* version is always generated even if it is missing information. The script now also handles a wider range of clones and workflows.