### PR TITLE
package: Do not package apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,6 @@ macro(katana_cpack_open_components)
 
   cpack_add_component(tools GROUP tools_pkg DEPENDS shlib)
 
-  cpack_add_component(apps GROUP apps_pkg DEPENDS shlib)
-
   cpack_add_component(python GROUP python_pkg DEPENDS shlib)
 endmacro()
 

--- a/cmake/Modules/KatanaBuildCommon.cmake
+++ b/cmake/Modules/KatanaBuildCommon.cmake
@@ -459,7 +459,7 @@ set(CPACK_RPM_COMPONENT_INSTALL TRUE)
 # Create a package for each component group.
 set(CPACK_COMPONENTS_GROUPING ONE_PER_GROUP)
 
-# Setup the cpack component groups: dev_pkg, shlib_pkg, tools_pkg, apps_pkg.
+# Setup the cpack component groups: dev_pkg, shlib_pkg, tools_pkg.
 # After calling this, call cpack_add_component to add components to the groups.
 macro(katana_setup_cpack_component_groups NAME SUFFIX)
   # The groups are named *_pkg to distinguish them from the components themselves.
@@ -484,13 +484,6 @@ macro(katana_setup_cpack_component_groups NAME SUFFIX)
   cpack_add_component_group(tools_pkg)
   set(CPACK_COMPONENT_TOOLS_PKG_DESCRIPTION "Katana Graph system management and data processing tools")
   set(CPACK_COMPONENT_TOOLS_PKG_DEPENDS shlib_pkg)
-
-  set(CPACK_DEBIAN_APPS_PKG_PACKAGE_NAME "${NAME}-apps${SUFFIX}")
-  set(CPACK_RPM_APPS_PKG_PACKAGE_NAME "${NAME}-apps${SUFFIX}")
-  # No addition dependencies on apps_pkg since it depends on shlib_pkg
-  cpack_add_component_group(apps_pkg)
-  set(CPACK_COMPONENT_APPS_PKG_DESCRIPTION "Katana Graph applications and CLI algorithms")
-  set(CPACK_COMPONENT_APPS_PKG_DEPENDS shlib_pkg tools_pkg)
 
   set(CPACK_DEBIAN_PYTHON_PKG_PACKAGE_NAME "python3-${NAME}${SUFFIX}")
   list(APPEND CPACK_DEBIAN_PYTHON_PKG_PACKAGE_DEPENDS "python3-minimal")

--- a/lonestar/analytics/cpu/betweennesscentrality/CMakeLists.txt
+++ b/lonestar/analytics/cpu/betweennesscentrality/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(betweennesscentrality-cpu betweenness_centrality_cli.cpp)
 add_dependencies(apps betweennesscentrality-cpu)
 target_link_libraries(betweennesscentrality-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS betweennesscentrality-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small-level betweennesscentrality-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" -algo=Level -numberOfSources=4 )
 #add_test_scale(small-async betweennesscentrality-cpu -algo=Async -numberOfSources=4 "${BASEINPUT}/propertygraphs/rmat15")
 add_test_scale(small-outer betweennesscentrality-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" -algo=Outer -numberOfSources=4 )

--- a/lonestar/analytics/cpu/bfs/CMakeLists.txt
+++ b/lonestar/analytics/cpu/bfs/CMakeLists.txt
@@ -1,12 +1,11 @@
 add_executable(bfs-cpu bfs_cli.cpp)
 add_dependencies(apps bfs-cpu)
 target_link_libraries(bfs-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS bfs-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small1 bfs-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" --edgePropertyName=value --algo=SyncTile)
 
 #add_executable(bfs-directionopt-cpu bfsDirectionOpt.cpp)
 #add_dependencies(apps bfs-directionopt-cpu)
 #target_link_libraries(bfs-directionopt-cpu PRIVATE Katana::galois lonestar)
-#install(TARGETS bfs-directionopt-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 #add_test_scale(small1 bfs-directionopt-cpu "${BASEINPUT}/reference/structured/rome99.gr")
 #add_test_scale(small2 bfs-directionopt-cpu "${BASEINPUT}/scalefree/rmat10.gr")

--- a/lonestar/analytics/cpu/bipart/CMakeLists.txt
+++ b/lonestar/analytics/cpu/bipart/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(bipart-cpu Helper.cpp Coarsening.cpp Partitioning.cpp Refine.cpp Metric.cpp Bipart.cpp) 
 add_dependencies(apps bipart-cpu)
 target_link_libraries(bipart-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS bipart-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small1 bipart-cpu INPUT ibm01 INPUT_URI "${BASEINPUT}/partitioning/ibm01.hgr" NO_VERIFY -hMetisGraph)

--- a/lonestar/analytics/cpu/connected-components/CMakeLists.txt
+++ b/lonestar/analytics/cpu/connected-components/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(connected-components-cpu connected_components_cli.cpp)
 add_dependencies(apps connected-components-cpu)
 target_link_libraries(connected-components-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS connected-components-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small connected-components-cpu NO_VERIFY INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_symmetric" "-symmetricGraph" "-algo=LabelProp")

--- a/lonestar/analytics/cpu/gmetis/CMakeLists.txt
+++ b/lonestar/analytics/cpu/gmetis/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(gmetis-cpu Coarsening.cpp GMetis.cpp Metric.cpp Partitioning.cpp Refine.cpp)
 add_dependencies(apps gmetis-cpu)
 target_link_libraries(gmetis-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS gmetis-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 # Disable failing test (issue #116).
 add_test_scale(small1 gmetis-cpu "${BASEINPUT}/reference/structured/rome99.gr" "-numPartitions=4" NOT_QUICK NO_VERIFY)

--- a/lonestar/analytics/cpu/independentset/CMakeLists.txt
+++ b/lonestar/analytics/cpu/independentset/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(independentset-cpu independent_set_cli.cpp)
 add_dependencies(apps independentset-cpu)
 target_link_libraries(independentset-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS independentset-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small independentset-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat10_symmetric" NO_VERIFY "--algo=Priority" "--symmetricGraph")

--- a/lonestar/analytics/cpu/jaccard/CMakeLists.txt
+++ b/lonestar/analytics/cpu/jaccard/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(jaccard-cpu jaccard_cli.cpp)
 add_dependencies(apps jaccard-cpu)
 target_link_libraries(jaccard-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS jaccard-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 # add_test_scale(small1 jaccard-cpu "${BASEINPUT}/reference/structured/rome99.gr")
 add_test_scale(small2 jaccard-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_cleaned_symmetric" NO_VERIFY)

--- a/lonestar/analytics/cpu/k-core/CMakeLists.txt
+++ b/lonestar/analytics/cpu/k-core/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(k-core-cpu kcore_cli.cpp)
 add_dependencies(apps k-core-cpu)
 target_link_libraries(k-core-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS k-core-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small k-core-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_symmetric" --kCoreNumber=100 -symmetricGraph --algo=Synchronous)

--- a/lonestar/analytics/cpu/k-shortest-paths/CMakeLists.txt
+++ b/lonestar/analytics/cpu/k-shortest-paths/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(k-shortest-paths-cpu SSSP.cpp)
 add_dependencies(apps k-shortest-paths-cpu)
 target_link_libraries(k-shortest-paths-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS k-shortest-paths-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small1 k-shortest-paths-cpu NO_VERIFY INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" -delta=8 --edgePropertyName=value)

--- a/lonestar/analytics/cpu/k-shortest-simple-paths/CMakeLists.txt
+++ b/lonestar/analytics/cpu/k-shortest-simple-paths/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(k-shortest-simple-paths-cpu yen_k_SSSP.cpp)
 add_dependencies(apps k-shortest-simple-paths-cpu)
 target_link_libraries(k-shortest-simple-paths-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS k-shortest-simple-paths-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small1 k-shortest-simple-paths-cpu NO_VERIFY INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" -delta=8 --edgePropertyName=value)

--- a/lonestar/analytics/cpu/k-truss/CMakeLists.txt
+++ b/lonestar/analytics/cpu/k-truss/CMakeLists.txt
@@ -1,10 +1,9 @@
 add_executable(k-truss-cpu k_truss_cli.cpp)
 add_dependencies(apps k-truss-cpu)
 target_link_libraries(k-truss-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS k-truss-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_executable(verify-k-truss Verify.cpp)
 add_dependencies(apps verify-k-truss)
 target_link_libraries(verify-k-truss PRIVATE Katana::galois lonestar)
-install(TARGETS verify-k-truss DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small k-truss-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat10_symmetric" NO_VERIFY -kTrussNumber=4 -symmetricGraph)

--- a/lonestar/analytics/cpu/local_clustering_coefficient/CMakeLists.txt
+++ b/lonestar/analytics/cpu/local_clustering_coefficient/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(local-clustering-coefficient-cpu local_clustering_coefficient_cli.cpp)
 add_dependencies(apps local-clustering-coefficient-cpu)
 target_link_libraries(local-clustering-coefficient-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS local-clustering-coefficient-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small-ordered-atomics-relabel local-clustering-coefficient-cpu INPUT rmat15_cleaned_symmetric INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_cleaned_symmetric" NOT_QUICK NO_VERIFY -symmetricGraph -algo=orderedCountAtomics --relabel=true)
 add_test_scale(small-ordered-atomics local-clustering-coefficient-cpu  INPUT rmat15_cleaned_symmetric INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_cleaned_symmetric" NOT_QUICK NO_VERIFY -symmetricGraph -algo=orderedCountAtomics)

--- a/lonestar/analytics/cpu/louvain_clustering/CMakeLists.txt
+++ b/lonestar/analytics/cpu/louvain_clustering/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(louvain-clustering-cpu louvain_clustering_cli.cpp)
 add_dependencies(apps louvain-clustering-cpu)
 target_link_libraries(louvain-clustering-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS louvain-clustering-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small louvain-clustering-cpu NO_VERIFY INPUT rmat10 INPUT_URI "${BASEINPUT}/propertygraphs/rmat10_symmetric" "-symmetricGraph" --edgePropertyName=value) 
 

--- a/lonestar/analytics/cpu/matching/CMakeLists.txt
+++ b/lonestar/analytics/cpu/matching/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(maximum-cardinality-matching-cpu bipartite-mcm.cpp)
 add_dependencies(apps maximum-cardinality-matching-cpu)
 target_link_libraries(maximum-cardinality-matching-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS maximum-cardinality-matching-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small1 maximum-cardinality-matching-cpu NO_VERIFY -symmetricGraph -inputType generated -n 100 -numEdges 1000 -numGroups 10 -seed 0)
 add_test_scale(small2 maximum-cardinality-matching-cpu NO_VERIFY -symmetricGraph -inputType generated -n 100 -numEdges 10000 -numGroups 100 -seed 0)

--- a/lonestar/analytics/cpu/matrixcompletion/CMakeLists.txt
+++ b/lonestar/analytics/cpu/matrixcompletion/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_executable(matrixcompletion-cpu matrixCompletion.cpp)
 add_dependencies(apps matrixcompletion-cpu)
 target_link_libraries(matrixcompletion-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS matrixcompletion-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
-
 
 if(CMAKE_COMPILER_IS_GNUCC)
   target_compile_options(matrixcompletion-cpu PRIVATE -ffast-math)

--- a/lonestar/analytics/cpu/pagerank/CMakeLists.txt
+++ b/lonestar/analytics/cpu/pagerank/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(pagerank-cpu pagerank-cli.cpp)
 add_dependencies(apps pagerank-cpu)
 target_link_libraries(pagerank-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS pagerank-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small pagerank-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" -maxIterations=100 -algo=PushAsync)
 

--- a/lonestar/analytics/cpu/pointstoanalysis/CMakeLists.txt
+++ b/lonestar/analytics/cpu/pointstoanalysis/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(pointstoanalysis-cpu PointsTo.cpp)
 add_dependencies(apps pointstoanalysis-cpu)
 target_link_libraries(pointstoanalysis-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS pointstoanalysis-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small pointstoanalysis-cpu INPUT gap_constraints INPUT_URI "${BASEINPUT}/java/pta/gap_constraints.txt" NO_VERIFY)

--- a/lonestar/analytics/cpu/preflowpush/CMakeLists.txt
+++ b/lonestar/analytics/cpu/preflowpush/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_executable(preflowpush-cpu Preflowpush.cpp)
 add_dependencies(apps preflowpush-cpu)
 target_link_libraries(preflowpush-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS preflowpush-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 add_test_scale(small1 preflowpush-cpu INPUT torus5 INPUT_URI "${BASEINPUT}/reference/structured/torus5.gr" NO_VERIFY "-sourceNode=0" "-sinkNode=10")

--- a/lonestar/analytics/cpu/random-walks/CMakeLists.txt
+++ b/lonestar/analytics/cpu/random-walks/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(random-walk-cpu random_walks_cli.cpp)
 add_dependencies(apps random-walk-cpu)
 target_link_libraries(random-walk-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS random-walk-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small random-walk-cpu NO_VERIFY INPUT rmat10 INPUT_URI "${BASEINPUT}/propertygraphs/rmat10_symmetric" "-symmetricGraph" "-algo=Node2Vec" "-walkLength=3")

--- a/lonestar/analytics/cpu/spanningtree/CMakeLists.txt
+++ b/lonestar/analytics/cpu/spanningtree/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(minimum-spanningtree-cpu Boruvka.cpp)
 add_dependencies(apps minimum-spanningtree-cpu)
 target_link_libraries(minimum-spanningtree-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS minimum-spanningtree-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small1 minimum-spanningtree-cpu INPUT rmat10 INPUT_URI "${BASEINPUT}/scalefree/rmat10.gr" NO_VERIFY)
 add_test_scale(small2 minimum-spanningtree-cpu INPUT rome99 INPUT_URI "${BASEINPUT}/reference/structured/rome99.gr" NO_VERIFY)

--- a/lonestar/analytics/cpu/sssp/CMakeLists.txt
+++ b/lonestar/analytics/cpu/sssp/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(sssp-cpu sssp_cli.cpp)
 add_dependencies(apps sssp-cpu)
 target_link_libraries(sssp-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS sssp-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small1 sssp-cpu INPUT rmat15 INPUT_URI "${BASEINPUT}/propertygraphs/rmat15" -delta=8 --edgePropertyName=value --algo=Automatic)
 #add_test_scale(small2 sssp-cpu "${BASEINPUT}/propertygraphs/rmat15" -delta=8 --edgePropertyName=value)

--- a/lonestar/analytics/cpu/subgraph_extraction/CMakeLists.txt
+++ b/lonestar/analytics/cpu/subgraph_extraction/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(subgraph-extraction-cpu subgraph_extraction_cli.cpp)
 add_dependencies(apps subgraph-extraction-cpu)
 target_link_libraries(subgraph-extraction-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS subgraph-extraction-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
+
 add_test_scale(small1 subgraph-extraction-cpu INPUT rmat10 INPUT_URI "${BASEINPUT}/propertygraphs/rmat10" --nodes="0 3 11 120" NO_VERIFY)

--- a/lonestar/analytics/cpu/triangle-counting/CMakeLists.txt
+++ b/lonestar/analytics/cpu/triangle-counting/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(triangle-counting-cpu triangle_counting_cli.cpp)
 add_dependencies(apps triangle-counting-cpu)
 target_link_libraries(triangle-counting-cpu PRIVATE Katana::galois lonestar)
-install(TARGETS triangle-counting-cpu DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
 add_test_scale(small-ordered-relabel triangle-counting-cpu INPUT rmat15_cleaned_symmetric INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_cleaned_symmetric" NOT_QUICK NO_VERIFY -symmetricGraph -algo=orderedCount --relabel=true)
 add_test_scale(small-ordered triangle-counting-cpu  INPUT rmat15_cleaned_symmetric INPUT_URI "${BASEINPUT}/propertygraphs/rmat15_cleaned_symmetric" NOT_QUICK NO_VERIFY -symmetricGraph -algo=orderedCount)

--- a/lonestar/tutorial_examples/CMakeLists.txt
+++ b/lonestar/tutorial_examples/CMakeLists.txt
@@ -2,7 +2,6 @@ function(app name)
   add_executable(${name} ${ARGN})
   add_dependencies(apps ${name})
   target_link_libraries(${name} PRIVATE Katana::galois lonestar)
-  install(TARGETS ${name} DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 endfunction()
 
 app(example-sssp-push-simple SSSPPushSimple.cpp)


### PR DESCRIPTION
Applications take a lot of space (500 MB) and they slow down packaging
because we spend time compressing, uncompressing and hashing them. No
one needs to use them currently so omit them from any packages we make.