### PR TITLE
Make prealloc for CC consistent with other algos

### DIFF
--- a/libgalois/src/analytics/connected_components/connected_components.cpp
+++ b/libgalois/src/analytics/connected_components/connected_components.cpp
@@ -1129,6 +1129,10 @@ static katana::Result<void>
 ConnectedComponentsWithWrap(
     katana::PropertyGraph* pg, std::string output_property_name,
     ConnectedComponentsPlan plan) {
+  katana::EnsurePreallocated(
+      2,
+      pg->topology().num_nodes() * sizeof(typename Algorithm::NodeComponent));
+
   if (auto r = ConstructNodeProperties<
           std::tuple<typename Algorithm::NodeComponent>>(
           pg, {output_property_name});

--- a/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
+++ b/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
@@ -147,7 +147,6 @@ main(int argc, char** argv) {
     abort();
   }
 
-  katana::Prealloc(pg->topology().num_nodes() * 80ul / (1ul << 20));
   katana::reportPageAlloc("MeminfoPre");
 
   std::cout << "Running " << AlgorithmName(algo) << " algorithm\n";


### PR DESCRIPTION
All other algorithms preallocate within the analytics library rather
than in the command-line interface (CLI) executable.