### PR TITLE
tsuba: make arrow tables canonical for all cases

### DIFF
--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -155,9 +155,7 @@ tsuba::ParquetReader::ReadFromUriSliced(const katana::Uri& uri) {
 
   out = out->Slice(row_offset, slice.length);
 
-  // TODO(thunt) re-enable this when query is fixed
-  //return FixTable(std::move(out));
-  return out;
+  return FixTable(std::move(out));
 }
 
 Result<std::shared_ptr<arrow::Table>>


### PR DESCRIPTION
Signed-off-by: Tyler Hunt <thunt@katanagraph.com>