### PR TITLE
tsuba: revert fix to sliced parquet reads

### DIFF
--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -155,7 +155,9 @@ tsuba::ParquetReader::ReadFromUriSliced(const katana::Uri& uri) {
 
   out = out->Slice(row_offset, slice.length);
 
-  return FixTable(std::move(out));
+  // TODO(thunt) re-enable this when query is fixed
+  //return FixTable(std::move(out));
+  return out;
 }
 
 Result<std::shared_ptr<arrow::Table>>


### PR DESCRIPTION
The intention was to use `utf8_large` strings in memory. In my last
patch I made the sliced parquet reading code match the unsliced and
convert to `ut8_large` for consistency. Unfortunately this broke the
unit tests for graph-query which relied on this bug.

The error message is:

```
type of left and right operands not equal: large_string != string
(Evaluate.cpp:662)
```

I checked to see if I could fix it quickly at first, it appears that the
parameters are parsed as non-large strings and OpGraph is picky about
those types matching.

I think this means that these queries will be broken for graphs
that are already partitioned on disk that are not read through this path.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>