### PR TITLE
Improve arch and tune build options and defaults. 

### DIFF
--- a/cmake/Modules/CheckArchFlags.cmake
+++ b/cmake/Modules/CheckArchFlags.cmake
@@ -1,7 +1,17 @@
-# Find architecture-specific flags based on the value of KATANA_USE_ARCH.
-# KATANA_USE_ARCH is a cmake list of possible architecture names. Return the
-# flags corresponding to the first architecture available for the current
-# compiler toolchain.
+# Find architecture-specific flags based on the values of KATANA_USE_ARCH and
+# KATANA_USE_TUNE. KATANA_USE_ARCH and KATANA_USE_TUNE are cmake lists of
+# possible architecture names. Return the flags corresponding to the first
+# architecture available for the current compiler toolchain for both arch
+# (-march) and tune (-mtune).
+#
+# For maximum performance, but no compatibility with different computers, use:
+# -DKATANA_USE_ARCH=native -DKATANA_USE_TUNE=native
+#
+# The default is:
+# -DKATANA_USE_ARCH=sandybridge -DKATANA_USE_TUNE=intel;generic;auto
+# which tries to optimize for the most recent Intel processors, then falls back
+# to optimizing for the most common processors and then to optimizing for
+# sandybridge.
 #
 # Once done this will define
 #  ARCH_FLAGS_FOUND
@@ -10,10 +20,10 @@
 #  ARCH_LINK_FLAGS - Compiler flags to enable architecture-specific optimizations
 include(CheckCXXCompilerFlag)
 
-if(ARCH_FLAGS_FOUND)
-  return()
-endif()
+# TODO(amp): This code duplicates the same process for arch and tune. Dedup.
+# TODO(amp): If KATANA_USE_ARCH or KATANA_USE_TUNE contain " " or ";", this will fail.
 
+# Determine and add -march
 if(NOT KATANA_USE_ARCH OR KATANA_USE_ARCH STREQUAL "none" OR ARCH_FLAGS_FOUND)
   set(ARCH_CXX_FLAGS_CANDIDATES)
 else()
@@ -32,32 +42,60 @@ else()
   endforeach()
 endif()
 
-set(ARCH_CXX_FLAGS "-mtune=native")
-set(ARCH_C_FLAGS "-mtune=native")
-set(ARCH_LINK_FLAGS "-mtune=native")
-# foreach(FLAG ${ARCH_CXX_FLAGS_CANDIDATES})
-#   check_cxx_compiler_flag("${FLAG}" ARCH_CXX_MARCH_FLAG_DETECTED)
-#   if(ARCH_CXX_MARCH_FLAG_DETECTED)
-#     set(ARCH_FLAGS_FOUND "YES")
-#     set(ARCH_CXX_FLAGS "${FLAG}")
-#     set(ARCH_C_FLAGS "${FLAG}")
-#     set(ARCH_LINK_FLAGS "${FLAG}")
-#     break()
-#   endif()
-# endforeach()
-# unset(ARCH_CXX_MARCH_FLAG_DETECTED)
-# 
-# if(ARCH_FLAGS_FOUND)
-#   foreach(FLAG "-mtune=generic")
-#     check_cxx_compiler_flag("${FLAG}" ARCH_CXX_MTUNE_FLAG_DETECTED)
-#     if(ARCH_CXX_MTUNE_FLAG_DETECTED)
-#       list(APPEND ARCH_CXX_FLAGS "${FLAG}")
-#       list(APPEND ARCH_C_FLAGS "${FLAG}")
-#       list(APPEND ARCH_LINK_FLAGS "${FLAG}")
-#       break()
-#     endif()
-#   endforeach()
-# endif()
-unset(ARCH_CXX_MTUNE_FLAG_DETECTED)
+set(CMAKE_REQUIRED_QUIET TRUE)
+foreach(FLAG ${ARCH_CXX_FLAGS_CANDIDATES})
+  message(CHECK_START "Trying architecture argument ${FLAG}")
+  check_cxx_compiler_flag("${FLAG}" "ARCH_CXX_MARCH_FLAG_DETECTED-${FLAG}")
+  if(ARCH_CXX_MARCH_FLAG_DETECTED-${FLAG})
+    message(CHECK_PASS "supported")
+    set(ARCH_FLAGS_FOUND "YES")
+    set(ARCH_CXX_FLAGS "${FLAG}")
+    set(ARCH_C_FLAGS "${FLAG}")
+    set(ARCH_LINK_FLAGS "${FLAG}")
+    break()
+  else()
+    message(CHECK_FAIL "unsupported")
+  endif()
+endforeach()
+unset(CMAKE_REQUIRED_QUIET)
 
-message(STATUS "Using architecture flags: ${ARCH_CXX_FLAGS}")
+# Determine and add -mtune
+if(NOT KATANA_USE_TUNE OR KATANA_USE_TUNE STREQUAL "none" OR TUNE_FLAGS_FOUND)
+  set(TUNE_CXX_FLAGS_CANDIDATES)
+else()
+  list(TRANSFORM KATANA_USE_TUNE REPLACE "^auto$" "${KATANA_USE_ARCH}")
+  foreach(FLAG ${KATANA_USE_TUNE})
+    if(FLAG STREQUAL "mic")
+      if(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+        # TODO(amp): Does icc support an mtune like flag for "mic"?
+        # list(APPEND TUNE_CXX_FLAGS_CANDIDATES -mmic)
+      endif()
+      if(CMAKE_COMPILER_IS_GNUCC)
+        list(APPEND TUNE_CXX_FLAGS_CANDIDATES -mtune=knc)
+      endif()
+    else()
+      list(APPEND TUNE_CXX_FLAGS_CANDIDATES "-mtune=${FLAG}")
+    endif()
+  endforeach()
+endif()
+
+set(CMAKE_REQUIRED_QUIET TRUE)
+foreach(FLAG ${TUNE_CXX_FLAGS_CANDIDATES})
+  message(CHECK_START "Trying tune argument ${FLAG}")
+  check_cxx_compiler_flag("${ARCH_CXX_FLAGS} ${FLAG}" "ARCH_CXX_MTUNE_FLAG_DETECTED-${FLAG}")
+  if(ARCH_CXX_MTUNE_FLAG_DETECTED-${FLAG})
+    message(CHECK_PASS "supported")
+    set(TUNE_FLAGS_FOUND "YES")
+    list(APPEND ARCH_CXX_FLAGS "${FLAG}")
+    list(APPEND ARCH_C_FLAGS "${FLAG}")
+    list(APPEND ARCH_LINK_FLAGS "${FLAG}")
+    break()
+  else()
+    message(CHECK_FAIL "unsupported")
+  endif()
+endforeach()
+unset(CMAKE_REQUIRED_QUIET)
+
+list(JOIN ARCH_CXX_FLAGS " " ARCH_CXX_FLAGS_STR)
+message(STATUS "Using architecture flags: ${ARCH_CXX_FLAGS_STR}")
+unset(ARCH_CXX_FLAGS_STR)

--- a/cmake/Modules/KatanaBuildCommon.cmake
+++ b/cmake/Modules/KatanaBuildCommon.cmake
@@ -25,7 +25,13 @@ set(KATANA_STRICT_CONFIG OFF CACHE BOOL "Instead of falling back gracefully, fai
 set(KATANA_GRAPH_LOCATION "" CACHE PATH "Location of inputs for tests if downloaded/stored separately.")
 set(CXX_CLANG_TIDY "" CACHE STRING "Semi-colon separated list of clang-tidy command and arguments")
 set(CMAKE_CXX_COMPILER_LAUNCHER "" CACHE STRING "Semi-colon separated list of command and arguments to wrap compiler invocations (e.g., ccache)")
-set(KATANA_USE_ARCH "sandybridge" CACHE STRING "Semi-colon separated list of processor architectures to attempt to optimize for; use the first valid configuration ('none' to disable)")
+set(KATANA_USE_ARCH "sandybridge" CACHE STRING "Semi-colon separated list of processor architectures to use features of;
+  Any older/incompatible processors will be unable to run resulting binaries.
+  Use the first valid configuration ('none' to disable). Default: 'sandybridge'")
+set(KATANA_USE_TUNE "intel;generic;auto" CACHE STRING "Semi-colon separated list of processor architectures to attempt to optimize for.
+  Use the first valid configuration (the 'auto' is replaced with KATANA_USE_ARCH, 'none' to disable).
+  Default: 'intel;generic;auto' which tries to optimize for the most recent Intel processors, then falls back to
+  optimizing for the most common processors and then to optimizing for the processor selected by KATANA_USE_ARCH")
 set(KATANA_USE_SANITIZER "" CACHE STRING "Semi-colon separated list of sanitizers to use (Memory, MemoryWithOrigins, Address, Undefined, Thread)")
 # This option is automatically handled by CMake.
 # It makes add_library build a shared lib unless STATIC is explicitly specified.


### PR DESCRIPTION
 Adds `KATANA_USE_TUNE`. Makes the default oriented towards new Intel
 processors. Fully optimizing for one machine is now possible with:
 
` -DKATANA_USE_ARCH=native -DKATANA_USE_TUNE=native`

This removes the fixed mtune from 11d6d75efeb from #280.