### PR TITLE
tsuba: add an interface to read number of rows

### DIFF
--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -68,6 +68,10 @@ public:
   ///   \param uri an identifier for a parquet file
   katana::Result<int32_t> NumColumns(const katana::Uri& uri);
 
+  /// Get the number of rows for the table stored in a parquet file
+  ///   \param uri an identifier for a parquet file
+  katana::Result<int64_t> NumRows(const katana::Uri& uri);
+
 private:
   ParquetReader(std::optional<Slice> slice, bool make_cannonical)
       : slice_(slice), make_cannonical_{make_cannonical} {}

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -272,13 +272,19 @@ tsuba::ParquetReader::NumColumns(const katana::Uri& uri) {
   }
   std::unique_ptr<parquet::arrow::FileReader> reader(
       std::move(reader_res.value()));
+  return reader->parquet_reader()->metadata()->num_columns();
+}
 
-  std::shared_ptr<arrow::Schema> schema;
-  auto status = reader->GetSchema(&schema);
-  if (!status.ok()) {
-    return KATANA_ERROR(ErrorCode::ArrowError, "reading schema: {}", status);
+Result<int64_t>
+tsuba::ParquetReader::NumRows(const katana::Uri& uri) {
+  auto reader_res = MakeFileReader(uri, 0, 0);
+  if (!reader_res) {
+    return reader_res.error();
   }
-  return schema->num_fields();
+  std::unique_ptr<parquet::arrow::FileReader> reader(
+      std::move(reader_res.value()));
+
+  return reader->parquet_reader()->metadata()->num_rows();
 }
 
 Result<std::shared_ptr<arrow::Table>>


### PR DESCRIPTION
Call should be cheap because it just looks at the metadata.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>