### PR TITLE
[KAT-279] Create pip package for katana-python

### DIFF
--- a/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
+++ b/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
@@ -208,6 +208,8 @@ function(add_python_setuptools_target TARGET_NAME)
       "KATANA_SETUP_REQUIREMENTS_CACHE=${CMAKE_BINARY_DIR}/katana_setup_requirements_cache.txt"
       # Finally, launch setup.py
       ${Python3_EXECUTABLE} setup.py)
+  # Write the python setup.py command to a file similar to link.txt to aid in build debugging
+  file(GENERATE OUTPUT ${PYTHON_BINARY_DIR}/python_setup.txt CONTENT "$<JOIN:${PYTHON_SETUP_COMMAND}, >")
 
   add_custom_target(
       ${TARGET_NAME}
@@ -218,6 +220,14 @@ function(add_python_setuptools_target TARGET_NAME)
       WORKING_DIRECTORY ${PYTHON_BINARY_DIR}
       COMMENT "Building ${TARGET_NAME} in symlink tree ${PYTHON_BINARY_DIR}"
   )
+
+  add_custom_target(
+      ${TARGET_NAME}_wheel
+      COMMAND ${PYTHON_SETUP_COMMAND} ${quiet} bdist_wheel --dist-dir ${CMAKE_BINARY_DIR}/pkg
+      WORKING_DIRECTORY ${PYTHON_BINARY_DIR}
+      COMMENT "bdist ${TARGET_NAME} in symlink tree ${PYTHON_BINARY_DIR}"
+  )
+  add_dependencies(${TARGET_NAME}_wheel ${TARGET_NAME})
 
   add_dependencies(${TARGET_NAME} ${TARGET_NAME}_python_tree ${TARGET_NAME}_setup_tree ${TARGET_NAME}_scripts_tree)
   if(X_DEPENDS)

--- a/python/katana/__init__.py
+++ b/python/katana/__init__.py
@@ -29,11 +29,12 @@ try:
     # Trigger the load of katana libraries
     import katana.galois
 except ImportError as e:
-    if "libnuma" in str(e):
+    if "libkatana" in str(e):
         raise ImportError(
-            "katana requires libnuma to be installed. Install it with your native package manager. "
-            "E.g., `sudo apt install libnuma1`."
+            "The native libraries required by katana are missing or incorrectly installed. NOTE: The native libraries "
+            "are not included in pip packages and must be installed separately (e.g., with `conda install katana-cpp`)."
         ) from e
+    raise
 
 
 # A global variable to hold the Katana runtime "Sys". The type will vary and has no methods. None means no Katana

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -18,7 +18,7 @@ def in_build_call():
     # This is a hack, but WOW setuptools is terrible.
     # We need to check if we are building because otherwise every call to setup.py (even for metadata not build) will
     # cause cython files to be processed. Often the processing happens in tree spewing build files all over the tree.
-    return any(a.startswith("build") or a.startswith("install") for a in sys.argv)
+    return any(a.startswith("build") or a.startswith("install") or "dist" in a for a in sys.argv)
 
 
 def split_cmake_list(s):
@@ -422,7 +422,7 @@ def setup(*, source_dir, package_name, doc_package_name, additional_requires=Non
     if additional_requires:
         requires.extend(additional_requires)
 
-    source_dir = Path(source_dir).absolute()
+    source_dir = Path(source_dir)
 
     pxd_files, pyx_files = collect_cython_files(source_root=source_dir / package_name)
 
@@ -436,6 +436,7 @@ def setup(*, source_dir, package_name, doc_package_name, additional_requires=Non
         # packages in the overall build environment. (It installs them in .eggs in the source tree.)
         requires=requires,
         ext_modules=cythonize(pyx_files, source_root=source_dir),
+        include_package_data=True,
         zip_safe=False,
         command_options={
             "build_sphinx": {

--- a/setup.py
+++ b/setup.py
@@ -16,3 +16,18 @@ def package_setup():
 
 if __name__ == "__main__":
     package_setup()
+
+
+# This project can generate a pip package, but it's bad and is missing dependencies. If you must generate it, run
+# `make katana_python_wheel` in your build directory. To install it:
+#
+#     Install Katana native library
+# conda install -c katanagraph/label/dev katana-cpp
+#     Make sure we are the correct Python version
+# conda install python==3.8
+#     Install Katana Python Conda dependencies (due to problems in the pip pyarrow package we must use the conda pkg)
+# conda install pyarrow==2
+#     Install Katana Python pip dependencies (using what we can from pip)
+# pip install numba
+#     Install Katana Python pip package
+# pip install <katana_python package .whl>


### PR DESCRIPTION
The pip package is crude and doesn't work without conda currently (making it a bit silly). As such it is not built by default or in CI. To build run `make katana_python_wheel` in your build directory. It's really just around to full a formal requirement.