### PR TITLE
Add build_in_container.py script. And document it.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -133,6 +133,16 @@ jobs:
       - name: Install in docker container
         run: python3 test/install_conda_packages_test.py pkgs ${{matrix.image}}
 
+  test_build_in_container_conda:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Run build_in_container
+        run: scripts/build_in_container.py --build $HOME/build --type conda
+
   lint:
     runs-on: ${{matrix.os}}
     strategy:

--- a/README.md
+++ b/README.md
@@ -27,17 +27,11 @@ Galois is released under the BSD-3-Clause license.
 Building Galois
 ===============
 
-You can checkout the latest release by typing (in a terminal):
-
-```Shell
-git clone -b release-5.0 https://github.com/IntelligentSoftwareSystems/Galois
-```
-
 The master branch will be regularly updated, so you may try out the latest
-development code as well by checking out master branch:
+development code by checking out master branch:
 
 ```Shell
-git clone https://github.com/IntelligentSoftwareSystems/Galois
+git clone https://github.com/KatanaGraph/katana.git
 ```
 
 Dependencies
@@ -151,6 +145,25 @@ in the build directory.
 
 To build the Python API see [Python.md](Python.md).
 
+Compiling in Docker
+-------------------
+
+Instead of setting up a development environment explicitly you can build Katana in docker.
+
+```Shell
+scripts/build_in_container.py -B $BUILD_DIR --type conda
+```
+where `$BUILD_DIR` is a path at which to place the resulting build directory.
+Build types other than `conda` may be supported in the future.
+You can also pass build targets to the command.
+
+For example,
+```Shell
+scripts/build_in_container.py -B ~/katana-build --type conda docs
+```
+will build the documentation (C++ and Python).
+The C++ documentation will be in `~/katana-build/docs/cxx` and the Python documentation will be in `~/katana-build/*_python/`.
+This command also works in the enterprise repository.
 
 Running Galois Applications
 ===========================

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -9,16 +9,19 @@ dependencies:
  - awscli
  - backward-cpp>=1.4
  - benchmark
- - boost-cpp>=1.74
  - black=19.10
+ - boost-cpp>=1.74
  - cmake>=3.17
+ - conan
  - conda-build
  - conda-verify
  - cxx-compiler>=1.1.3
  - cython>=0.29.12
+ - doxygen
  - eigen
  - elfutils
  - fmt>=6.2.1
+ - isort
  - jinja2
  - libcurl>=7.66
  - libxml2>=2.9.10
@@ -29,15 +32,13 @@ dependencies:
  - numba
  - numpy
  - openblas>=0.3.12
+ - packaging
  - parquet-cpp
  - pyarrow
+ - pygithub
  - pytest
  - python>=3.8
+ - setuptools
  - shellcheck
  - sphinx>=3.5.1
  - zlib>=1.2.11
- - setuptools
- - conan
- - pygithub
- - packaging
- - doxygen

--- a/scripts/build_in_container.py
+++ b/scripts/build_in_container.py
@@ -1,0 +1,118 @@
+#! /usr/bin/env python3
+
+import argparse
+import os
+import tarfile
+from pathlib import Path
+from subprocess import PIPE, Popen, check_call, check_output
+from sys import stderr
+
+build_configs = dict(
+    conda=dict(
+        dockerfile="build_in_container_conda.Dockerfile",
+        context_files=[
+            # name in context, name in source directory
+            ("environment.yml", "conda_recipe/environment.yml"),
+            ("open_environment.yml", "external/katana/conda_recipe/environment.yml"),
+        ],
+    )
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build katana in a container using the current source tree.")
+    parser.add_argument(
+        "--tag",
+        type=str,
+        help="Specify the tag for the generated docker image. (default: katana/build-in-container/<type>)",
+        default=None,
+    )
+    parser.add_argument("--build", "-B", type=Path, help="The build directory in the container host.", required=True)
+    parser.add_argument(
+        "--source", "-S", type=Path, help="The root of the source tree to use. Defaults to auto detect.", default=None
+    )
+    parser.add_argument("--type", "-t", type=str, help="The type of build to perform.", default="conda")
+    parser.add_argument("targets", nargs="*", help="The targets to build")
+    parser.add_argument(
+        "--reuse", help="Rebuild the build image even if it already exists.", default=False, action="store_true"
+    )
+    parser.add_argument(
+        "--image-only",
+        help="Only generate the docker image, do not build Katana within the image.",
+        default=False,
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+
+    build_config = build_configs[args.type]
+    if not args.source:
+        args.source = Path(__file__).parent.parent
+    source = Path(args.source).absolute()
+    build = Path(args.build).absolute()
+
+    build.mkdir(exist_ok=True)
+
+    image_tag = args.tag or f"katana/build-in-container/{args.type}"
+
+    has_image = False
+    if image_tag:
+        has_image = len(check_output(["docker", "image", "ls", "--quiet", image_tag])) > 0
+
+    if not has_image or not args.reuse:
+        docker_proc = Popen(["docker", "build", "-t", image_tag, "-"], stdin=PIPE)
+        with docker_proc.stdin, tarfile.open(fileobj=docker_proc.stdin, mode="w:gz") as context_tar:
+            context_tar.add((Path(__file__).parent / build_config["dockerfile"]).resolve(), arcname="Dockerfile")
+            for target_file, source_file in build_config["context_files"]:
+                if (source / source_file).exists():
+                    context_tar.add(source / source_file, arcname=target_file)
+        err_code = docker_proc.wait()
+        if err_code != 0:
+            print(f"Failed to build docker container.", file=stderr)
+            return err_code
+
+    print(f"Docker image tag: {image_tag}")
+
+    targets_str = " ".join(args.targets)
+
+    user = os.getuid()
+    group = os.getgid()
+
+    def make_docker_run_command(katana_version):
+        return [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            f"{user}:{group}",
+            "--env",
+            f"KATANA_VERSION={katana_version}",
+            "--env",
+            f"TARGETS={targets_str}",
+            "--mount",
+            f"type=bind,src={build},dst=/build",
+            "--mount",
+            f"type=bind,src={source},dst=/source",
+            image_tag,
+        ]
+
+    if not args.image_only:
+        build_command = make_docker_run_command(
+            check_output([f"{source}/scripts/version", "show"], cwd=source, encoding="ascii").strip()
+        )
+        check_call(build_command)
+        print("Built Katana in docker using: " + " ".join(build_command))
+        print(f"/build in the container is {build} in the host")
+        print(f"/source in the container is {source} in the host")
+    else:
+        build_command = make_docker_run_command(f"$({source}/scripts/version show)")
+        print(
+            "You can build Katana in docker using:\n\n"
+            + " ".join((f'"{s}"' if " " in s else s) for s in build_command)
+            + "\n"
+        )
+        print("or modify this command to access the build environment in other ways.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_in_container_conda.Dockerfile
+++ b/scripts/build_in_container_conda.Dockerfile
@@ -1,0 +1,49 @@
+ARG DEBIAN_VERSION=buster-slim
+FROM debian:${DEBIAN_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=America/Chicago \
+    APT_GET="apt-get --yes --quiet"
+
+RUN set -eux; \
+    ${APT_GET} update; \
+    ${APT_GET} install curl bzip2 ca-certificates git libnuma1 texlive-font-utils; \
+    ${APT_GET} clean
+
+ENV CONDA_PREFIX=/opt/conda
+ARG MAMBAFORGE_VERSION="4.9.2-7"
+ARG MAMBAFORGE_PLATFORM=Linux-x86_64
+
+RUN set -eux; \
+    curl --location --output /mambaforge.sh "https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VERSION}/Mambaforge-${MAMBAFORGE_VERSION}-${MAMBAFORGE_PLATFORM}.sh"; \
+    bash /mambaforge.sh -b -p $CONDA_PREFIX; \
+    rm /mambaforge.sh; \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \
+    echo "conda activate base" >> /etc/profile.d/z-conda-activate.sh; \
+    /opt/conda/bin/mamba update --quiet --yes --name base --all; \
+    /opt/conda/bin/conda clean --quiet --all --force-pkgs-dirs --yes
+
+ENV PATH="${CONDA_PREFIX}/bin:${PATH}"
+
+# The * is a misuse of globs that makes open_environment.yml optional. The glob
+# will match nothing if the file is missing.
+COPY environment.yml open_environment.yml* ctx/
+
+RUN set -eux; \
+    [ -f ctx/open_environment.yml ] && \
+        mamba env update --name base --file ctx/open_environment.yml; \
+    mamba env update --name base --file ctx/environment.yml; \
+    rm -rf ctx; \
+    conda clean --quiet --all --force-pkgs-dirs --yes
+
+VOLUME /source /build
+WORKDIR /build
+
+ENTRYPOINT ["bash", "-l", "-c", "\"$@\"", "\"$0\""]
+
+ENV CMAKE_SETTINGS="-DKATANA_LANG_BINDINGS=python -DBUILD_DOCS=ON -DBUILD_SHARED_LIBS=ON"
+ENV CMAKE_BUILD_TYPE="Release"
+
+CMD set -eux; \
+    cmake -B /build -S /source -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_SETTINGS}; \
+    cmake --build /build --parallel $(nproc) ${TARGETS:+--target ${TARGETS}}

--- a/scripts/katana_version/git.py
+++ b/scripts/katana_version/git.py
@@ -1,11 +1,11 @@
-import re
 import logging
+import re
 from datetime import datetime
 from functools import cmp_to_key, lru_cache
 from pathlib import Path
 from typing import Tuple, Union
 
-from .commands import action_command, capture_command, CommandError, predicate_command
+from .commands import CommandError, action_command, capture_command, predicate_command
 
 logger = logging.getLogger(__name__)
 
@@ -183,9 +183,11 @@ def simplify_merge_commit(commit, dir):
     """
     parents = get_commit_parents(commit, dir)
     parents.sort(key=cmp_to_key(lambda a, b: is_ancestor_of(a, b, dir=dir)))
-    potential_simplification = parents[-1]
-    if is_same_tree(commit, potential_simplification, dir) and all(
-        is_ancestor_of(p, potential_simplification, dir) for p in parents
+    potential_simplification = parents[-1] if parents else None
+    if (
+        potential_simplification
+        and is_same_tree(commit, potential_simplification, dir)
+        and all(is_ancestor_of(p, potential_simplification, dir) for p in parents)
     ):
         return potential_simplification
     else:

--- a/test/install_conda_packages_test.py
+++ b/test/install_conda_packages_test.py
@@ -1,4 +1,4 @@
-#! /bin/python
+#! /usr/bin/env python3
 
 import argparse
 import tarfile


### PR DESCRIPTION
This PR introduces a script that runs a build in a docker container in conda. This can be extended later to do other builds in containers. @bosconi This should interest you.

This script can also be used to easily build the documentation with just one command. This may help with the documentation work flow. @origandrew 