### PR TITLE
Basic support for global edge ids

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -240,11 +240,24 @@ public:
 
   // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
   // really a ChunkedArray of one chunk, change to arrow::Array.
-  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_ids() const {
-    return rdg_.host_to_owned_global_ids();
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
+      const {
+    return rdg_.host_to_owned_global_node_ids();
   }
-  void set_host_to_owned_global_ids(std::shared_ptr<arrow::ChunkedArray>&& a) {
-    rdg_.set_host_to_owned_global_ids(std::move(a));
+  void set_host_to_owned_global_node_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    rdg_.set_host_to_owned_global_node_ids(std::move(a));
+  }
+
+  // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
+  // really a ChunkedArray of one chunk, change to arrow::Array.
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
+      const {
+    return rdg_.host_to_owned_global_edge_ids();
+  }
+  void set_host_to_owned_global_edge_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    rdg_.set_host_to_owned_global_edge_ids(std::move(a));
   }
 
   // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -138,11 +138,22 @@ public:
     mirror_nodes_ = std::move(a);
   }
 
-  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_ids() const {
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
+      const {
     return host_to_owned_global_node_ids_;
   }
-  void set_host_to_owned_global_ids(std::shared_ptr<arrow::ChunkedArray>&& a) {
+  void set_host_to_owned_global_node_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
     host_to_owned_global_node_ids_ = std::move(a);
+  }
+
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
+      const {
+    return host_to_owned_global_edge_ids_;
+  }
+  void set_host_to_owned_global_edge_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    host_to_owned_global_edge_ids_ = std::move(a);
   }
 
   const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
@@ -195,6 +206,7 @@ private:
   // Called while constructing to put these arrays into a usable state for Distribution
   void InitArrowVectors();
   std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
+  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_edge_ids_;
   std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
   std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;
 

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -139,10 +139,10 @@ public:
   }
 
   const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_ids() const {
-    return host_to_owned_global_ids_;
+    return host_to_owned_global_node_ids_;
   }
   void set_host_to_owned_global_ids(std::shared_ptr<arrow::ChunkedArray>&& a) {
-    host_to_owned_global_ids_ = std::move(a);
+    host_to_owned_global_node_ids_ = std::move(a);
   }
 
   const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
@@ -194,7 +194,7 @@ private:
   std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
   // Called while constructing to put these arrays into a usable state for Distribution
   void InitArrowVectors();
-  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_ids_;
+  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
   std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
   std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;
 


### PR DESCRIPTION
The basic in-memory and on-storage graph representations need to be updated to support differentiated global and local edge ids.