### PR TITLE
tsuba: move parquet transformations into async tasks

### DIFF
--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -14,6 +14,7 @@ add_dependencies(lib tsuba tsuba-preload)
 
 set(sources
   src/AddProperties.cpp
+  src/AsyncOpGroup.cpp
   src/Errors.cpp
   src/FaultTest.cpp
   src/file.cpp
@@ -34,6 +35,7 @@ set(sources
   src/RDGPartHeader.cpp
   src/RDGPrefix.cpp
   src/RDGSlice.cpp
+  src/ReadGroup.cpp
   src/tsuba.cpp
   src/WriteGroup.cpp
 )

--- a/libtsuba/include/tsuba/AsyncOpGroup.h
+++ b/libtsuba/include/tsuba/AsyncOpGroup.h
@@ -1,0 +1,39 @@
+#ifndef KATANA_LIBTSUBA_TSUBA_ASYNCOPGROUP_H_
+#define KATANA_LIBTSUBA_TSUBA_ASYNCOPGROUP_H_
+
+#include <future>
+#include <list>
+
+#include "katana/Result.h"
+
+namespace tsuba {
+
+class AsyncOpGroup {
+public:
+  struct AsyncOp {
+    std::future<katana::Result<void>> result;
+    std::string location;
+    std::function<katana::Result<void>()> on_complete;
+  };
+
+  /// Add future to the list of futures this descriptor will wait for, note
+  /// the file name for debugging.
+  void AddOp(
+      std::future<katana::Result<void>> future, std::string file,
+      const std::function<katana::Result<void>()>& on_complete);
+
+  /// Wait until all operations this descriptor knows about have completed
+  katana::Result<void> Finish();
+  /// wait for the op at the head of the list, return true if there was one
+  bool FinishOne();
+
+private:
+  std::list<AsyncOp> pending_ops_;
+  uint64_t errors_{0};
+  uint64_t total_{0};
+  katana::Result<void> last_error_{katana::ResultSuccess()};
+};
+
+}  // namespace tsuba
+
+#endif

--- a/libtsuba/include/tsuba/FileFrame.h
+++ b/libtsuba/include/tsuba/FileFrame.h
@@ -20,7 +20,10 @@ class KATANA_EXPORT FileFrame : public arrow::io::OutputStream {
   uint64_t cursor_;
   bool valid_ = false;
   bool synced_ = false;
+
   katana::Result<void> GrowBuffer(int64_t accommodate);
+
+  katana::Result<void> MapContguousExtension(uint64_t new_size);
 
 public:
   FileFrame() = default;

--- a/libtsuba/include/tsuba/ParquetWriter.h
+++ b/libtsuba/include/tsuba/ParquetWriter.h
@@ -28,8 +28,8 @@ public:
   /// \param name will become the name of the column in the table
   /// \param opts controls things like output format
   static katana::Result<std::unique_ptr<ParquetWriter>> Make(
-      std::shared_ptr<arrow::ChunkedArray> array, const std::string& name,
-      WriteOpts opts = WriteOpts::Defaults());
+      const std::shared_ptr<arrow::ChunkedArray>& array,
+      const std::string& name, WriteOpts opts = WriteOpts::Defaults());
 
   /// \returns a Writer that will write a table to a storage location
   /// \param table the table to be written out
@@ -55,7 +55,7 @@ private:
   std::shared_ptr<parquet::ArrowWriterProperties> StandardArrowProperties();
 
   katana::Result<void> StoreParquet(
-      const arrow::Table& table, const katana::Uri& uri,
+      std::shared_ptr<arrow::Table> table, const katana::Uri& uri,
       tsuba::WriteGroup* desc);
 
   std::shared_ptr<arrow::Table> table_;

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -17,6 +17,7 @@
 #include "tsuba/FileView.h"
 #include "tsuba/PartitionMetadata.h"
 #include "tsuba/RDGLineage.h"
+#include "tsuba/ReadGroup.h"
 #include "tsuba/WriteGroup.h"
 #include "tsuba/tsuba.h"
 

--- a/libtsuba/include/tsuba/ReadGroup.h
+++ b/libtsuba/include/tsuba/ReadGroup.h
@@ -1,0 +1,63 @@
+#ifndef KATANA_LIBTSUBA_TSUBA_READGROUP_H_
+#define KATANA_LIBTSUBA_TSUBA_READGROUP_H_
+
+#include <future>
+#include <list>
+#include <memory>
+
+#include "katana/Result.h"
+#include "tsuba/AsyncOpGroup.h"
+
+namespace tsuba {
+
+/// Track multiple, outstanding async writes and provide a mechanism to ensure
+/// that they have all completed
+class ReadGroup {
+public:
+  static katana::Result<std::unique_ptr<ReadGroup>> Make();
+
+  /// Wait until all operations this descriptor knows about have completed
+  katana::Result<void> Finish();
+
+  /// Add future to the list of futures this ReadGroup will wait for, note
+  /// the file name for debugging. `on_complete` is guaranteed to be called
+  /// in FIFO order
+  void AddOp(
+      std::future<katana::Result<void>> future, std::string file,
+      const std::function<katana::Result<void>()>& on_complete);
+
+  /// same as AddOp, but the future may return a data type which can then be
+  /// consumed by on_complete
+  template <typename RetType>
+  void AddReturnsOp(
+      std::future<katana::Result<RetType>> future, const std::string& file,
+      const std::function<katana::Result<void>(RetType)>& on_complete) {
+    // n.b., make shared instead of unique because move capture below prevents
+    // passing generic_complete_fn as a std::function
+    auto ret_val = std::make_shared<RetType>();
+    auto new_future = std::async(
+        std::launch::deferred,
+        [future = std::move(future),
+         &ret_val_storage = *ret_val]() mutable -> katana::Result<void> {
+          auto res = future.get();
+          if (!res) {
+            return res.error();
+          }
+          ret_val_storage = res.value();
+          return katana::ResultSuccess();
+        });
+
+    std::function<katana::Result<void>()> generic_complete_fn =
+        [ret_val, on_complete]() -> katana::Result<void> {
+      return on_complete(std::move(*ret_val));
+    };
+    AddOp(std::move(new_future), file, generic_complete_fn);
+  }
+
+private:
+  AsyncOpGroup async_op_group_;
+};
+
+}  // namespace tsuba
+
+#endif

--- a/libtsuba/include/tsuba/WriteGroup.h
+++ b/libtsuba/include/tsuba/WriteGroup.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "katana/Result.h"
+#include "tsuba/AsyncOpGroup.h"
 #include "tsuba/FileFrame.h"
 #include "tsuba/file.h"
 
@@ -21,17 +22,10 @@ class WriteGroup {
   };
 
   std::string tag_;
-  std::list<AsyncOp> pending_ops_;
   std::atomic<uint64_t> outstanding_size_{0};
-  uint64_t errors_{0};
-  uint64_t total_{0};
-  katana::Result<void> last_error_{katana::ResultSuccess()};
+  AsyncOpGroup async_op_group_;
 
   WriteGroup(std::string tag) : tag_(std::move(tag)){};
-
-  /// Wait for the next op if there is one, account errors. Returns true if
-  /// there was a next op
-  bool Drain();
 
 public:
   static constexpr uint64_t kMaxOutstandingSize = 10ULL << 30;  // 10 GB

--- a/libtsuba/src/AsyncOpGroup.cpp
+++ b/libtsuba/src/AsyncOpGroup.cpp
@@ -1,0 +1,51 @@
+#include "tsuba/AsyncOpGroup.h"
+
+bool
+tsuba::AsyncOpGroup::FinishOne() {
+  auto op_it = pending_ops_.begin();
+  if (op_it == pending_ops_.end()) {
+    return false;
+  }
+  auto res = op_it->result.get();
+  if (!res) {
+    KATANA_LOG_DEBUG(
+        "async op for {} returned {}", op_it->location, res.error());
+    errors_++;
+    last_error_ = res.error();
+  } else {
+    res = op_it->on_complete();
+    if (!res) {
+      KATANA_LOG_DEBUG(
+          "complete cb for async op for {} returned {}", op_it->location,
+          res.error());
+    }
+  }
+  pending_ops_.erase(op_it);
+  return true;
+}
+
+katana::Result<void>
+tsuba::AsyncOpGroup::Finish() {
+  while (FinishOne()) {
+    // Wait for all ops
+  }
+
+  if (errors_ > 0) {
+    return last_error_.error().WithContext(
+        "{} of {} async write ops returned errors", errors_, total_);
+  }
+
+  return last_error_;
+}
+
+void
+tsuba::AsyncOpGroup::AddOp(
+    std::future<katana::Result<void>> future, std::string file,
+    const std::function<katana::Result<void>()>& on_complete) {
+  pending_ops_.emplace_back(AsyncOp{
+      .result = std::move(future),
+      .location = std::move(file),
+      .on_complete = on_complete,
+  });
+  total_ += 1;
+}

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -9,6 +9,7 @@
 katana::Result<void>
 tsuba::RDGSlice::DoMake(
     const katana::Uri& metadata_dir, const SliceArg& slice) {
+  ReadGroup grp;
   katana::Uri t_path = metadata_dir.Join(core_->part_header().topology_path());
 
   if (auto res = core_->topology_file_storage().Bind(
@@ -20,7 +21,7 @@ tsuba::RDGSlice::DoMake(
 
   auto node_result = AddPropertySlice(
       metadata_dir, core_->part_header().node_prop_info_list(),
-      slice.node_range,
+      slice.node_range, &grp,
       [rdg = this](const std::shared_ptr<arrow::Table>& props) {
         return rdg->core_->AddNodeProperties(props);
       });
@@ -30,7 +31,7 @@ tsuba::RDGSlice::DoMake(
 
   auto edge_result = AddPropertySlice(
       metadata_dir, core_->part_header().edge_prop_info_list(),
-      slice.edge_range,
+      slice.edge_range, &grp,
       [rdg = this](const std::shared_ptr<arrow::Table>& props) {
         return rdg->core_->AddEdgeProperties(props);
       });
@@ -38,7 +39,7 @@ tsuba::RDGSlice::DoMake(
     return edge_result.error();
   }
 
-  return katana::ResultSuccess();
+  return grp.Finish();
 }
 
 katana::Result<tsuba::RDGSlice>

--- a/libtsuba/src/ReadGroup.cpp
+++ b/libtsuba/src/ReadGroup.cpp
@@ -1,0 +1,13 @@
+#include "tsuba/ReadGroup.h"
+
+void
+tsuba::ReadGroup::AddOp(
+    std::future<katana::Result<void>> future, std::string file,
+    const std::function<katana::Result<void>()>& on_complete) {
+  async_op_group_.AddOp(std::move(future), std::move(file), on_complete);
+}
+
+katana::Result<void>
+tsuba::ReadGroup::Finish() {
+  return async_op_group_.Finish();
+}


### PR DESCRIPTION
These transformations are single threaded and slow so try to overlap
them.

Some data:
For a graph with 1mil nodes, 100mil edges, 1 node property (string), and 5 edge properties (mix of types), the RDG is 2GB on disk.
 
Writes:
| Hosts     | Before |  After | Speedup |
| -------- | ------- |------| ----------|
| 1  |  41.54s | 22.40s   |  1.8X |
| 4  |   14.2s |  8.6s    | 1.6X |

Reads:
| Hosts     | Before |  After | Speedup |
| -------- | ------- |------| ----------|
| 1  |  58.4s | 23.6s   |  2.46X |
| 4  |   17.7s |  7.25s    | 2.45X |

(All machines have 32 cores, 25Gbps NICs, 256GB ram, numbers are average of 5 runs)


Signed-off-by: Tyler Hunt <thunt@katanagraph.com>