### PR TITLE
tsuba: provide interfaces to read and write parquet

### DIFF
--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -24,6 +24,8 @@ set(sources
   src/LocalStorage.cpp
   src/MemoryNameServerClient.cpp
   src/NameServerClient.cpp
+  src/ParquetReader.cpp
+  src/ParquetWriter.cpp
   src/RDG.cpp
   src/RDGCore.cpp
   src/RDGHandleImpl.cpp

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -1,0 +1,40 @@
+#ifndef KATANA_LIBTSUBA_TSUBA_PARQUETREADER_H_
+#define KATANA_LIBTSUBA_TSUBA_PARQUETREADER_H_
+
+#include <optional>
+
+#include <arrow/api.h>
+
+#include "katana/Result.h"
+#include "katana/Uri.h"
+
+namespace tsuba {
+
+class ParquetReader {
+public:
+  struct Slice {
+    int64_t offset;
+    int64_t length;
+  };
+
+  /// \returns a Reader that will read a table from storage location optionally
+  /// reading only part of the table defined by \param slice
+  static katana::Result<std::unique_ptr<ParquetReader>> Make(
+      std::optional<Slice> slice = std::nullopt);
+
+  /// read table from \param uri
+  katana::Result<std::shared_ptr<arrow::Table>> ReadFromUri(
+      const katana::Uri& uri);
+
+private:
+  ParquetReader(std::optional<Slice> slice) : slice_(slice) {}
+
+  katana::Result<std::shared_ptr<arrow::Table>> ReadFromUriSliced(
+      const katana::Uri& uri);
+
+  std::optional<Slice> slice_;
+};
+
+}  // namespace tsuba
+
+#endif

--- a/libtsuba/include/tsuba/ParquetWriter.h
+++ b/libtsuba/include/tsuba/ParquetWriter.h
@@ -1,0 +1,35 @@
+#ifndef KATANA_LIBTSUBA_TSUBA_PARQUETWRITER_H_
+#define KATANA_LIBTSUBA_TSUBA_PARQUETWRITER_H_
+
+#include <arrow/api.h>
+
+#include "katana/Result.h"
+#include "katana/Uri.h"
+#include "tsuba/WriteGroup.h"
+
+namespace tsuba {
+
+class ParquetWriter {
+public:
+  /// \returns a Writer that will write a table consisting of a single column
+  /// \param array named \param name to a storage location
+  static katana::Result<std::unique_ptr<ParquetWriter>> Make(
+      const std::shared_ptr<arrow::ChunkedArray>& array,
+      const std::string& name);
+
+  /// write table out to a storage location \param uri If \param group is null,
+  /// the write is synchronous, if not an asynchronous write is started to be
+  /// managed by group
+  katana::Result<void> WriteToUri(
+      const katana::Uri& uri, WriteGroup* group = nullptr);
+
+private:
+  ParquetWriter(std::shared_ptr<arrow::Table> table)
+      : table_(std::move(table)) {}
+
+  std::shared_ptr<arrow::Table> table_;
+};
+
+}  // namespace tsuba
+
+#endif

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -5,117 +5,26 @@
 #include "katana/Result.h"
 #include "tsuba/Errors.h"
 #include "tsuba/FileView.h"
+#include "tsuba/ParquetReader.h"
 
 namespace {
 
-katana::Result<std::shared_ptr<arrow::ChunkedArray>>
-ChunkedStringToLargeString(const std::shared_ptr<arrow::ChunkedArray>& arr) {
-  arrow::LargeStringBuilder builder;
-
-  for (const auto& chunk : arr->chunks()) {
-    std::shared_ptr<arrow::StringArray> string_array =
-        std::static_pointer_cast<arrow::StringArray>(chunk);
-    for (uint64_t i = 0, size = string_array->length(); i < size; ++i) {
-      if (!string_array->IsValid(i)) {
-        auto status = builder.AppendNull();
-        if (!status.ok()) {
-          return KATANA_ERROR(
-              tsuba::ErrorCode::ArrowError, "appending null to array: {}",
-              status);
-        }
-        continue;
-      }
-      auto status = builder.Append(string_array->GetView(i));
-      if (!status.ok()) {
-        return KATANA_ERROR(
-            tsuba::ErrorCode::ArrowError, "appending string to array: {}",
-            status);
-      }
-    }
-  }
-
-  std::shared_ptr<arrow::Array> new_arr;
-  auto status = builder.Finish(&new_arr);
-  if (!status.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "finishing array: {}", status);
-  }
-
-  auto maybe_res = arrow::ChunkedArray::Make({new_arr}, arrow::large_utf8());
-  if (!maybe_res.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "building chunked array: {}",
-        maybe_res.status());
-  }
-  return maybe_res.ValueOrDie();
-}
-
-// HandleBadParquetTypes here and HandleBadParquetTypes in RDG.cpp
-// workaround a libarrow2.0 limitation in reading and writing LargeStrings to
-// parquet files.
-katana::Result<std::shared_ptr<arrow::ChunkedArray>>
-HandleBadParquetTypes(std::shared_ptr<arrow::ChunkedArray> old_array) {
-  if (old_array->num_chunks() <= 1) {
-    return old_array;
-  }
-  switch (old_array->type()->id()) {
-  case arrow::Type::type::STRING: {
-    return ChunkedStringToLargeString(old_array);
-  }
-  default:
-    return old_array;
-  }
-}
-
 katana::Result<std::shared_ptr<arrow::Table>>
 DoLoadProperties(
-    const std::string& expected_name, const katana::Uri& file_path) {
-  auto fv = std::make_shared<tsuba::FileView>(tsuba::FileView());
-  if (auto res = fv->Bind(file_path.string(), false); !res) {
-    return res.error().WithContext("preparing read buffer");
+    const std::string& expected_name, const katana::Uri& file_path,
+    std::optional<tsuba::ParquetReader::Slice> slice = std::nullopt) {
+  auto reader_res = tsuba::ParquetReader::Make(slice);
+  if (!reader_res) {
+    return reader_res.error().WithContext("loading property");
+  }
+  std::unique_ptr<tsuba::ParquetReader> reader = std::move(reader_res.value());
+
+  auto out_res = reader->ReadFromUri(file_path);
+  if (!out_res) {
+    return out_res.error().WithContext("loading property");
   }
 
-  std::unique_ptr<parquet::arrow::FileReader> reader;
-
-  auto open_file_result =
-      parquet::arrow::OpenFile(fv, arrow::default_memory_pool(), &reader);
-  if (!open_file_result.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "arrow error: {}", open_file_result);
-  }
-
-  std::shared_ptr<arrow::Table> out;
-  auto read_result = reader->ReadTable(&out);
-  if (!read_result.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "arrow error: {}", read_result);
-  }
-
-  auto fixed_column_res = HandleBadParquetTypes(out->column(0));
-  if (!fixed_column_res) {
-    return fixed_column_res.error();
-  }
-  std::shared_ptr<arrow::ChunkedArray> fixed_column(
-      std::move(fixed_column_res.value()));
-
-  out = arrow::Table::Make(
-      arrow::schema(
-          {arrow::field(out->field(0)->name(), fixed_column->type())}),
-      {fixed_column});
-
-  // Combine multiple chunks into one. Binary and string columns (c.f. large
-  // binary and large string columns) are a special case. They may not be
-  // combined into a single chunk due to the fact the offset type for these
-  // columns is int32_t and thus the maximum size of an arrow::Array for these
-  // types is 2^31.
-  auto combine_result = out->CombineChunks(arrow::default_memory_pool());
-  if (!combine_result.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "arrow error: {}",
-        combine_result.status());
-  }
-
-  out = std::move(combine_result.ValueOrDie());
+  std::shared_ptr<arrow::Table> out = std::move(out_res.value());
 
   std::shared_ptr<arrow::Schema> schema = out->schema();
   if (schema->num_fields() != 1) {
@@ -129,87 +38,7 @@ DoLoadProperties(
         tsuba::ErrorCode::InvalidArgument, "expected {} found {} instead",
         expected_name, schema->field(0)->name());
   }
-
   return out;
-}
-
-katana::Result<std::shared_ptr<arrow::Table>>
-DoLoadPropertySlice(
-    const std::string& expected_name, const katana::Uri& file_path,
-    int64_t offset, int64_t length) {
-  if (offset < 0 || length < 0) {
-    return tsuba::ErrorCode::InvalidArgument;
-  }
-  auto fv = std::make_shared<tsuba::FileView>(tsuba::FileView());
-  if (auto res = fv->Bind(file_path.string(), 0, 0, false); !res) {
-    return res.error();
-  }
-
-  std::unique_ptr<parquet::arrow::FileReader> reader;
-
-  auto open_file_result =
-      parquet::arrow::OpenFile(fv, arrow::default_memory_pool(), &reader);
-  if (!open_file_result.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "arrow error: {}", open_file_result);
-  }
-
-  std::vector<int> row_groups;
-  int rg_count = reader->num_row_groups();
-  int64_t row_offset = 0;
-  int64_t cumulative_rows = 0;
-  int64_t file_offset = 0;
-  int64_t cumulative_bytes = 0;
-  for (int i = 0; cumulative_rows < offset + length && i < rg_count; ++i) {
-    auto rg_md = reader->parquet_reader()->metadata()->RowGroup(i);
-    int64_t new_rows = rg_md->num_rows();
-    int64_t new_bytes = rg_md->total_byte_size();
-    if (offset < cumulative_rows + new_rows) {
-      if (row_groups.empty()) {
-        row_offset = offset - cumulative_rows;
-        file_offset = cumulative_bytes;
-      }
-      row_groups.push_back(i);
-    }
-    cumulative_rows += new_rows;
-    cumulative_bytes += new_bytes;
-  }
-
-  if (auto res = fv->Fill(file_offset, cumulative_bytes, false); !res) {
-    return res.error();
-  }
-
-  std::shared_ptr<arrow::Table> out;
-  auto read_result = reader->ReadRowGroups(row_groups, &out);
-  if (!read_result.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "arrow error: {}", read_result);
-  }
-
-  auto combine_result = out->CombineChunks(arrow::default_memory_pool());
-  if (!combine_result.ok()) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::ArrowError, "arrow error: {}",
-        combine_result.status());
-  }
-
-  out = std::move(combine_result.ValueOrDie());
-
-  std::shared_ptr<arrow::Schema> schema = out->schema();
-  if (schema->num_fields() != 1) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::InvalidArgument, "expected 1 field found {} instead",
-        schema->num_fields());
-  }
-
-  if (schema->field(0)->name() != expected_name) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::InvalidArgument,
-        "expected column {} found {} instead", expected_name,
-        schema->field(0)->name());
-  }
-
-  return out->Slice(row_offset, length);
 }
 
 }  // namespace
@@ -230,7 +59,9 @@ tsuba::LoadPropertySlice(
     const std::string& expected_name, const katana::Uri& file_path,
     int64_t offset, int64_t length) {
   try {
-    return DoLoadPropertySlice(expected_name, file_path, offset, length);
+    return DoLoadProperties(
+        expected_name, file_path,
+        ParquetReader::Slice{.offset = offset, .length = length});
   } catch (const std::exception& exp) {
     return KATANA_ERROR(
         ErrorCode::ArrowError, "arrow exception: {}", exp.what());

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -1,0 +1,212 @@
+#include "tsuba/ParquetReader.h"
+
+#include "tsuba/Errors.h"
+#include "tsuba/FileView.h"
+
+template <typename T>
+using Result = katana::Result<T>;
+
+namespace {
+
+Result<std::shared_ptr<arrow::ChunkedArray>>
+ChunkedStringToLargeString(const std::shared_ptr<arrow::ChunkedArray>& arr) {
+  arrow::LargeStringBuilder builder;
+
+  for (const auto& chunk : arr->chunks()) {
+    std::shared_ptr<arrow::StringArray> string_array =
+        std::static_pointer_cast<arrow::StringArray>(chunk);
+    for (uint64_t i = 0, size = string_array->length(); i < size; ++i) {
+      if (!string_array->IsValid(i)) {
+        auto status = builder.AppendNull();
+        if (!status.ok()) {
+          return KATANA_ERROR(
+              tsuba::ErrorCode::ArrowError, "appending null to array: {}",
+              status);
+        }
+        continue;
+      }
+      auto status = builder.Append(string_array->GetView(i));
+      if (!status.ok()) {
+        return KATANA_ERROR(
+            tsuba::ErrorCode::ArrowError, "appending string to array: {}",
+            status);
+      }
+    }
+  }
+
+  std::shared_ptr<arrow::Array> new_arr;
+  auto status = builder.Finish(&new_arr);
+  if (!status.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "finishing array: {}", status);
+  }
+
+  auto maybe_res = arrow::ChunkedArray::Make({new_arr}, arrow::large_utf8());
+  if (!maybe_res.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "building chunked array: {}",
+        maybe_res.status());
+  }
+  return maybe_res.ValueOrDie();
+}
+
+// HandleBadParquetTypes here and HandleBadParquetTypes in ParquetWriter.cpp
+// workaround a libarrow2.0 limitation in reading and writing LargeStrings to
+// parquet files.
+katana::Result<std::shared_ptr<arrow::ChunkedArray>>
+HandleBadParquetTypes(std::shared_ptr<arrow::ChunkedArray> old_array) {
+  if (old_array->num_chunks() <= 1) {
+    return old_array;
+  }
+  switch (old_array->type()->id()) {
+  case arrow::Type::type::STRING: {
+    return ChunkedStringToLargeString(old_array);
+  }
+  default:
+    return old_array;
+  }
+}
+
+}  // namespace
+
+Result<std::unique_ptr<tsuba::ParquetReader>>
+tsuba::ParquetReader::Make(std::optional<Slice> slice) {
+  return std::unique_ptr<ParquetReader>(new ParquetReader(slice));
+}
+
+// Internal use only, invoke iff slice_ has a value
+Result<std::shared_ptr<arrow::Table>>
+tsuba::ParquetReader::ReadFromUriSliced(const katana::Uri& uri) {
+  auto slice = slice_.value();
+  if (slice.offset < 0 || slice.length < 0) {
+    return tsuba::ErrorCode::InvalidArgument;
+  }
+
+  auto fv = std::make_shared<tsuba::FileView>(tsuba::FileView());
+  if (auto res = fv->Bind(uri.string(), 0, 0, false); !res) {
+    return res.error();
+  }
+
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+
+  auto open_file_result =
+      parquet::arrow::OpenFile(fv, arrow::default_memory_pool(), &reader);
+  if (!open_file_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}", open_file_result);
+  }
+
+  std::vector<int> row_groups;
+  int rg_count = reader->num_row_groups();
+  int64_t row_offset = 0;
+  int64_t cumulative_rows = 0;
+  int64_t file_offset = 0;
+  int64_t cumulative_bytes = 0;
+  int64_t last_row = slice.offset + slice.length;
+  for (int i = 0; cumulative_rows < last_row && i < rg_count; ++i) {
+    auto rg_md = reader->parquet_reader()->metadata()->RowGroup(i);
+    int64_t new_rows = rg_md->num_rows();
+    int64_t new_bytes = rg_md->total_byte_size();
+    if (slice.offset < cumulative_rows + new_rows) {
+      if (row_groups.empty()) {
+        row_offset = slice.offset - cumulative_rows;
+        file_offset = cumulative_bytes;
+      }
+      row_groups.push_back(i);
+    }
+    cumulative_rows += new_rows;
+    cumulative_bytes += new_bytes;
+  }
+
+  if (auto res = fv->Fill(file_offset, cumulative_bytes, false); !res) {
+    return res.error();
+  }
+
+  std::shared_ptr<arrow::Table> out;
+  auto read_result = reader->ReadRowGroups(row_groups, &out);
+  if (!read_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}", read_result);
+  }
+
+  out = out->Slice(row_offset, slice.length);
+
+  auto combine_result = out->CombineChunks(arrow::default_memory_pool());
+  if (!combine_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}",
+        combine_result.status());
+  }
+  return combine_result.ValueOrDie();
+}
+
+Result<std::shared_ptr<arrow::Table>>
+tsuba::ParquetReader::ReadFromUri(const katana::Uri& uri) {
+  if (slice_) {
+    // logic for a sliced read is different enough not to bother trying
+    // to DRY these out
+    return ReadFromUriSliced(uri);
+  }
+
+  auto fv = std::make_shared<tsuba::FileView>();
+  if (auto res = fv->Bind(uri.string(), false); !res) {
+    return res.error().WithContext("preparing read buffer");
+  }
+
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+
+  auto open_file_result =
+      parquet::arrow::OpenFile(fv, arrow::default_memory_pool(), &reader);
+  if (!open_file_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}", open_file_result);
+  }
+
+  std::shared_ptr<arrow::Table> out;
+  auto read_result = reader->ReadTable(&out);
+  if (!read_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}", read_result);
+  }
+
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> new_columns;
+  arrow::SchemaBuilder schema_builder;
+  for (int i = 0, size = out->num_columns(); i < size; ++i) {
+    auto fixed_column_res = HandleBadParquetTypes(out->column(i));
+    if (!fixed_column_res) {
+      return fixed_column_res.error();
+    }
+    std::shared_ptr<arrow::ChunkedArray> fixed_column(
+        std::move(fixed_column_res.value()));
+    new_columns.emplace_back(fixed_column);
+    auto new_field = std::make_shared<arrow::Field>(
+        out->field(i)->name(), fixed_column->type());
+    if (auto status = schema_builder.AddField(new_field); !status.ok()) {
+      return KATANA_ERROR(
+          ErrorCode::ArrowError, "adding field to table schema: {}", status);
+    }
+  }
+  auto maybe_schema = schema_builder.Finish();
+  if (!maybe_schema.ok()) {
+    return KATANA_ERROR(
+        ErrorCode::ArrowError, "finishing table schema: {}",
+        maybe_schema.status());
+  }
+  std::shared_ptr<arrow::Schema> final_schema = maybe_schema.ValueOrDie();
+
+  out = arrow::Table::Make(final_schema, new_columns);
+
+  // Combine multiple chunks into one. Binary and string columns (c.f. large
+  // binary and large string columns) are a special case. They may not be
+  // combined into a single chunk due to the fact the offset type for these
+  // columns is int32_t and thus the maximum size of an arrow::Array for these
+  // types is 2^31.
+  auto combine_result = out->CombineChunks(arrow::default_memory_pool());
+  if (!combine_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}",
+        combine_result.status());
+  }
+
+  return combine_result.ValueOrDie();
+}

--- a/libtsuba/src/ParquetWriter.cpp
+++ b/libtsuba/src/ParquetWriter.cpp
@@ -1,0 +1,165 @@
+#include "tsuba/ParquetWriter.h"
+
+#include <arrow/chunked_array.h>
+
+#include "katana/Result.h"
+#include "tsuba/Errors.h"
+#include "tsuba/FaultTest.h"
+
+template <typename T>
+using Result = katana::Result<T>;
+
+namespace {
+
+// constant taken directly from the arrow docs
+constexpr uint64_t kMaxStringChunkSize = 0x7FFFFFFE;
+
+std::shared_ptr<parquet::WriterProperties>
+StandardWriterProperties() {
+  // int64 timestamps with nanosecond resolution requires Parquet version 2.0.
+  // In Arrow to Parquet version 1.0, nanosecond timestamps will get truncated
+  // to milliseconds.
+  return parquet::WriterProperties::Builder()
+      .version(parquet::ParquetVersion::PARQUET_2_0)
+      ->data_page_version(parquet::ParquetDataPageVersion::V2)
+      ->build();
+}
+
+std::shared_ptr<parquet::ArrowWriterProperties>
+StandardArrowProperties() {
+  return parquet::ArrowWriterProperties::Builder().build();
+}
+
+/// Store the arrow table in a file
+katana::Result<void>
+StoreParquet(
+    const arrow::Table& table, const katana::Uri& uri,
+    tsuba::WriteGroup* desc) {
+  auto ff = std::make_shared<tsuba::FileFrame>();
+  if (auto res = ff->Init(); !res) {
+    return res.error().WithContext("creating output buffer");
+  }
+
+  auto write_result = parquet::arrow::WriteTable(
+      table, arrow::default_memory_pool(), ff,
+      std::numeric_limits<int64_t>::max(), StandardWriterProperties(),
+      StandardArrowProperties());
+
+  if (!write_result.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow error: {}", write_result);
+  }
+
+  ff->Bind(uri.string());
+  TSUBA_PTP(tsuba::internal::FaultSensitivity::Normal);
+  if (!desc) {
+    return ff->Persist();
+  }
+
+  desc->StartStore(std::move(ff));
+  return katana::ResultSuccess();
+}
+
+katana::Result<std::shared_ptr<arrow::ChunkedArray>>
+LargeStringToChunkedString(
+    const std::shared_ptr<arrow::LargeStringArray>& arr) {
+  std::vector<std::shared_ptr<arrow::Array>> chunks;
+
+  arrow::StringBuilder builder;
+
+  uint64_t inserted = 0;
+
+  for (uint64_t i = 0, size = arr->length(); i < size; ++i) {
+    if (!arr->IsValid(i)) {
+      auto status = builder.AppendNull();
+      if (!status.ok()) {
+        return KATANA_ERROR(
+            tsuba::ErrorCode::ArrowError, "appending null: {}", status);
+      }
+      continue;
+    }
+    arrow::util::string_view val = arr->GetView(i);
+    uint64_t val_size = val.size();
+    KATANA_LOG_ASSERT(val_size < kMaxStringChunkSize);
+    if (inserted + val_size >= kMaxStringChunkSize) {
+      std::shared_ptr<arrow::Array> new_arr;
+      auto status = builder.Finish(&new_arr);
+      if (!status.ok()) {
+        return KATANA_ERROR(
+            tsuba::ErrorCode::ArrowError, "finishing string array: {}", status);
+      }
+      chunks.emplace_back(new_arr);
+      inserted = 0;
+      builder.Reset();
+    }
+    inserted += val_size;
+    auto status = builder.Append(val);
+    if (!status.ok()) {
+      return KATANA_ERROR(
+          tsuba::ErrorCode::ArrowError, "adding string to array: {}", status);
+    }
+  }
+  if (inserted > 0) {
+    std::shared_ptr<arrow::Array> new_arr;
+    auto status = builder.Finish(&new_arr);
+    if (!status.ok()) {
+      return KATANA_ERROR(
+          tsuba::ErrorCode::ArrowError, "finishing string array: {}", status);
+    }
+    chunks.emplace_back(new_arr);
+  }
+
+  auto maybe_res = arrow::ChunkedArray::Make(chunks, arrow::utf8());
+  if (!maybe_res.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "building chunked array: {}",
+        maybe_res.status());
+  }
+  return maybe_res.ValueOrDie();
+}
+
+// HandleBadParquetTypes here and HandleBadParquetTypes in ParquetReader.cpp
+// workaround a libarrow2.0 limitation in reading and writing LargeStrings to
+// parquet files.
+katana::Result<std::shared_ptr<arrow::ChunkedArray>>
+HandleBadParquetTypes(std::shared_ptr<arrow::ChunkedArray> old_array) {
+  if (old_array->num_chunks() > 1) {
+    return old_array;
+  }
+  switch (old_array->type()->id()) {
+  case arrow::Type::type::LARGE_STRING: {
+    std::shared_ptr<arrow::LargeStringArray> large_string_array =
+        std::static_pointer_cast<arrow::LargeStringArray>(old_array->chunk(0));
+    return LargeStringToChunkedString(large_string_array);
+  }
+  default:
+    return old_array;
+  }
+}
+
+}  // namespace
+
+Result<std::unique_ptr<tsuba::ParquetWriter>>
+tsuba::ParquetWriter::Make(
+    const std::shared_ptr<arrow::ChunkedArray>& array,
+    const std::string& name) {
+  auto res = HandleBadParquetTypes(array);
+  if (!res) {
+    return res.error().WithContext("handling arrow->parquet type mismatch");
+  }
+  std::shared_ptr<arrow::ChunkedArray> new_array(std::move(res.value()));
+
+  std::shared_ptr<arrow::Table> column = arrow::Table::Make(
+      arrow::schema({arrow::field(name, new_array->type())}), {new_array});
+  return std::unique_ptr<ParquetWriter>(new ParquetWriter(column));
+}
+
+katana::Result<void>
+tsuba::ParquetWriter::WriteToUri(const katana::Uri& uri, WriteGroup* group) {
+  try {
+    return StoreParquet(*table_, uri, group);
+  } catch (const std::exception& exp) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "arrow exception: {}", exp.what());
+  }
+}


### PR DESCRIPTION
I plan to use these interfaces to support out-of-core properties for import.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>