### PR TITLE
Workarounds to compile the code with nvcc (CUDA)

### DIFF
--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -32,6 +32,7 @@ set(sources
         src/ParaMeter.cpp
         src/PerThreadStorage.cpp
         src/Profile.cpp
+        src/Properties.cpp
         src/PropertyGraph.cpp
         src/PropertyViews.cpp
         src/PtrLock.cpp

--- a/libgalois/include/katana/Properties.h
+++ b/libgalois/include/katana/Properties.h
@@ -149,7 +149,7 @@ template <typename PropTuple>
 Result<std::tuple<>>
 ConstructPropertyViews(
     const std::vector<arrow::Array*>&, std::index_sequence<>) {
-  return std::tuple<>();
+  return Result<std::tuple<>>(std::tuple<>());
 }
 
 template <typename PropTuple, size_t head, size_t... tail>
@@ -298,9 +298,7 @@ public:
   using value_type = uint8_t;
 
   static Result<BooleanPropertyReadOnlyView> Make(
-      const arrow::BooleanArray& array) {
-    return BooleanPropertyReadOnlyView(array);
-  }
+      const arrow::BooleanArray& array);
 
   bool IsValid(size_t i) const {
     KATANA_LOG_DEBUG_ASSERT(i < (size_t)array_.length());
@@ -400,9 +398,9 @@ AllocateTable(uint64_t num_rows, const std::vector<std::string>& names) {
           arrow::default_memory_pool(), std::move(rows), names, &table);
       !r.ok()) {
     KATANA_LOG_DEBUG("arrow error: {}", r);
-    return katana::ErrorCode::ArrowError;
+    return Result<std::shared_ptr<arrow::Table>>(katana::ErrorCode::ArrowError);
   }
-  return table;
+  return Result<std::shared_ptr<arrow::Table>>(table);
 }
 
 }  // namespace katana

--- a/libgalois/include/katana/Properties.h
+++ b/libgalois/include/katana/Properties.h
@@ -290,7 +290,7 @@ private:
 
 /// BooleanPropertyReadOnlyView provides a read-only property view over
 /// arrow::Arrays of boolean elements.
-class BooleanPropertyReadOnlyView {
+class KATANA_EXPORT BooleanPropertyReadOnlyView {
 public:
   // use uint8_t instead of bool for value_type to avoid std::vector<bool>
   // (std::vector<bool> specialization leads to issues in concurrent writes

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -290,18 +290,7 @@ public:
   /// the original read location of the graph
   Result<void> Commit(const std::string& command_line);
   /// Tell the RDG where it's data is coming from
-  Result<void> InformPath(const std::string& input_path) {
-    if (!rdg_.rdg_dir().empty()) {
-      KATANA_LOG_DEBUG("rdg dir from {} to {}", rdg_.rdg_dir(), input_path);
-    }
-    auto uri_res = katana::Uri::Make(input_path);
-    if (!uri_res) {
-      return uri_res.error();
-    }
-
-    rdg_.set_rdg_dir(uri_res.value());
-    return ResultSuccess();
-  }
+  Result<void> InformPath(const std::string& input_path);
 
   /// Determine if two PropertyGraphs are Equal
   bool Equals(const PropertyGraph* other) const;

--- a/libgalois/src/Properties.cpp
+++ b/libgalois/src/Properties.cpp
@@ -1,12 +1,12 @@
 #include "katana/Properties.h"
+
 #include "katana/Result.h"
 
 namespace katana {
 
-Result<BooleanPropertyReadOnlyView> BooleanPropertyReadOnlyView::Make(
-      const arrow::BooleanArray& array)
-{
+Result<BooleanPropertyReadOnlyView>
+BooleanPropertyReadOnlyView::Make(const arrow::BooleanArray& array) {
   return BooleanPropertyReadOnlyView(array);
 }
 
-} // namespace katana
+}  // namespace katana

--- a/libgalois/src/Properties.cpp
+++ b/libgalois/src/Properties.cpp
@@ -1,0 +1,12 @@
+#include "katana/Properties.h"
+#include "katana/Result.h"
+
+namespace katana {
+
+Result<BooleanPropertyReadOnlyView> BooleanPropertyReadOnlyView::Make(
+      const arrow::BooleanArray& array)
+{
+  return BooleanPropertyReadOnlyView(array);
+}
+
+} // namespace katana

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -473,7 +473,8 @@ katana::PropertyGraph::SetTopology(const katana::GraphTopology& topology) {
   return katana::ResultSuccess();
 }
 
-katana::Result<void> katana::PropertyGraph::InformPath(const std::string& input_path) {
+katana::Result<void>
+katana::PropertyGraph::InformPath(const std::string& input_path) {
   if (!rdg_.rdg_dir().empty()) {
     KATANA_LOG_DEBUG("rdg dir from {} to {}", rdg_.rdg_dir(), input_path);
   }

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -473,6 +473,19 @@ katana::PropertyGraph::SetTopology(const katana::GraphTopology& topology) {
   return katana::ResultSuccess();
 }
 
+katana::Result<void> katana::PropertyGraph::InformPath(const std::string& input_path) {
+  if (!rdg_.rdg_dir().empty()) {
+    KATANA_LOG_DEBUG("rdg dir from {} to {}", rdg_.rdg_dir(), input_path);
+  }
+  auto uri_res = katana::Uri::Make(input_path);
+  if (!uri_res) {
+    return uri_res.error();
+  }
+
+  rdg_.set_rdg_dir(uri_res.value());
+  return ResultSuccess();
+}
+
 katana::Result<std::shared_ptr<arrow::UInt64Array>>
 katana::SortAllEdgesByDest(katana::PropertyGraph* pg) {
   auto view_result_dests =

--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -148,7 +148,8 @@ VectorToArrowTable(const std::string& name, const std::vector<T>& source) {
         katana::ErrorCode::ArrowError, "setting arrow column attributes: {}",
         nullable_table);
   }
-  return katana::Result<std::shared_ptr<arrow::Table>>(nullable_table.ValueOrDie());
+  return katana::Result<std::shared_ptr<arrow::Table>>(
+      nullable_table.ValueOrDie());
 }
 
 template <typename T>
@@ -183,7 +184,7 @@ MarshalVectorOfVectors(const std::vector<std::vector<T>>& source) {
     dest.emplace_back(res.value());
   }
   return katana::Result<std::vector<std::shared_ptr<arrow::ChunkedArray>>>(
-    std::vector<std::shared_ptr<arrow::ChunkedArray>>(std::move(dest)));
+      std::vector<std::shared_ptr<arrow::ChunkedArray>>(std::move(dest)));
 }
 
 //////////////////////////////////////////////////////////

--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -120,7 +120,7 @@ MarshalVector(const std::vector<T>& source) {
     return KATANA_ERROR(
         katana::ErrorCode::ArrowError, "converting vector to arrow: {}", r);
   }
-  return table->column(0);
+  return katana::Result<std::shared_ptr<arrow::ChunkedArray>>(table->column(0));
 }
 
 template <typename T>
@@ -148,7 +148,7 @@ VectorToArrowTable(const std::string& name, const std::vector<T>& source) {
         katana::ErrorCode::ArrowError, "setting arrow column attributes: {}",
         nullable_table);
   }
-  return nullable_table.ValueOrDie();
+  return katana::Result<std::shared_ptr<arrow::Table>>(nullable_table.ValueOrDie());
 }
 
 template <typename T>
@@ -182,7 +182,8 @@ MarshalVectorOfVectors(const std::vector<std::vector<T>>& source) {
     }
     dest.emplace_back(res.value());
   }
-  return std::vector<std::shared_ptr<arrow::ChunkedArray>>(std::move(dest));
+  return katana::Result<std::vector<std::shared_ptr<arrow::ChunkedArray>>>(
+    std::vector<std::shared_ptr<arrow::ChunkedArray>>(std::move(dest)));
 }
 
 //////////////////////////////////////////////////////////

--- a/libsupport/include/katana/JSON.h
+++ b/libsupport/include/katana/JSON.h
@@ -32,7 +32,7 @@ JsonParse(U& obj, T* val) {
   } catch (const std::exception& exp) {
     KATANA_LOG_DEBUG("nlohmann::json::parse exception: {}", exp.what());
   }
-  return katana::ErrorCode::JsonParseFailed;
+  return katana::Result<void>(katana::ErrorCode::JsonParseFailed);
 }
 
 /// Dump to string, but catch errors


### PR DESCRIPTION
Small workarounds to fix the compilation of katana::Result with nvcc in CUDA