### PR TITLE
tsuba: add write options struct

### DIFF
--- a/libtsuba/include/tsuba/ParquetWriter.h
+++ b/libtsuba/include/tsuba/ParquetWriter.h
@@ -2,6 +2,7 @@
 #define KATANA_LIBTSUBA_TSUBA_PARQUETWRITER_H_
 
 #include <arrow/api.h>
+#include <parquet/properties.h>
 
 #include "katana/Result.h"
 #include "katana/Uri.h"
@@ -11,26 +12,54 @@ namespace tsuba {
 
 class KATANA_EXPORT ParquetWriter {
 public:
+  struct WriteOpts {
+    /// int64 timestamps with nanosecond resolution requires Parquet version
+    /// 2.0. In Arrow to Parquet version 1.0, nanosecond timestamps will get
+    /// truncated to milliseconds.
+    parquet::ParquetVersion::type parquet_version{
+        parquet::ParquetVersion::PARQUET_2_0};
+    parquet::ParquetDataPageVersion data_page_version{
+        parquet::ParquetDataPageVersion::V2};
+    static WriteOpts Defaults() { return WriteOpts{}; }
+  };
+
   /// \returns a Writer that will write a table consisting of a single column
-  /// \param array named \param name to a storage location
+  /// \param array will become the lone column in the table
+  /// \param name will become the name of the column in the table
+  /// \param opts controls things like output format
   static katana::Result<std::unique_ptr<ParquetWriter>> Make(
-      std::shared_ptr<arrow::ChunkedArray> array, const std::string& name);
+      std::shared_ptr<arrow::ChunkedArray> array, const std::string& name,
+      WriteOpts opts = WriteOpts::Defaults());
 
-  /// \returns a Writer that will write \param table to a storage location
+  /// \returns a Writer that will write a table to a storage location
+  /// \param table the table to be written out
+  /// \param opts controls things like output format
   static katana::Result<std::unique_ptr<ParquetWriter>> Make(
-      std::shared_ptr<arrow::Table> table);
+      std::shared_ptr<arrow::Table> table,
+      WriteOpts opts = WriteOpts::Defaults());
 
-  /// write table out to a storage location \param uri If \param group is null,
+  /// write table out to a storage location. If `group` is null,
   /// the write is synchronous, if not an asynchronous write is started to be
   /// managed by group
+  /// \param uri the storage location to write to
+  /// \param group optional write group to group this write operation with
   katana::Result<void> WriteToUri(
       const katana::Uri& uri, WriteGroup* group = nullptr);
 
 private:
-  ParquetWriter(std::shared_ptr<arrow::Table> table)
-      : table_(std::move(table)) {}
+  ParquetWriter(std::shared_ptr<arrow::Table> table, WriteOpts opts)
+      : table_(std::move(table)), opts_(opts) {}
+
+  std::shared_ptr<parquet::WriterProperties> StandardWriterProperties();
+
+  std::shared_ptr<parquet::ArrowWriterProperties> StandardArrowProperties();
+
+  katana::Result<void> StoreParquet(
+      const arrow::Table& table, const katana::Uri& uri,
+      tsuba::WriteGroup* desc);
 
   std::shared_ptr<arrow::Table> table_;
+  WriteOpts opts_;
 };
 
 }  // namespace tsuba


### PR DESCRIPTION
For now let's you change the version of the output format. This is not
useful for reading and writing RDGs where we control both ends of the
operation, but it _is_ useful when we would like to use this interface
to write parquet files that should be usable by another consumer,
e.g., [BigQuery](https://issuetracker.google.com/issues/116699318).

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>