### PR TITLE
Rework CPack packaging to generate multiple packages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,26 +40,58 @@ endif()
 
 add_subdirectory(tools)
 
-###### Distribution ######
 
-set(CPACK_GENERATOR "TGZ")
-set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYRIGHT")
-set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
-set(CPACK_PACKAGE_VERSION_MAJOR ${KATANA_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${KATANA_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${KATANA_VERSION_PATCH})
-# The debian version sorts correctly for RPMs too
-set(CPACK_PACKAGE_VERSION ${KATANA_VERSION_DEBIAN})
-include(CPack)
+####### Language Bindings #######
 
 if(KATANA_LANG_BINDINGS_PYTHON)
   add_python_setuptools_target(katana_python
-                               DEPENDS Katana::galois)
+                               DEPENDS Katana::galois
+                               COMPONENT python)
   if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
     add_python_setuptools_tests(katana_python PATH python/tests)
   endif()
   if(BUILD_DOCS)
     add_python_setuptools_docs(katana_python)
   endif()
+endif()
+
+###### Packaging ######
+
+set(CPACK_PACKAGE_NAME "katana")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYRIGHT")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+
+if(NOT BUILD_SHARED_LIBS)
+  set(PACKAGE_SUFFIX "${PACKAGE_SUFFIX}-static")
+endif()
+
+string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
+
+if(build_type STREQUAL "debug")
+  set(PACKAGE_SUFFIX "${PACKAGE_SUFFIX}-dbg")
+endif()
+
+katana_setup_cpack_component_groups("${CPACK_PACKAGE_NAME}" "${PACKAGE_SUFFIX}")
+
+set(CPACK_PACKAGE_DESCRIPTION "Katana Graph system (Open-source)")
+
+macro(katana_cpack_open_components)
+  cpack_add_component(dev GROUP dev_pkg DEPENDS shlib)
+  cpack_add_component(lib GROUP dev_pkg DEPENDS shlib)
+
+  cpack_add_component(shlib GROUP shlib_pkg)
+
+  cpack_add_component(tools GROUP tools_pkg DEPENDS shlib)
+
+  cpack_add_component(apps GROUP apps_pkg DEPENDS shlib)
+
+  cpack_add_component(python GROUP python_pkg DEPENDS shlib)
+endmacro()
+
+# Use a macro here so it can be called in the enterprise build to setup components there (they are directory local)
+katana_cpack_open_components()
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  katana_reformat_cpack_dependencies()
+  include(CPack)
 endif()

--- a/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
+++ b/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
@@ -142,7 +142,7 @@ endfunction()
 
 function(add_python_setuptools_target TARGET_NAME)
   set(no_value_options)
-  set(one_value_options SETUP_DIRECTORY)
+  set(one_value_options SETUP_DIRECTORY COMPONENT)
   set(multi_value_options DEPENDS)
 
   cmake_parse_arguments(X "${no_value_options}" "${one_value_options}" "${multi_value_options}" ${ARGN})
@@ -150,6 +150,10 @@ function(add_python_setuptools_target TARGET_NAME)
   set(PYTHON_SETUP_DIR ${X_SETUP_DIRECTORY})
   if(NOT PYTHON_SETUP_DIR)
     set(PYTHON_SETUP_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  if (NOT X_COMPONENT)
+    set(X_COMPONENT python)
   endif()
 
   set(PYTHON_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_build)
@@ -227,10 +231,10 @@ function(add_python_setuptools_target TARGET_NAME)
   install(
       CODE "execute_process(
                 COMMAND
-                  ${PYTHON_SETUP_COMMAND} install --skip-build --prefix=\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}
+                  ${PYTHON_SETUP_COMMAND} install --prefix=\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}
                 WORKING_DIRECTORY ${PYTHON_BINARY_DIR}
                 COMMAND_ERROR_IS_FATAL ANY)"
-      COMPONENT python)
+      COMPONENT ${X_COMPONENT})
 
   set_target_properties(${TARGET_NAME} PROPERTIES
                         PYTHON_ENV_SCRIPT "${PYTHON_ENV_SCRIPT}"

--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -63,7 +63,7 @@ install(TARGETS tsuba tsuba-preload
   EXPORT KatanaTargets
   LIBRARY
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    COMPONENT lib
+    COMPONENT shlib
   ARCHIVE
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     COMPONENT lib


### PR DESCRIPTION
This is in preparation for open-source binary packages and in
support of enterprise packaging improvements.

The new packages are (with debian names in parens):

* Katana shared libraries (libkatana)
* Katana headers and static libraries (libkatana-dev)
* Katana CLI tools (katana-tools)
* Katana CLI applications (katana-apps)
* Katana Python wrappers (python3-katana)

The changes in this repo do not yet support automatic clean
packaging. However, cpack should work at a basic level for
deb and rpm packages.