### PR TITLE
Revive python linting by file

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -82,7 +82,7 @@ jobs:
         mamba install -y -q -c conda-forge conda-build boa conda-verify pygithub packaging
 
     ###
-    # Conda build process for two packages
+    # Conda build process
     ###
     - name: Build conda Packages
       run: |
@@ -181,7 +181,7 @@ jobs:
     - name: Check for lint
       run: |
         . .github/workflows/activate_miniconda.sh
-        ./scripts/check_python_lint.sh python test/*.py
+        ./scripts/check_python_lint.sh python test
 
   build_and_test:
     runs-on: ${{matrix.os}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,12 @@ disable = "all"
 #   "unused-import",  # Some imports have important side-effects
 # 
 #   # Too proscriptive
-#   "too-many-statements",
-#   "too-many-locals",
 #   "too-few-public-methods",
+#   "too-many-ancestors",
 #   "too-many-arguments",
+#   "too-many-branches",
+#   "too-many-locals",
+#   "too-many-statements",
 #   "protected-access",
 #   "fixme",
 #   "invalid-name",  # Rules out single letter names
@@ -275,9 +277,7 @@ enable = [
   "superfluous-parens",
   "syntax-error",
   "too-few-format-args",
-  "too-many-ancestors",
   "too-many-boolean-expressions",
-  "too-many-branches",
   "too-many-format-args",
   "too-many-function-args",
   "too-many-instance-attributes",

--- a/python/test/test_cpp_algos.py
+++ b/python/test/test_cpp_algos.py
@@ -4,7 +4,47 @@ from pyarrow import Schema, table
 from pytest import approx, raises
 
 from katana import GaloisError
-from katana.analytics import *
+from katana.analytics import (
+    BetweennessCentralityPlan,
+    BetweennessCentralityStatistics,
+    BfsStatistics,
+    ConnectedComponentsStatistics,
+    IndependentSetPlan,
+    IndependentSetStatistics,
+    JaccardPlan,
+    JaccardStatistics,
+    KCoreStatistics,
+    KTrussStatistics,
+    LouvainClusteringStatistics,
+    PagerankStatistics,
+    SsspStatistics,
+    TriangleCountPlan,
+    betweenness_centrality,
+    bfs,
+    bfs_assert_valid,
+    connected_components,
+    connected_components_assert_valid,
+    find_edge_sorted_by_dest,
+    independent_set,
+    independent_set_assert_valid,
+    jaccard,
+    jaccard_assert_valid,
+    k_core,
+    k_core_assert_valid,
+    k_truss,
+    k_truss_assert_valid,
+    local_clustering_coefficient,
+    louvain_clustering,
+    louvain_clustering_assert_valid,
+    pagerank,
+    pagerank_assert_valid,
+    sort_all_edges_by_dest,
+    sort_nodes_by_degree,
+    sssp,
+    sssp_assert_valid,
+    subgraph_extraction,
+    triangle_count,
+)
 from katana.example_utils import get_input
 from katana.lonestar.analytics.bfs import verify_bfs
 from katana.lonestar.analytics.sssp import verify_sssp

--- a/scripts/check_python_lint.sh
+++ b/scripts/check_python_lint.sh
@@ -2,11 +2,30 @@
 
 set -eu
 
+GIT_ROOT=$(readlink -f $(dirname $0)/..)
+
 if [ $# -eq 0 ]; then
   echo "$(basename $0) <paths>" >&2
   exit 1
 fi
 
 LINT=${PYLINT:-pylint}
+ARGS="-j 0 --rcfile=${GIT_ROOT}/pyproject.toml"
+ROOTS="$@"
+FAILED=
+PRUNE_LIST="build .git"
 
-exec ${LINT} "$@"
+emit_prunes() {
+  for p in ${PRUNE_LIST}; do echo "-name ${p} -prune -o"; done | xargs
+}
+
+while read -d '' filename; do
+  if ! ${LINT} ${ARGS} "${filename}"; then
+    echo "${filename} NOT OK"
+    FAILED=1
+  fi
+done < <(find ${ROOTS} $(emit_prunes) -name '*.py' -print0)
+
+if [ -n "${FAILED}" ]; then
+  exit 1
+fi


### PR DESCRIPTION
The logic on how pylint searches for pyproject.toml and how it treats
directories versus file is subtle. Instead, just pass pylint files and
its configuration directly.