### PR TITLE
Add max_global_node_id field to PartitionMetadata

### DIFF
--- a/libtsuba/include/tsuba/PartitionMetadata.h
+++ b/libtsuba/include/tsuba/PartitionMetadata.h
@@ -12,6 +12,7 @@ struct PartitionMetadata {
   bool is_outgoing_edge_cut_{false};
   bool is_incoming_edge_cut_{false};
   uint64_t num_global_nodes_{0UL};
+  uint64_t max_global_node_id_{0UL};
   uint64_t num_global_edges_{0UL};
   uint64_t num_edges_{0UL};
   uint32_t num_nodes_{0};

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -416,6 +416,7 @@ tsuba::to_json(json& j, const tsuba::PartitionMetadata& pmd) {
       {"is_outgoing_edge_cut", pmd.is_outgoing_edge_cut_},
       {"is_incoming_edge_cut", pmd.is_incoming_edge_cut_},
       {"num_global_nodes", pmd.num_global_nodes_},
+      {"max_global_node_id", pmd.max_global_node_id_},
       {"num_global_edges", pmd.num_global_edges_},
       {"num_nodes", pmd.num_nodes_},
       {"num_edges", pmd.num_edges_},
@@ -427,11 +428,17 @@ void
 tsuba::from_json(const json& j, tsuba::PartitionMetadata& pmd) {
   uint32_t magic;
   j.at("magic").get_to(magic);
+
   j.at("policy_id").get_to(pmd.policy_id_);
   j.at("transposed").get_to(pmd.transposed_);
   j.at("is_outgoing_edge_cut").get_to(pmd.is_outgoing_edge_cut_);
   j.at("is_incoming_edge_cut").get_to(pmd.is_incoming_edge_cut_);
   j.at("num_global_nodes").get_to(pmd.num_global_nodes_);
+  if (auto it = j.find("max_global_node_id"); it != j.end()) {
+    it->get_to(pmd.max_global_node_id_);
+  } else {
+    pmd.max_global_node_id_ = pmd.num_global_nodes_ - 1;
+  }
   j.at("num_global_edges").get_to(pmd.num_global_edges_);
   j.at("num_nodes").get_to(pmd.num_nodes_);
   j.at("num_edges").get_to(pmd.num_edges_);


### PR DESCRIPTION
The simplest way to support sparse global node ids is to maintain a `max_global_node_id` in addition to a `num_global_nodes`. Add this field to `PartitionMetadata` and support writing it to disk and reading it from disk when present.