### PR TITLE
galois/stats: don't write anything if stream is empty

### DIFF
--- a/libgalois/src/Statistics.cpp
+++ b/libgalois/src/Statistics.cpp
@@ -256,7 +256,11 @@ katana::StatManager::Print() {
   std::ostringstream out;
   PrintStats(out);
 
-  if (auto res = tsuba::FileStore(impl_->outfile_, out.str()); !res) {
+  std::string stats = out.str();
+  if (stats.empty()) {
+    return;
+  }
+  if (auto res = tsuba::FileStore(impl_->outfile_, stats); !res) {
     KATANA_LOG_ERROR("printing stats: {}", res.error());
   }
 }


### PR DESCRIPTION
All hosts follow this code path, and we were causing problems when
different hosts stepped on each other; sometimes overwriting stats with
a zero length file, sometimes triggering and error from google storage
because of a race.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>