### PR TITLE
Bump minimum CMake version to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.17)
 
 project(Katana)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ beware.
 At the minimum, Galois depends on the following software:
 
 - A modern C++ compiler compliant with the C++-17 standard (gcc >= 7, Intel >= 19.0.1, clang >= 7.0)
-- CMake (>= 3.13)
+- CMake (>= 3.17)
 - Boost library (>= 1.58.0, we recommend building/installing the full library)
 - libllvm (>= 7.0 with RTTI support)
 - libfmt (>= 4.0)

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -11,7 +11,7 @@ dependencies:
  - benchmark
  - boost-cpp>=1.74
  - black=19.10
- - cmake>=3.19
+ - cmake>=3.17
  - conda-build
  - conda-verify
  - cxx-compiler>=1.1.3

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ cdt('numactl-devel') }}
-    - cmake>=3.19
+    - cmake>=3.17
     - cython>=0.29.12
     - make
     - pyarrow {{ arrow_cpp }}
@@ -109,7 +109,7 @@ outputs:
       requires:
         - {{ compiler('cxx') }}
         - {{ cdt('numactl') }}
-        - cmake>=3.13
+        - cmake>=3.17
         - make
       files:
         - test_app/CMakeLists.txt

--- a/lonestar/CMakeLists.txt
+++ b/lonestar/CMakeLists.txt
@@ -35,7 +35,7 @@ function(add_test_scale type app)
     endif()
 
     add_test(NAME setup-clean${suffix}
-      COMMAND ${CMAKE_COMMAND} -E remove_directory ${output_location})
+      COMMAND ${CMAKE_COMMAND} -E rm -rf ${output_location})
     add_test(NAME setup-make${suffix}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${output_location})
 


### PR DESCRIPTION
CMake 3.17 has deprecated `cmake -E remove_directory` and `-E remove` in
favor of `cmake -E rm [-rf]` because the former two commands always
return success even if the target directory or file does not exist.
`cmake -E rm` does not exist before 3.17.

Given that our current development environments always install the most
recent CMake versions, it seems better to just move forward the minimum
CMake version rather than continuing to use the soon-to-be-deprecated
`remove_directory` command.