### PR TITLE
tsuba: properly write out all null string columns

### DIFF
--- a/libtsuba/src/AddProperties.h
+++ b/libtsuba/src/AddProperties.h
@@ -33,7 +33,8 @@ AddProperties(
 
     auto add_result = add_fn(props);
     if (!add_result) {
-      return add_result.error();
+      return add_result.error().WithContext(
+          "adding {}", std::quoted(properties.name));
     }
   }
 

--- a/libtsuba/src/ParquetWriter.cpp
+++ b/libtsuba/src/ParquetWriter.cpp
@@ -69,7 +69,6 @@ LargeStringToChunkedString(
   arrow::StringBuilder builder;
 
   uint64_t inserted = 0;
-
   for (uint64_t i = 0, size = arr->length(); i < size; ++i) {
     if (!arr->IsValid(i)) {
       auto status = builder.AppendNull();
@@ -100,13 +99,14 @@ LargeStringToChunkedString(
           tsuba::ErrorCode::ArrowError, "adding string to array: {}", status);
     }
   }
-  if (inserted > 0) {
-    std::shared_ptr<arrow::Array> new_arr;
-    auto status = builder.Finish(&new_arr);
-    if (!status.ok()) {
-      return KATANA_ERROR(
-          tsuba::ErrorCode::ArrowError, "finishing string array: {}", status);
-    }
+
+  std::shared_ptr<arrow::Array> new_arr;
+  auto status = builder.Finish(&new_arr);
+  if (!status.ok()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::ArrowError, "finishing string array: {}", status);
+  }
+  if (new_arr->length() > 0) {
     chunks.emplace_back(new_arr);
   }
   return chunks;

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -361,7 +361,7 @@ tsuba::RDG::DoMake(const katana::Uri& metadata_dir) {
         return rdg->core_->AddNodeProperties(props);
       });
   if (!node_result) {
-    return node_result.error();
+    return node_result.error().WithContext("populating node properties");
   }
 
   auto edge_result = AddProperties(
@@ -370,7 +370,7 @@ tsuba::RDG::DoMake(const katana::Uri& metadata_dir) {
         return rdg->core_->AddEdgeProperties(props);
       });
   if (!edge_result) {
-    return edge_result.error();
+    return edge_result.error().WithContext("populating edge properties");
   }
 
   const std::vector<PropStorageInfo>& part_prop_info_list =


### PR DESCRIPTION
Fixed corner that case caused a column of all null string values to be
written out as a zero length array.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>