### PR TITLE
Fix for building with ninja

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -142,6 +142,16 @@ jobs:
       - name: Run build_in_container
         run: scripts/build_in_container.py --build $HOME/build --type conda
 
+  test_build_in_container_conda_ninja:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Run build_in_container (with Ninja)
+        run: scripts/build_in_container.py --build $HOME/build --type conda --cmake-generator Ninja
+
   lint:
     runs-on: ${{matrix.os}}
     strategy:

--- a/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
+++ b/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
@@ -219,7 +219,7 @@ function(add_python_setuptools_target TARGET_NAME)
       ALL
       COMMAND ${PYTHON_SETUP_COMMAND} ${quiet} build "$<$<CONFIG:Debug>:--debug>" ${parallel}
       COMMAND install ${PYTHON_ENV_SCRIPT}.tmp ${PYTHON_ENV_SCRIPT}
-      BYPRODUCTS ${PYTHON_BINARY_DIR} ${PYTHON_ENV_SCRIPT} ${CMAKE_BINARY_DIR}/katana_setup_requirements_cache.txt
+      BYPRODUCTS ${PYTHON_BINARY_DIR} ${PYTHON_ENV_SCRIPT}
       WORKING_DIRECTORY ${PYTHON_BINARY_DIR}
       COMMENT "Building ${TARGET_NAME} in symlink tree ${PYTHON_BINARY_DIR}"
   )
@@ -231,6 +231,14 @@ function(add_python_setuptools_target TARGET_NAME)
       COMMENT "bdist ${TARGET_NAME} in symlink tree ${PYTHON_BINARY_DIR}"
   )
   add_dependencies(${TARGET_NAME}_wheel ${TARGET_NAME})
+
+  # When building with Ninja, Ninja refuses to delete non-empty directories when cleaning.
+  # Thus ${PYTHON_BINARY_DIR} is included here, which explicitly removes the directory for the clean target.
+  set_property(
+      TARGET ${TARGET_NAME}
+      APPEND
+      PROPERTY ADDITIONAL_CLEAN_FILES ${PYTHON_BINARY_DIR} ${CMAKE_BINARY_DIR}/katana_setup_requirements_cache.txt
+  )
 
   add_dependencies(${TARGET_NAME} ${TARGET_NAME}_python_tree ${TARGET_NAME}_setup_tree ${TARGET_NAME}_scripts_tree)
   if(X_DEPENDS)

--- a/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
+++ b/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
@@ -180,7 +180,7 @@ function(add_python_setuptools_target TARGET_NAME)
   #  -j will not propagate into python builds and if CMAKE_BUILD_PARALLEL_LEVEL varies then only some things will be
   #  in parallel. Parallel or not will not affect correctness however.
 
-  if(ENV{CMAKE_BUILD_PARALLEL_LEVEL})
+  if (DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
     set(parallel --parallel $ENV{CMAKE_BUILD_PARALLEL_LEVEL})
   endif()
   set(quiet "")

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -26,6 +26,7 @@ dependencies:
  - libxml2>=2.9.10
  - llvmdev>=8
  - make
+ - ninja
  - ncurses>=6.1
  - nlohmann_json>=3.7.3
  - numba

--- a/inputs/CMakeLists.txt
+++ b/inputs/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_command(
 )
 
 add_custom_command(
-  OUTPUT ${INPUTS_DIR}/current/current-${INPUT_VERSION}
+  OUTPUT ${INPUTS_DIR}/${INPUT_VERSION}/current-${INPUT_VERSION}
   DEPENDS ${INPUTS_DIR}/${INPUT_VERSION}/extracted
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${INPUT_VERSION} current
   COMMAND ${CMAKE_COMMAND} -E touch ${INPUT_VERSION}/current-${INPUT_VERSION}
@@ -39,4 +39,4 @@ add_custom_command(
   VERBATIM
 )
 
-add_custom_target(input ALL DEPENDS ${INPUTS_DIR}/current/current-${INPUT_VERSION})
+add_custom_target(input ALL DEPENDS ${INPUTS_DIR}/${INPUT_VERSION}/current-${INPUT_VERSION})

--- a/scripts/build_in_container.py
+++ b/scripts/build_in_container.py
@@ -32,6 +32,7 @@ def main():
         "--source", "-S", type=Path, help="The root of the source tree to use. Defaults to auto detect.", default=None
     )
     parser.add_argument("--type", "-t", type=str, help="The type of build to perform.", default="conda")
+    parser.add_argument("--cmake-generator", "-G", type=str, help="CMake generator to use", default="Unix Makefiles")
     parser.add_argument("targets", nargs="*", help="The targets to build")
     parser.add_argument(
         "--reuse", help="Rebuild the build image even if it already exists.", default=False, action="store_true"
@@ -89,6 +90,8 @@ def main():
             f"KATANA_VERSION={katana_version}",
             "--env",
             f"TARGETS={targets_str}",
+            "--env",
+            f"CMAKE_GENERATOR={args.cmake_generator}",
             "--mount",
             f"type=bind,src={build},dst=/build",
             "--mount",

--- a/scripts/build_in_container_conda.Dockerfile
+++ b/scripts/build_in_container_conda.Dockerfile
@@ -43,7 +43,8 @@ ENTRYPOINT ["bash", "-l", "-c", "\"$@\"", "\"$0\""]
 
 ENV CMAKE_SETTINGS="-DKATANA_LANG_BINDINGS=python -DBUILD_DOCS=ON"
 ENV CMAKE_BUILD_TYPE="Release"
+ENV CMAKE_GENERATOR="Unix Makefiles"
 
 CMD set -eux; \
-    cmake -B /build -S /source -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_SETTINGS}; \
+    cmake -G "${CMAKE_GENERATOR}" -B /build -S /source -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_SETTINGS}; \
     cmake --build /build --parallel $(nproc) ${TARGETS:+--target ${TARGETS}}


### PR DESCRIPTION
When building with CMake's Ninja generator, it creates "current" dir first, and makes create_symlink failed.

The PR fixes the problem.

Using Ninja speeds up building in my setup. For a fresh build, Ninja takes 4m13s while make takes 5m13s.