### PR TITLE
conda: remove explicit dependence on aws-sdk-cpp

### DIFF
--- a/conda_recipe/conda_build_config.yaml
+++ b/conda_recipe/conda_build_config.yaml
@@ -14,7 +14,6 @@ pin_run_as_build:
   arrow-cpp: x
   pyarrow: x
   fmt: x
-  aws-sdk-cpp: x.x
   nlohmann_json: x.x
   libcurl: x.x
   libxml2: x

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -5,7 +5,6 @@ channels:
  - conda-forge
 dependencies:
  - arrow-cpp<3.0.0a0
- - aws-sdk-cpp>=1.7.164,<2.0a0
  - awscli
  - backward-cpp>=1.4
  - benchmark

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ cdt('numactl-devel') }}
     - arrow-cpp {{ arrow_cpp }}
-    - aws-sdk-cpp>=1.7.164,<2.0a0
     - backward-cpp>=1.4
     - boost-cpp>=1.74
     - elfutils
@@ -61,7 +60,6 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - aws-sdk-cpp>=1.7.164,<2.0a0
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
@@ -76,7 +74,6 @@ outputs:
       host:
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - aws-sdk-cpp>=1.7.164,<2.0a0
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
@@ -91,7 +88,6 @@ outputs:
       run:
         - boost-cpp
         - arrow-cpp
-        - aws-sdk-cpp
         - fmt
         - nlohmann_json
         - openblas
@@ -118,7 +114,6 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - aws-sdk-cpp>=1.7.164,<2.0a0
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
@@ -139,7 +134,6 @@ outputs:
       host:
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - aws-sdk-cpp>=1.7.164,<2.0a0
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
@@ -185,7 +179,6 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - aws-sdk-cpp>=1.7.164,<2.0a0
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
@@ -200,7 +193,6 @@ outputs:
       host:
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - aws-sdk-cpp>=1.7.164,<2.0a0
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils


### PR DESCRIPTION
Signed-off-by: Tyler Hunt <thunt@katanagraph.com>