### PR TITLE
build: Use goimports over gofmt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -482,7 +482,7 @@ in terms of feedback latency, to run these checks locally first.
  * `scripts/check_ifndef.py [-fix] lib*`: checks that header guards are well
  formed.
  * `scripts/check_cpp_format.sh [-fix] lib*`: applies `clang-format` to check style.
- * `scripts/check_go_format.sh [-fix] .`: applies `gofmt` to format go code.
+ * `scripts/check_go_format.sh [-fix] .`: applies `goimports` to format go code.
  * `scripts/check_go_lint.sh .`: applies `golangci-lint` to check check style.
  * `scripts/check_python_format.sh .`: applies `black` to format python code.
 

--- a/scripts/check_go_format.sh
+++ b/scripts/check_go_format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GOFMT=${GOFMT:-gofmt}
+GOFMT=${GOFMT:-goimports -format-only}
 set -eu
 
 if [ $# -eq 0 ]; then
@@ -31,9 +31,9 @@ if [ -z "$FILES" ]; then
 fi
 
 if [ -n "${FIX}" ]; then
-  ${GOFMT} -s -w ${FILES}
+  ${GOFMT} -w ${FILES}
 else
-  FAILED=$(${GOFMT} -s -l ${FILES})
+  FAILED=$(${GOFMT} -l ${FILES})
 fi
 
 if [ -n "${FAILED}" ]; then


### PR DESCRIPTION
goimports sorts imports into groups while gofmt does not.