### PR TITLE
Allow rdg to remove all its properties

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -559,6 +559,11 @@ public:
   Result<void> RemoveEdgeProperty(int i);
   Result<void> RemoveEdgeProperty(const std::string& prop_name);
 
+  /// Remove all node properties
+  void DropNodeProperties() { rdg_.DropNodeProperties(); }
+  /// Remove all edge properties
+  void DropEdgeProperties() { rdg_.DropEdgeProperties(); }
+
   PropertyView node_property_view() {
     return PropertyView{
         .g = this,

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -122,6 +122,12 @@ public:
   /// The edge properties
   const std::shared_ptr<arrow::Table>& edge_properties() const;
 
+  /// Remove all node properties
+  void DropNodeProperties();
+
+  /// Remove all edge properties
+  void DropEdgeProperties();
+
   const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
       const {
     return master_nodes_;

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -693,6 +693,16 @@ tsuba::RDG::edge_properties() const {
   return core_->edge_properties();
 }
 
+void
+tsuba::RDG::DropNodeProperties() {
+  core_->drop_node_properties();
+}
+
+void
+tsuba::RDG::DropEdgeProperties() {
+  core_->drop_edge_properties();
+}
+
 const tsuba::FileView&
 tsuba::RDG::topology_file_storage() const {
   return core_->topology_file_storage();

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -55,6 +55,15 @@ public:
     edge_properties_ = std::move(edge_properties);
   }
 
+  void drop_node_properties() {
+    std::vector<std::shared_ptr<arrow::Array>> empty;
+    node_properties_ = arrow::Table::Make(arrow::schema({}), empty, 0);
+  }
+  void drop_edge_properties() {
+    std::vector<std::shared_ptr<arrow::Array>> empty;
+    edge_properties_ = arrow::Table::Make(arrow::schema({}), empty, 0);
+  }
+
   const FileView& topology_file_storage() const {
     return topology_file_storage_;
   }


### PR DESCRIPTION
The core issue here is that I want to modify an in-memory graph in place. And it is difficult to add a node property table that has a different number of rows than the RDG was created with.