### PR TITLE
python: Don't strip whitespace from build values from cmake.

### DIFF
--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -186,8 +186,8 @@ def check_cython_module(name, cython_code, python_code="", extension_options=Non
 def parse_text(fi):
     result = {}
     for line in fi:
-        line = line.strip()
-        if not line:
+        line = line.rstrip("\n")
+        if not line.strip():
             continue
         try:
             key, value = line.split("=", maxsplit=1)


### PR DESCRIPTION
Trailing whitespace in LINKER_WRAPPER_FLAG is significant. See
https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_LINKER_WRAPPER_FLAG.html