### PR TITLE
support: Expose katana library version in the Python API

### DIFF
--- a/python/katana/__init__.py
+++ b/python/katana/__init__.py
@@ -24,6 +24,8 @@ from typing import Type, Dict, Union
 # Initialize the galois runtime immediately.
 import katana.galois
 
+__version__ = katana.galois.get_version()
+
 
 def load_ipython_extension(ipython):
     import cython

--- a/python/katana/cpp/libgalois/Galois.pxd
+++ b/python/katana/cpp/libgalois/Galois.pxd
@@ -1,4 +1,5 @@
 from ..libstd cimport CPPAuto
+from libcpp.string cimport string
 
 cdef extern from "katana/Galois.h" namespace "katana" nogil:
     unsigned int setActiveThreads(unsigned int)
@@ -54,3 +55,6 @@ cdef extern from "katana/NoDerefIterator.h" namespace "katana" nogil:
         NoDerefIterator[it] operator++()
         NoDerefIterator[it] operator--()
         it operator*()
+
+cdef extern from "katana/Version.h" namespace "katana" nogil:
+    string getVersion()

--- a/python/katana/galois.pyx
+++ b/python/katana/galois.pyx
@@ -1,7 +1,12 @@
 from .cpp.libgalois.Galois cimport setActiveThreads as c_setActiveThreads
+from .cpp.libgalois.Galois cimport getVersion as c_getVersion
+
 
 _katana_runtime = _katana_runtime_wrapper()
 
 def setActiveThreads(int n):
     return c_setActiveThreads(n)
+
+def get_version():
+    return c_getVersion()
 


### PR DESCRIPTION
Fixes #124

Output:[](url)
![katana_python_version](https://user-images.githubusercontent.com/22681121/113833656-8ca6b400-97a7-11eb-9be6-66391319e3e8.png)
