### PR TITLE
Have BuildGraph and query agree on NANO timestamps

### DIFF
--- a/libgalois/src/BuildGraph.cpp
+++ b/libgalois/src/BuildGraph.cpp
@@ -157,7 +157,7 @@ GetNullArrays(size_t elts) {
   AddNullArrays<arrow::UInt8Builder>(&null_map, &lists_null_map, elts);
   AddNullArrays(
       &null_map, &lists_null_map, elts,
-      arrow::timestamp(arrow::TimeUnit::MILLI, "UTC"));
+      arrow::timestamp(arrow::TimeUnit::NANO, "UTC"));
 
   return NullMaps(std::move(null_map), std::move(lists_null_map));
 }
@@ -1987,7 +1987,7 @@ ToArrowArray(
   case arrow::Type::TIMESTAMP: {
     auto* pool = arrow::default_memory_pool();
     arrow::TimestampBuilder builder(
-        arrow::timestamp(arrow::TimeUnit::MILLI, "UTC"), pool);
+        arrow::timestamp(arrow::TimeUnit::NANO, "UTC"), pool);
     arrow_dst = BuildImportVec<arrow::TimestampBuilder, bool>(
         std::move(builder), arrow_dst, import_src);
     break;


### PR DESCRIPTION
This is a mini-PR to get Bo unstuck.  We need to agree on a global strategy for timestamps for our codebase.