### PR TITLE
Add dependency checks to katana_setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake>=3.13", "cython", "jinja2", "pyarrow"]
+requires = ["setuptools", "wheel", "Cython (>=0.29.12)", "jinja2", "pyarrow (>=1.0,<3.0.dev)", "numpy", "packaging"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 import sys
+
+assert sys.version_info.major >= 3 and sys.version_info.minor >= 6, "Katana requires Python 3.6 or greater"
+
 import pathlib
 
 sys.path.append(str(pathlib.Path.cwd() / "python"))


### PR DESCRIPTION
This makes direct calls to setup.py produce reasonable errors when
dependencies are not satified. This should also make it easier to
build python packages for unusual environments (like dpkg native
packages with pip python packages).