### PR TITLE
OpaqueID improvements

### DIFF
--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -181,6 +181,16 @@ public:
 
   using DifferenceType = std::make_signed_t<_Value>;
 
+  // iterator traits
+  using difference_type = DifferenceType;
+  using value_type = _IDType;
+  using pointer = _IDType*;
+  using reference = _IDType&;
+  using iterator_category = std::random_access_iterator_tag;
+
+  // must provide a dereference to be an iterator
+  reference operator*() { return *static_cast<_IDType*>(this); }
+
   _IDType& operator++() {
     ++this->value_;
     return *static_cast<_IDType*>(this);
@@ -201,6 +211,16 @@ public:
     _IDType ret{*static_cast<_IDType*>(this)};
     this->value_--;
     return ret;
+  }
+
+  _IDType& operator+=(const DifferenceType& rhs) {
+    this->value_ += rhs;
+    return *static_cast<_IDType*>(this);
+  }
+
+  _IDType& operator-=(const DifferenceType& rhs) {
+    this->value_ -= rhs;
+    return *static_cast<_IDType*>(this);
   }
 
   _IDType operator+(DifferenceType v) const {

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <iostream>
 
+#include <boost/math/tools/precision.hpp>
+
 namespace katana {
 
 /// Base class for opaque ID types.
@@ -174,6 +176,7 @@ struct OpaqueIDOrderedWithValue : public OpaqueIDOrdered<_IDType, _Value> {
 ///   ValueType)
 /// - Increment and decrement
 /// - Subtraction of two IDs to get a DifferenceType
+/// - Dereference
 template <typename _IDType, typename _Value>
 struct OpaqueIDLinear : public OpaqueIDOrderedWithValue<_IDType, _Value> {
 public:
@@ -235,6 +238,14 @@ public:
   /// ValueType.
   DifferenceType operator-(_IDType v) const {
     return DifferenceType(this->value()) - DifferenceType(v.value());
+  }
+
+  /// If your _Value is not a language-provided numeric type
+  /// you should specialize std::numeric_limits<_Value>, specialize this
+  /// sentinel function, or specialize boost::math::tools::max_value.
+  /// Otherwise this won't compile.
+  static constexpr _IDType sentinel() {
+    _IDType(boost::math::tools::max_value<_Value>());
   }
 };
 


### PR DESCRIPTION
`OpaqueIDLinear` is now an iterator, which allows it be passed to `katana::iterate` directly.

`OpaqueIDLinear` now has a static field called `sentinel`.