### PR TITLE
tsuba: add interface for only reading some columns

### DIFF
--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -8,6 +8,12 @@
 #include "katana/Result.h"
 #include "katana/Uri.h"
 
+namespace parquet::arrow {
+
+class FileReader;
+
+}  // namespace parquet::arrow
+
 namespace tsuba {
 
 class KATANA_EXPORT ParquetReader {
@@ -17,22 +23,67 @@ public:
     int64_t length;
   };
 
-  /// \returns a Reader that will read a table from storage location optionally
-  /// reading only part of the table defined by \param slice
-  static katana::Result<std::unique_ptr<ParquetReader>> Make(
-      std::optional<Slice> slice = std::nullopt);
+  struct ReadOpts {
+    /// if true (default) make sure canonical types are used and table columns
+    /// are not chunked
+    bool make_cannonical{true};
 
-  /// read table from \param uri
-  katana::Result<std::shared_ptr<arrow::Table>> ReadFromUri(
+    /// if provided, slice the resulting table so that it only contains
+    /// Slice.length rows starting from Slice.offset
+    std::optional<Slice> slice{std::nullopt};
+
+    static ReadOpts Defaults() { return ReadOpts{}; }
+  };
+
+  /// build a reader that will read a table from storage location optionally
+  /// reading only part of the table.
+  /// \param opts an opt structure detailing how reads should behave (see
+  ///    the ReadOpts struct definition for details)
+  static katana::Result<std::unique_ptr<ParquetReader>> Make(
+      ReadOpts opts = ReadOpts::Defaults());
+
+  /// read table from storage
+  ///   \param uri an identifier for a parquet file
+  katana::Result<std::shared_ptr<arrow::Table>> ReadTable(
       const katana::Uri& uri);
 
+  /// read part of a table from storage
+  /// n.b. support for the `slice` read option is missing here
+  ///   \param uri an identifier for a parquet file
+  ///   \param column_bitmap must have the same length as the number of columns
+  ///      in the table in the parquet file. The loaded table will only contain
+  ///      columns at indexes that are true in the bitmap
+  katana::Result<std::shared_ptr<arrow::Table>> ReadTable(
+      const katana::Uri& uri, const std::vector<int32_t>& column_bitmap);
+
+  /// read a column part of a table from storage
+  /// n.b. support for the `slice` read option is missing here
+  ///   \param uri an identifier for a parquet file
+  ///   \param column_idx must be a valid column index for the table in that
+  ///      file
+  katana::Result<std::shared_ptr<arrow::Table>> ReadColumn(
+      const katana::Uri& uri, int32_t column_idx);
+
+  /// Get the number of columns for the table stored in a parquet file
+  ///   \param uri an identifier for a parquet file
+  katana::Result<int32_t> NumColumns(const katana::Uri& uri);
+
 private:
-  ParquetReader(std::optional<Slice> slice) : slice_(slice) {}
+  ParquetReader(std::optional<Slice> slice, bool make_cannonical)
+      : slice_(slice), make_cannonical_{make_cannonical} {}
 
   katana::Result<std::shared_ptr<arrow::Table>> ReadFromUriSliced(
       const katana::Uri& uri);
 
+  katana::Result<std::shared_ptr<arrow::Table>> FixTable(
+      std::shared_ptr<arrow::Table>&& _table);
+
+  katana::Result<std::shared_ptr<arrow::Table>> DoFilteredTableRead(
+      parquet::arrow::FileReader* reader, const arrow::Schema& schema,
+      const std::vector<int32_t>& filter);
+
   std::optional<Slice> slice_;
+  bool make_cannonical_;
 };
 
 }  // namespace tsuba

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -13,13 +13,15 @@ katana::Result<std::shared_ptr<arrow::Table>>
 DoLoadProperties(
     const std::string& expected_name, const katana::Uri& file_path,
     std::optional<tsuba::ParquetReader::Slice> slice = std::nullopt) {
-  auto reader_res = tsuba::ParquetReader::Make(slice);
+  auto read_opts = tsuba::ParquetReader::ReadOpts::Defaults();
+  read_opts.slice = slice;
+  auto reader_res = tsuba::ParquetReader::Make(read_opts);
   if (!reader_res) {
     return reader_res.error().WithContext("loading property");
   }
   std::unique_ptr<tsuba::ParquetReader> reader = std::move(reader_res.value());
 
-  auto out_res = reader->ReadFromUri(file_path);
+  auto out_res = reader->ReadTable(file_path);
   if (!out_res) {
     return out_res.error().WithContext("loading property");
   }


### PR DESCRIPTION
Used in import to speed up reading when some columns are ignored.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>