### PR TITLE
More KATANA_ERROR

### DIFF
--- a/libgalois/src/BuildGraph.cpp
+++ b/libgalois/src/BuildGraph.cpp
@@ -1960,6 +1960,12 @@ ToArrowArray(
         std::move(builder), arrow_dst, import_src);
     break;
   }
+  case arrow::Type::UINT32: {
+    arrow::UInt32Builder builder;
+    arrow_dst = BuildImportVec<arrow::UInt32Builder, uint32_t>(
+        std::move(builder), arrow_dst, import_src);
+    break;
+  }
   case arrow::Type::DOUBLE: {
     arrow::DoubleBuilder builder;
     arrow_dst = BuildImportVec<arrow::DoubleBuilder, double>(

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -31,8 +31,6 @@ struct KATANA_EXPORT RDGLoadOptions {
   /// nullopt means the partition associated with the current host's ID will be
   /// loaded
   std::optional<uint32_t> partition_id_to_load;
-  /// Client is trying to load RDG into expected_num_hosts machines
-  std::optional<uint32_t> expected_num_hosts;
   /// List of node properties that should be loaded
   /// nullptr means all node properties will be loaded
   const std::vector<std::string>* node_properties{nullptr};
@@ -187,6 +185,8 @@ private:
 
   std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
   std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
+  // Called while constructing to put these arrays into a usable state for Distribution
+  void InitArrowVectors();
   std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_ids_;
   std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
   std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -31,6 +31,8 @@ struct KATANA_EXPORT RDGLoadOptions {
   /// nullopt means the partition associated with the current host's ID will be
   /// loaded
   std::optional<uint32_t> partition_id_to_load;
+  /// Client is trying to load RDG into expected_num_hosts machines
+  std::optional<uint32_t> expected_num_hosts;
   /// List of node properties that should be loaded
   /// nullptr means all node properties will be loaded
   const std::vector<std::string>* node_properties{nullptr};

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -424,6 +424,15 @@ katana::Result<tsuba::RDG>
 tsuba::RDG::Make(const RDGMeta& meta, const RDGLoadOptions& opts) {
   uint32_t partition_id_to_load =
       opts.partition_id_to_load.value_or(Comm()->ID);
+  if (opts.expected_num_hosts.has_value()) {
+    auto expected_num_hosts = opts.expected_num_hosts.value();
+    if (expected_num_hosts != meta.num_hosts()) {
+      return KATANA_ERROR(
+          ErrorCode::InvalidArgument,
+          "expected hosts: {} RDG expects {}, they should be equal",
+          expected_num_hosts, meta.num_hosts());
+    }
+  }
 
   katana::Uri partition_path = meta.PartitionFileName(partition_id_to_load);
 


### PR DESCRIPTION
- ~~Pass expected number of hosts to RDG to enable a better error message when a user opens a partitioned graph on the wrong number of hosts.~~
-  Finish support for UINT32 in ImportData
- KATANA_ERROR in PropertyGraph.cpp, and ArrowInterchange.h 
