### PR TITLE
Restrict ResultSuccess to Result<void>

### DIFF
--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -249,7 +249,7 @@ operator!=(const ErrorInfo& a, const ErrorInfo& b) {
   return !(a == b);
 }
 
-inline auto
+inline Result<void>
 ResultSuccess() {
   return BOOST_OUTCOME_V2_NAMESPACE::success();
 }


### PR DESCRIPTION
Prevents accidental default initialization resulting in nullptr. Motivating example:
```c++
katana::Result<std::shared_ptr<int>> MakeInt() {
  auto val = std::make_shared<int>();
  *val = 5;
  return katana::ResultSuccess();
}

int v = *(MakeInt().value());
```
Previously this case would compile and segfault, as the default-initialized `shared_ptr` was null.
Now it will fail at compile time, as `ResultSuccess` returns a `Result<void>` which is not implicitly convertible.