### PR TITLE
support: add SplitView for parsing strings with delimiters

### DIFF
--- a/.github/workflows/download_miniconda.sh
+++ b/.github/workflows/download_miniconda.sh
@@ -10,6 +10,6 @@ esac
 
 VER="4.9.2-7"
 
-INPUT_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-${VER}-${PLAT}.sh"
+INPUT_URL="https://github.com/conda-forge/miniforge/releases/download/${VER}/Mambaforge-${VER}-${PLAT}.sh"
 mkdir -p "$(dirname $MINICONDA_FILE)"
 curl -fL --output "$MINICONDA_FILE" "$INPUT_URL"

--- a/libsupport/include/katana/Strings.h
+++ b/libsupport/include/katana/Strings.h
@@ -2,6 +2,7 @@
 #define KATANA_LIBSUPPORT_KATANA_STRINGS_H_
 
 #include <initializer_list>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -32,6 +33,13 @@ KATANA_EXPORT std::string TrimSuffix(
     const std::string& s, const std::string& suffix);
 
 KATANA_EXPORT bool HasSuffix(const std::string& s, const std::string& suffix);
+
+/// SplitView returns a list of words in \param s using \param sep as the
+/// delimiter string. Splits at most \param max times (so there will be at most
+/// max + 1 entries in the output)
+KATANA_EXPORT std::vector<std::string_view> SplitView(
+    std::string_view s, std::string_view sep,
+    uint64_t max = std::numeric_limits<uint64_t>::max());
 
 /// Join returns a string that is the concatenation of every object from
 /// \param begin to \param end  all separated by an instance of \param sep

--- a/libsupport/src/Strings.cpp
+++ b/libsupport/src/Strings.cpp
@@ -1,5 +1,17 @@
 #include "katana/Strings.h"
 
+namespace {
+
+size_t
+next_sep(std::string_view s, std::string_view sep, size_t start = 0) {
+  if (sep.empty()) {
+    return start + 1;
+  }
+  return s.find(sep, start);
+}
+
+}  // namespace
+
 bool
 katana::HasPrefix(const std::string& s, const std::string& prefix) {
   size_t prefix_len = prefix.length();
@@ -40,4 +52,21 @@ katana::TrimSuffix(const std::string& s, const std::string& suffix) {
     return s.substr(0, s.length() - suffix_len);
   }
   return s;
+}
+
+std::vector<std::string_view>
+katana::SplitView(std::string_view s, std::string_view sep, uint64_t max) {
+  std::vector<std::string_view> words;
+  size_t start = 0;
+  size_t end = next_sep(s, sep);
+  for (uint64_t i = 0; i < max; ++i) {
+    if (end >= s.length()) {
+      break;
+    }
+    words.emplace_back(s.substr(start, end - start));
+    start = end + sep.length();
+    end = next_sep(s, sep, start);
+  }
+  words.emplace_back(s.substr(start));
+  return words;
 }

--- a/libsupport/test/strings.cpp
+++ b/libsupport/test/strings.cpp
@@ -23,6 +23,30 @@ main() {
       katana::TrimSuffix("prefix.suffix", "none") == "prefix.suffix");
 
   KATANA_LOG_ASSERT(
+      katana::SplitView("separated by spaces", " ") ==
+      std::vector<std::string_view>({"separated", "by", "spaces"}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView("no delimiter in string", ";") ==
+      std::vector<std::string_view>({"no delimiter in string"}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView("", " ") == std::vector<std::string_view>({""}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView(",delim,corner,,cases,", ",") ==
+      std::vector<std::string_view>({"", "delim", "corner", "", "cases", ""}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView("what if word delim word is a word word", " word ") ==
+      std::vector<std::string_view>({"what if", "delim", "is a", "word"}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView("empty", "") ==
+      std::vector<std::string_view>({"e", "m", "p", "t", "y"}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView("only\tsplit\tonce", "\t", 1) ==
+      std::vector<std::string_view>({"only", "split\tonce"}));
+  KATANA_LOG_ASSERT(
+      katana::SplitView("split\tthe\tright\tamount", "\t", 3) ==
+      std::vector<std::string_view>({"split", "the", "right", "amount"}));
+
+  KATANA_LOG_ASSERT(
       katana::Join(" ", {"list", "of", "strings"}) == "list of strings");
   KATANA_LOG_ASSERT(
       katana::Join("", {"list", "of", "strings"}) == "listofstrings");


### PR DESCRIPTION
I needed one of these for some string parsing. Couldn't find one in
fmt, and it seems like such a small thing to take a new dependency on.

Interface intended to be very close to python's `string.split()`

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>