### PR TITLE
tsuba: add option for parquet writer to write blocked files

### DIFF
--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -302,6 +302,12 @@ KATANA_EXPORT void DiffFormatTo(
     const std::shared_ptr<arrow::ChunkedArray>& a1,
     size_t approx_total_characters = 150);
 
+/// Estimate the amount of memory this array is using
+/// n.b. Estimate is best effort when array is a slice or a variable type like
+///   large_string; it will be an upper bound in those cases
+KATANA_EXPORT uint64_t
+ApproxArrayMemUse(const std::shared_ptr<arrow::Array>& array);
+
 }  // namespace katana
 
 #endif

--- a/libsupport/include/katana/Uri.h
+++ b/libsupport/include/katana/Uri.h
@@ -52,12 +52,12 @@ public:
   /// XXXX is a random alpha numeric string
   Uri RandFile(std::string_view prefix) const;
 
-  friend Uri operator+(const Uri& lhs, char rhs);
+  Uri operator+(char rhs) const;
+  Uri operator+(const std::string& rhs) const;
 };
 
 KATANA_EXPORT bool operator==(const Uri& lhs, const Uri& rhs);
 KATANA_EXPORT bool operator!=(const Uri& lhs, const Uri& rhs);
-KATANA_EXPORT Uri operator+(const Uri& lhs, char rhs);
 
 }  // namespace katana
 

--- a/libsupport/src/Uri.cpp
+++ b/libsupport/src/Uri.cpp
@@ -226,8 +226,13 @@ operator!=(const Uri& lhs, const Uri& rhs) {
 }
 
 Uri
-operator+(const Uri& lhs, char rhs) {
-  return Uri(lhs.scheme_, lhs.path_ + rhs);
+Uri::operator+(char rhs) const {
+  return Uri(scheme_, path_ + rhs);
+}
+
+Uri
+Uri::operator+(const std::string& rhs) const {
+  return Uri(scheme_, path_ + rhs);
 }
 
 }  // namespace katana

--- a/libtsuba/src/AsyncOpGroup.cpp
+++ b/libtsuba/src/AsyncOpGroup.cpp
@@ -8,14 +8,14 @@ tsuba::AsyncOpGroup::FinishOne() {
   }
   auto res = op_it->result.get();
   if (!res) {
-    KATANA_LOG_DEBUG(
+    KATANA_LOG_ERROR(
         "async op for {} returned {}", op_it->location, res.error());
     errors_++;
     last_error_ = res.error();
   } else {
     res = op_it->on_complete();
     if (!res) {
-      KATANA_LOG_DEBUG(
+      KATANA_LOG_ERROR(
           "complete cb for async op for {} returned {}", op_it->location,
           res.error());
     }


### PR DESCRIPTION
Large files are sometimes hard to swallow for downstream processors,
and writing many files means we can do the transformation in parallel.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>