### PR TITLE
[KAT-516] Introduce Types to PropertyGraph

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -288,19 +288,19 @@ public:
   std::string ReportDiff(const PropertyGraph* other) const;
 
   std::shared_ptr<arrow::Schema> node_schema() const {
-    return rdg_.node_properties()->schema();
+    return node_properties()->schema();
   }
 
   std::shared_ptr<arrow::Schema> edge_schema() const {
-    return rdg_.edge_properties()->schema();
+    return edge_properties()->schema();
   }
 
   // Return type dictated by arrow
   int32_t GetNodePropertyNum() const {
-    return rdg_.node_properties()->num_columns();
+    return node_properties()->num_columns();
   }
   int32_t GetEdgePropertyNum() const {
-    return rdg_.edge_properties()->num_columns();
+    return edge_properties()->num_columns();
   }
 
   // num_rows() == num_nodes() (all local nodes)
@@ -308,15 +308,15 @@ public:
     if (i >= rdg_.node_properties()->num_columns()) {
       return nullptr;
     }
-    return rdg_.node_properties()->column(i);
+    return node_properties()->column(i);
   }
 
   // num_rows() == num_edges() (all local edges)
   std::shared_ptr<arrow::ChunkedArray> GetEdgeProperty(int i) const {
-    if (i >= rdg_.edge_properties()->num_columns()) {
+    if (i >= edge_properties()->num_columns()) {
       return nullptr;
     }
-    return rdg_.edge_properties()->column(i);
+    return edge_properties()->column(i);
   }
 
   /// Get a node property by name.
@@ -325,7 +325,7 @@ public:
   /// \return The property data or NULL if the property is not found.
   std::shared_ptr<arrow::ChunkedArray> GetNodeProperty(
       const std::string& name) const {
-    return rdg_.node_properties()->GetColumnByName(name);
+    return node_properties()->GetColumnByName(name);
   }
   std::vector<std::string> GetNodePropertyNames() const {
     return node_properties()->ColumnNames();
@@ -333,7 +333,7 @@ public:
 
   std::shared_ptr<arrow::ChunkedArray> GetEdgeProperty(
       const std::string& name) const {
-    return rdg_.edge_properties()->GetColumnByName(name);
+    return edge_properties()->GetColumnByName(name);
   }
   std::vector<std::string> GetEdgePropertyNames() const {
     return edge_properties()->ColumnNames();

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -103,7 +103,6 @@ public:
   /// TypeSetID is represented using 8 bits
   /// TypeSetID for nodes is distinct from TypeSetID for edges
   using TypeSetID = uint8_t;
-  using ArrowTypeSetID = arrow::UInt8Type;
   static constexpr TypeSetID kUnknownType = TypeSetID{0};
   static constexpr TypeSetID kInvalidType =
       std::numeric_limits<TypeSetID>::max();
@@ -159,9 +158,9 @@ private:
   TypeNameToSetOfTypeSetIDsMap edge_type_name_to_type_set_ids_;
 
   /// The node TypeSetID for each node in the graph
-  std::shared_ptr<arrow::NumericArray<ArrowTypeSetID>> node_type_set_id_;
+  katana::LargeArray<TypeSetID> node_type_set_id_;
   /// The edge TypeSetID for each edge in the graph
-  std::shared_ptr<arrow::NumericArray<ArrowTypeSetID>> edge_type_set_id_;
+  katana::LargeArray<TypeSetID> edge_type_set_id_;
 
   // Keep partition_metadata, master_nodes, mirror_nodes out of the public interface,
   // while allowing Distribution to read/write it for RDG
@@ -418,12 +417,12 @@ public:
 
   /// \return returns the node TypeSetID for @param node
   TypeSetID GetNodeTypeSetID(Node node) const {
-    return node_type_set_id_->Value(node);
+    return node_type_set_id_[node];
   }
 
   /// \return returns the edge TypeSetID for @param edge
   TypeSetID GetEdgeTypeSetID(Edge edge) const {
-    return edge_type_set_id_->Value(edge);
+    return edge_type_set_id_[edge];
   }
 
   // Return type dictated by arrow

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -108,7 +108,7 @@ public:
   /// A map from TypeID to the set of the type names it contains
   using TypeIDToTypeNamesMap = std::vector<std::unordered_set<std::string>>;
   /// A map from the type name to the set of the TypeIDs that contain it
-  using TypeNameToTypeIDMap =
+  using TypeNameToTypeIDsMap =
       std::unordered_map<std::string, std::unordered_set<TypeID>>;
 
   // Pass through topology API
@@ -146,10 +146,10 @@ private:
 
   /// A map from the node type name
   /// to the set of the node TypeIDs that contain it
-  TypeNameToTypeIDMap node_type_name_to_type_ids_;
+  TypeNameToTypeIDsMap node_type_name_to_type_ids_;
   /// A map from the edge type name
   /// to the set of the edge TypeIDs that contain it
-  TypeNameToTypeIDMap edge_type_name_to_type_ids_;
+  TypeNameToTypeIDsMap edge_type_name_to_type_ids_;
 
   /// The node TypeID for each node in the graph
   std::shared_ptr<arrow::NumericArray<ArrowTypeID>> node_type_id_;

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -1,6 +1,7 @@
 #ifndef KATANA_LIBGALOIS_KATANA_PROPERTYGRAPH_H_
 #define KATANA_LIBGALOIS_KATANA_PROPERTYGRAPH_H_
 
+#include <bitset>
 #include <string>
 #include <utility>
 #include <vector>
@@ -105,11 +106,12 @@ public:
   using ArrowTypeID = arrow::UInt8Type;
   static constexpr TypeID kUnknownType = TypeID{0};
   static constexpr TypeID kInvalidType = std::numeric_limits<TypeID>::max();
+  /// A set of TypeIDs
+  using TypeIDsSet = std::bitset<std::numeric_limits<TypeID>::max() + 1>;
   /// A map from TypeID to the set of the type names it contains
   using TypeIDToTypeNamesMap = std::vector<std::unordered_set<std::string>>;
   /// A map from the type name to the set of the TypeIDs that contain it
-  using TypeNameToTypeIDsMap =
-      std::unordered_map<std::string, std::unordered_set<TypeID>>;
+  using TypeNameToTypeIDsMap = std::unordered_map<std::string, TypeIDsSet>;
 
   // Pass through topology API
   using node_iterator = GraphTopology::node_iterator;
@@ -366,16 +368,14 @@ public:
   /// \returns the set of node TypeIDs that contain
   /// the node type with @param name
   /// (assumes that the node type exists)
-  const std::unordered_set<TypeID>& NodeTypeNameToTypeIDs(
-      const std::string& name) const {
+  const TypeIDsSet& NodeTypeNameToTypeIDs(const std::string& name) const {
     return node_type_name_to_type_ids_.at(name);
   }
 
   /// \returns the set of edge TypeIDs that contain
   /// the edge type with @param name
   /// (assumes that the edge type exists)
-  const std::unordered_set<TypeID>& EdgeTypeNameToTypeIDs(
-      const std::string& name) const {
+  const TypeIDsSet& EdgeTypeNameToTypeIDs(const std::string& name) const {
     return edge_type_name_to_type_ids_.at(name);
   }
 

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -195,7 +195,8 @@ GetTypeIDsFromProperties(
         type_name_to_type_ids->find(field_name) ==
         type_name_to_type_ids->end());
 
-    std::unordered_set<katana::PropertyGraph::TypeID> type_ids{new_type_id};
+    katana::PropertyGraph::TypeIDsSet type_ids;
+    type_ids.set(new_type_id);
     type_name_to_type_ids->emplace(std::make_pair(field_name, type_ids));
     type_id_to_type_names->push_back({field_name});
   }
@@ -254,7 +255,7 @@ GetTypeIDsFromProperties(
           type_name_to_type_ids->find(field_name) !=
           type_name_to_type_ids->end());
 
-      type_name_to_type_ids->at(field_name).emplace(new_type_id);
+      type_name_to_type_ids->at(field_name).set(new_type_id);
       type_id_to_type_names->at(new_type_id).emplace(field_name);
     }
   }

--- a/libgalois/test/property-file-graph.cpp
+++ b/libgalois/test/property-file-graph.cpp
@@ -30,7 +30,8 @@ TestRoundTrip() {
   using ValueType = int32_t;
   using ThrowAwayType = int64_t;
 
-  auto g = std::make_unique<katana::PropertyGraph>();
+  RandomPolicy policy{1};
+  auto g = MakeFileGraph<uint32_t>(test_length, 0, &policy);
 
   std::shared_ptr<arrow::Table> node_throw_away =
       MakeProps<ThrowAwayType>("node-throw-away", test_length);
@@ -158,7 +159,8 @@ MakePFGFile(const std::string& n1name) {
   const std::string e0name = "e0";
   const std::string e1name = "e1";
 
-  auto g = std::make_unique<katana::PropertyGraph>();
+  RandomPolicy policy{1};
+  auto g = MakeFileGraph<uint32_t>(test_length, 0, &policy);
 
   std::shared_ptr<arrow::Table> node_props = MakeProps<V0>(n0name, test_length);
 


### PR DESCRIPTION
    Differentiate between types and non-type/arbitrary properties.
    Currently, assumes all boolean or uint8 properties are types.

    Constructs a new array to store types of all nodes and another
    for all edges. The types of a node are encoded using a TypeID.

    Encode TypeID to identify/contain a unique combinations of
    types. Currently, the encoding uses 8 bits, so it supports up
    to 254 unique combinations of types (excluding unknown and
    invalid types).