### PR TITLE
PropertyGraph and RDG support upsert for properties

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -163,6 +163,8 @@ public:
         PropertyGraph::*properties_fn)() const;
     Result<void> (PropertyGraph::*add_properties_fn)(
         const std::shared_ptr<arrow::Table>& props);
+    Result<void> (PropertyGraph::*upsert_properties_fn)(
+        const std::shared_ptr<arrow::Table>& props);
     Result<void> (PropertyGraph::*remove_property_int)(int i);
     Result<void> (PropertyGraph::*remove_property_str)(const std::string& str);
 
@@ -183,6 +185,11 @@ public:
     Result<void> AddProperties(
         const std::shared_ptr<arrow::Table>& props) const {
       return (g->*add_properties_fn)(props);
+    }
+
+    Result<void> UpsertProperties(
+        const std::shared_ptr<arrow::Table>& props) const {
+      return (g->*upsert_properties_fn)(props);
     }
 
     Result<void> RemoveProperty(int i) const {
@@ -403,8 +410,14 @@ public:
 
   const GraphTopology& topology() const { return topology_; }
 
+  /// Add Node properties that do not exist in the current graph
   Result<void> AddNodeProperties(const std::shared_ptr<arrow::Table>& props);
+  /// Add Edge properties that do not exist in the current graph
   Result<void> AddEdgeProperties(const std::shared_ptr<arrow::Table>& props);
+  /// If property name exists, replace it, otherwise insert it
+  Result<void> UpsertNodeProperties(const std::shared_ptr<arrow::Table>& props);
+  /// If property name exists, replace it, otherwise insert it
+  Result<void> UpsertEdgeProperties(const std::shared_ptr<arrow::Table>& props);
 
   Result<void> RemoveNodeProperty(int i);
   Result<void> RemoveNodeProperty(const std::string& prop_name);
@@ -419,6 +432,7 @@ public:
         .property_fn = &PropertyGraph::GetNodeProperty,
         .properties_fn = &PropertyGraph::node_properties,
         .add_properties_fn = &PropertyGraph::AddNodeProperties,
+        .upsert_properties_fn = &PropertyGraph::UpsertNodeProperties,
         .remove_property_int = &PropertyGraph::RemoveNodeProperty,
         .remove_property_str = &PropertyGraph::RemoveNodeProperty,
     };
@@ -431,6 +445,7 @@ public:
         .property_fn = &PropertyGraph::GetEdgeProperty,
         .properties_fn = &PropertyGraph::edge_properties,
         .add_properties_fn = &PropertyGraph::AddEdgeProperties,
+        .upsert_properties_fn = &PropertyGraph::UpsertEdgeProperties,
         .remove_property_int = &PropertyGraph::RemoveEdgeProperty,
         .remove_property_str = &PropertyGraph::RemoveEdgeProperty,
     };

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -314,6 +314,22 @@ katana::PropertyGraph::AddNodeProperties(
 }
 
 katana::Result<void>
+katana::PropertyGraph::UpsertNodeProperties(
+    const std::shared_ptr<arrow::Table>& props) {
+  if (props->num_columns() == 0) {
+    KATANA_LOG_DEBUG("upsert empty node prop table");
+    return ResultSuccess();
+  }
+  if (topology_.out_indices &&
+      topology_.out_indices->length() != props->num_rows()) {
+    return KATANA_ERROR(
+        ErrorCode::InvalidArgument, "expected {} rows found {} instead",
+        topology_.out_indices->length(), props->num_rows());
+  }
+  return rdg_.UpsertNodeProperties(props);
+}
+
+katana::Result<void>
 katana::PropertyGraph::RemoveNodeProperty(int i) {
   return rdg_.RemoveNodeProperty(i);
 }
@@ -342,6 +358,22 @@ katana::PropertyGraph::AddEdgeProperties(
         topology_.out_dests->length(), props->num_rows());
   }
   return rdg_.AddEdgeProperties(props);
+}
+
+katana::Result<void>
+katana::PropertyGraph::UpsertEdgeProperties(
+    const std::shared_ptr<arrow::Table>& props) {
+  if (props->num_columns() == 0) {
+    KATANA_LOG_DEBUG("upsert empty edge prop table");
+    return ResultSuccess();
+  }
+  if (topology_.out_dests &&
+      topology_.out_dests->length() != props->num_rows()) {
+    return KATANA_ERROR(
+        ErrorCode::InvalidArgument, "expected {} rows found {} instead",
+        topology_.out_dests->length(), props->num_rows());
+  }
+  return rdg_.UpsertEdgeProperties(props);
 }
 
 katana::Result<void>

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -68,6 +68,12 @@ public:
   katana::Result<void> AddEdgeProperties(
       const std::shared_ptr<arrow::Table>& props);
 
+  katana::Result<void> UpsertNodeProperties(
+      const std::shared_ptr<arrow::Table>& props);
+
+  katana::Result<void> UpsertEdgeProperties(
+      const std::shared_ptr<arrow::Table>& props);
+
   katana::Result<void> RemoveNodeProperty(uint32_t i);
   katana::Result<void> RemoveEdgeProperty(uint32_t i);
 

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -27,6 +27,12 @@ public:
   katana::Result<void> AddEdgeProperties(
       const std::shared_ptr<arrow::Table>& props);
 
+  katana::Result<void> UpsertNodeProperties(
+      const std::shared_ptr<arrow::Table>& props);
+
+  katana::Result<void> UpsertEdgeProperties(
+      const std::shared_ptr<arrow::Table>& props);
+
   katana::Result<void> RemoveNodeProperty(uint32_t i);
 
   katana::Result<void> RemoveEdgeProperty(uint32_t i);

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -39,12 +39,28 @@ public:
   // Property manipulation
   //
 
-  void AppendNodePropStorageInfo(PropStorageInfo&& pmd) {
-    node_prop_info_list_.emplace_back(std::move(pmd));
+  void AddNodePropStorageInfo(PropStorageInfo&& pmd) {
+    auto pmd_it = std::find_if(
+        node_prop_info_list_.begin(), node_prop_info_list_.end(),
+        [&](const PropStorageInfo& my_pmd) { return my_pmd.name == pmd.name; });
+    if (pmd_it == node_prop_info_list_.end()) {
+      node_prop_info_list_.emplace_back(std::move(pmd));
+    } else {
+      // If we already have a record, clear the path so we will rewrite it
+      pmd_it->path = "";
+    }
   }
 
-  void AppendEdgePropStorageInfo(PropStorageInfo&& pmd) {
-    edge_prop_info_list_.emplace_back(std::move(pmd));
+  void AddEdgePropStorageInfo(PropStorageInfo&& pmd) {
+    auto pmd_it = std::find_if(
+        edge_prop_info_list_.begin(), edge_prop_info_list_.end(),
+        [&](const PropStorageInfo& my_pmd) { return my_pmd.name == pmd.name; });
+    if (pmd_it == edge_prop_info_list_.end()) {
+      edge_prop_info_list_.emplace_back(std::move(pmd));
+    } else {
+      // If we already have a record, clear the path so we will rewrite it
+      pmd_it->path = "";
+    }
   }
 
   void RemoveNodeProperty(uint32_t i) {


### PR DESCRIPTION
Bo wants to move to a more Arrow-based interface for GraphUpdate, and I think that is a good idea.  With that in mind, and with an eye toward transactional semantics, I'd like to add an upsert operation for properties.  This will update existing properties and insert new columns in one operation.  Nothing in this PR should complicate holding a subset of property data in memory at once.

I reimplemented AddProperties using Upsert and all tests in libgalois succeed.  Are there other tests I should run?  This PR changes the semantics of AddProperties slightly.  It used to be if you tried to add two properties, one of which already existed, the new property would add, but the operation would return a failure.  Now we check in advance for any name collisions and fail before making any changes.