### PR TITLE
Bump katana-input to v18

### DIFF
--- a/inputs/CMakeLists.txt
+++ b/inputs/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(INPUT_VERSION v17)
+set(INPUT_VERSION v18)
 
 set(INPUT_URL "https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-${INPUT_VERSION}.tar.gz")
 

--- a/python/katana/example_utils.py
+++ b/python/katana/example_utils.py
@@ -20,7 +20,7 @@ def get_inputs_directory():
     if os.path.isdir(inputs_dir) and os.path.isdir(inputs_dir + "/propertygraphs/ldbc_003"):
         return inputs_dir
     fn, _headers = urllib.request.urlretrieve(
-        "https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-v16.tar.gz"
+        "https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-v18.tar.gz"
     )
     try:
         with tarfile.open(fn) as tar:


### PR DESCRIPTION
Adds a "value" type to the GNN tester graph which acts as an edge type.
Used for testing various GTN related things.