### PR TITLE
python: Simplify black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [build-system]
 requires = ["setuptools", "wheel", "Cython (>=0.29.12)", "jinja2", "pyarrow (>=1.0,<3.0.dev)", "numpy", "packaging"]
+
+[tool.black]
+line-length = 120

--- a/scripts/check_python_format.sh
+++ b/scripts/check_python_format.sh
@@ -15,16 +15,9 @@ if [ "$1" == "-fix" ]; then
 fi
 
 ROOTS="$@"
-PRUNE_LIST="notebook-home .git build*"
-
-emit_prunes() {
-  for p in $PRUNE_LIST; do echo "-name $p -prune -o"; done | xargs
-}
-
-FILES=$(find ${ROOTS} $(emit_prunes) -name '*.py' -print | xargs)
 
 if [ -n "${FIX}" ]; then
-  ${PYFMT} ${FILES}
+  ${PYFMT} "$@"
 else
-  ${PYFMT} --check ${FILES}
+  ${PYFMT} --check "$@"
 fi


### PR DESCRIPTION
Black knows to read pyproject.toml for project-wide configuration. Set
the formatting configuration there to help people with IDEs that pick up
on this or if someone wants to run black directly. Leave the command
line argument configuration around as well because some uses of
check_python_format occur in repos without pyproject.toml.

Also, remove redundant ignores and pruning. Black already ignores
directories named .git or build.