### PR TITLE
Fix typo (functions should return)

### DIFF
--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -245,7 +245,7 @@ public:
   /// sentinel function, or specialize boost::math::tools::max_value.
   /// Otherwise this won't compile.
   static constexpr _IDType sentinel() {
-    _IDType(boost::math::tools::max_value<_Value>());
+    return _IDType(boost::math::tools::max_value<_Value>());
   }
 };
 

--- a/libsupport/test/opaque-id.cpp
+++ b/libsupport/test/opaque-id.cpp
@@ -27,6 +27,12 @@ struct TestLongOrdered : public katana::OpaqueIDLinear<TestLongOrdered, long> {
 static_assert(sizeof(TestLongOrdered) == sizeof(long));
 static_assert(alignof(TestLongOrdered) == alignof(long));
 
+// Make sure sentinel is okay
+static_assert(
+    std::is_same_v<decltype(TestCharOrdered::sentinel()), TestCharOrdered>);
+static_assert(
+    std::is_same_v<decltype(TestLongOrdered::sentinel()), TestLongOrdered>);
+
 int
 main() {
   return 0;


### PR DESCRIPTION
For a while `sentinel` was a value and not a function. Clang didn't like that and when I switched it to be a function I forgot to add `return`.