### PR TITLE
masters/mirrors are for DistPropertyGraph, not PropertyGraph

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -228,16 +228,6 @@ public:
 
   uint32_t partition_id() const { return rdg_.partition_id(); }
 
-  // Accessors for information in partition_metadata.
-  GraphTopology::nodes_range masters() const {
-    auto pm = rdg_.part_metadata();
-    return topology_.nodes(0, pm.num_owned_);
-  }
-  GraphTopology::nodes_range mirrors() const {
-    auto pm = rdg_.part_metadata();
-    return topology_.nodes(pm.num_owned_, pm.num_nodes_);
-  }
-
   // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
   // really a ChunkedArray of one chunk, change to arrow::Array.
   const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()


### PR DESCRIPTION
Thanks to @arthurp for motivation and @roshandathathri for guidance, this simple PR removes the masters/mirrors implementation from PropertyGraph.  It will remain in DistPropertyGraph, but its implementation changes as part of enterprise #1163.