### PR TITLE
Report prealloc in analytics library

### DIFF
--- a/libgalois/include/katana/Statistics.h
+++ b/libgalois/include/katana/Statistics.h
@@ -434,8 +434,29 @@ ReportStatAvg(
 //! @param id Identifier to prefix stat with in statistics output
 KATANA_EXPORT void reportRUsage(const std::string& id);
 
-//! Reports Galois system memory stats for all threads
+//! Reports system memory stats for all threads
 KATANA_EXPORT void reportPageAlloc(const char* category);
+
+class [[nodiscard]] ReportPageAllocGuard {
+public:
+  ReportPageAllocGuard() { reportPageAlloc("MeminfoPre"); }
+  ~ReportPageAllocGuard() { Report(); }
+  ReportPageAllocGuard(const ReportPageAllocGuard&) = delete;
+  ReportPageAllocGuard(ReportPageAllocGuard &&) = delete;
+  ReportPageAllocGuard& operator=(const ReportPageAllocGuard&) = delete;
+  ReportPageAllocGuard& operator=(ReportPageAllocGuard&&) = delete;
+
+  void Report() {
+    if (reported_) {
+      return;
+    }
+    reportPageAlloc("MeminfoPost");
+    reported_ = true;
+  }
+
+private:
+  bool reported_{false};
+};
 
 /// Prints statistics out to standard out or to the file indicated by
 /// SetStatFile

--- a/libgalois/src/analytics/betweenness_centrality/async.cpp
+++ b/libgalois/src/analytics/betweenness_centrality/async.cpp
@@ -411,8 +411,6 @@ BetweennessCentralityAsynchronous() {
   katana::ReportStatSingle(
       "BetweennessCentralityAsynchronous", "ChunkSize", ASYNC_CHUNK_SIZE);
 
-  katana::reportPageAlloc("MemAllocPre");
-  katana::gInfo("Going to pre-allocate pages");
   katana::EnsurePreallocated(
       std::min(
           static_cast<uint64_t>(
@@ -421,8 +419,7 @@ BetweennessCentralityAsynchronous() {
               std::max((nedges / 30000000), uint64_t{5}) * 2.5),
           uint64_t{1500}) +
       5);
-  katana::gInfo("Pre-allocation complete");
-  katana::reportPageAlloc("MemAllocMid");
+  katana::ReportPageAllocGuard page_alloc;
 
   // reset everything in preparation for run
   katana::do_all(
@@ -510,7 +507,7 @@ BetweennessCentralityAsynchronous() {
 
   katana::gInfo("Number of sources with outgoing edges was ", goodSource);
 
-  katana::reportPageAlloc("MemAllocPost");
+  page_alloc.Report();
 
   // sanity
   AsynchronousSanity(bcGraph);

--- a/libgalois/src/analytics/betweenness_centrality/level.cpp
+++ b/libgalois/src/analytics/betweenness_centrality/level.cpp
@@ -255,8 +255,6 @@ BetweennessCentralityLevel(
     katana::analytics::BetweennessCentralityPlan plan [[maybe_unused]]) {
   katana::ReportStatSingle(
       "BetweennessCentrality", "ChunkSize", kLevelChunkSize);
-  katana::reportPageAlloc("MemAllocPre");
-
   // LevelGraph construction
   katana::StatTimer graph_construct_timer(
       "TimerConstructGraph", "BetweennessCentrality");
@@ -279,7 +277,7 @@ BetweennessCentralityLevel(
       size_t{katana::getActiveThreads()} * (graph.size() / 1350000),
       std::max(10U, katana::getActiveThreads()) * size_t{10}));
   prealloc_time.stop();
-  katana::reportPageAlloc("MemAllocMid");
+  katana::ReportPageAllocGuard page_alloc;
 
   // If particular set of sources was specified, use them
   std::vector<uint32_t> source_vector;
@@ -328,8 +326,6 @@ BetweennessCentralityLevel(
     LevelBackwardBrandes(&graph, &worklists, &graph_data, &active_edges);
     exec_time.stop();
   }
-
-  katana::reportPageAlloc("MemAllocPost");
 
   // Get the BC proporty into the property graph by extracting from AoS
   return ExtractBC(pg, graph, graph_data, output_property_name);

--- a/libgalois/src/analytics/betweenness_centrality/outer.cpp
+++ b/libgalois/src/analytics/betweenness_centrality/outer.cpp
@@ -257,10 +257,9 @@ BetweennessCentralityOuter(
   BCOuter bc_outer(graph);
 
   // preallocate pages for use in algorithm
-  katana::reportPageAlloc("MeminfoPre");
   katana::EnsurePreallocated(
       katana::getActiveThreads() * graph.num_nodes() / 1650);
-  katana::reportPageAlloc("MeminfoMid");
+  katana::ReportPageAllocGuard page_alloc;
 
   // vector of sources to process; initialized if doing outSources
   std::vector<uint32_t> source_vector;
@@ -307,7 +306,6 @@ BetweennessCentralityOuter(
   if (auto r = pg->AddNodeProperties(table); !r) {
     return r.error();
   }
-  katana::reportPageAlloc("MeminfoPost");
 
   return katana::ResultSuccess();
 }

--- a/libgalois/src/analytics/bfs/bfs.cpp
+++ b/libgalois/src/analytics/bfs/bfs.cpp
@@ -25,6 +25,7 @@
 #include "katana/DynamicBitset.h"
 #include "katana/ErrorCode.h"
 #include "katana/Result.h"
+#include "katana/Statistics.h"
 #include "katana/TypedPropertyGraph.h"
 #include "katana/analytics/BfsSsspImplementationBase.h"
 
@@ -511,6 +512,7 @@ BfsImpl(
 
   size_t approxNodeData = 4 * (graph.num_nodes() + graph.num_edges());
   katana::EnsurePreallocated(8, approxNodeData);
+  katana::ReportPageAllocGuard page_alloc;
 
   // TODO(lhc): due to lack of in-edge iteration, manually creates a transposed graph
   const katana::GraphTopology& topology = pg->topology();

--- a/libgalois/src/analytics/connected_components/connected_components.cpp
+++ b/libgalois/src/analytics/connected_components/connected_components.cpp
@@ -1132,6 +1132,7 @@ ConnectedComponentsWithWrap(
   katana::EnsurePreallocated(
       2,
       pg->topology().num_nodes() * sizeof(typename Algorithm::NodeComponent));
+  katana::ReportPageAllocGuard page_alloc;
 
   if (auto r = ConstructNodeProperties<
           std::tuple<typename Algorithm::NodeComponent>>(

--- a/libgalois/src/analytics/independent_set/independent_set.cpp
+++ b/libgalois/src/analytics/independent_set/independent_set.cpp
@@ -641,14 +641,13 @@ Run(katana::PropertyGraph* pg, const std::string& output_property_name) {
       1, kChunkSize * (sizeof(GNode) + sizeof(typename Algo::NodeFlag)) *
              graph.size());
 
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
   katana::StatTimer exec_time("IndependentSet");
 
   exec_time.start();
   impl(&graph);
   exec_time.stop();
-
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
   if (std::is_same<Algo, PrioAlgo>::value ||
       std::is_same<Algo, EdgeTiledPrioAlgo>::value) {

--- a/libgalois/src/analytics/k_core/k_core.cpp
+++ b/libgalois/src/analytics/k_core/k_core.cpp
@@ -20,6 +20,7 @@
 #include "katana/analytics/k_core/k_core.h"
 
 #include "katana/ArrowRandomAccessBuilder.h"
+#include "katana/Statistics.h"
 #include "katana/TypedPropertyGraph.h"
 
 using namespace katana::analytics;
@@ -200,6 +201,7 @@ KCoreImpl(
     KCorePlan algo, uint32_t k_core_number) {
   size_t approxNodeData = 4 * (graph->num_nodes() + graph->num_edges());
   katana::EnsurePreallocated(8, approxNodeData);
+  katana::ReportPageAllocGuard page_alloc;
 
   //! Intialization of degrees.
   DegreeCounting(graph);

--- a/libgalois/src/analytics/k_truss/k_truss.cpp
+++ b/libgalois/src/analytics/k_truss/k_truss.cpp
@@ -340,6 +340,8 @@ katana::Result<void>
 katana::analytics::KTruss(
     katana::PropertyGraph* pg, uint32_t k_truss_number,
     const std::string& output_property_name, KTrussPlan plan) {
+  katana::ReportPageAllocGuard page_alloc;
+
   if (auto result =
           ConstructEdgeProperties<EdgeData>(pg, {output_property_name});
       !result) {

--- a/libgalois/src/analytics/pagerank/pagerank-pull.cpp
+++ b/libgalois/src/analytics/pagerank/pagerank-pull.cpp
@@ -302,6 +302,7 @@ PagerankPullTopological(
     katana::PropertyGraph* pg, const std::string& output_property_name,
     katana::analytics::PagerankPlan plan) {
   katana::EnsurePreallocated(2, 3 * pg->num_nodes() * sizeof(NodeData));
+  katana::ReportPageAllocGuard page_alloc;
 
   // NUMA-awere temporary node data
   katana::LargeArray<PagerankValueAndOutDegreeTy> node_data;
@@ -323,6 +324,7 @@ PagerankPullResidual(
     katana::PropertyGraph* pg, const std::string& output_property_name,
     katana::analytics::PagerankPlan plan) {
   katana::EnsurePreallocated(2, 3 * pg->num_nodes() * sizeof(NodeData));
+  katana::ReportPageAllocGuard page_alloc;
 
   if (auto result = katana::analytics::ConstructNodeProperties<NodeData>(
           pg, {output_property_name});

--- a/libgalois/src/analytics/pagerank/pagerank-push.cpp
+++ b/libgalois/src/analytics/pagerank/pagerank-push.cpp
@@ -54,6 +54,7 @@ PagerankPushAsynchronous(
     katana::PropertyGraph* pg, const std::string& output_property_name,
     katana::analytics::PagerankPlan plan) {
   katana::EnsurePreallocated(5, 5 * pg->num_nodes() * sizeof(NodeData));
+  katana::ReportPageAllocGuard page_alloc;
 
   katana::analytics::TemporaryPropertyGuard temporary_property{pg};
 
@@ -112,6 +113,7 @@ PagerankPushSynchronous(
     katana::PropertyGraph* pg, const std::string& output_property_name,
     katana::analytics::PagerankPlan plan) {
   katana::EnsurePreallocated(5, 5 * pg->num_nodes() * sizeof(NodeData));
+  katana::ReportPageAllocGuard page_alloc;
 
   katana::analytics::TemporaryPropertyGuard temporary_property{pg};
 

--- a/libgalois/src/analytics/random_walks/random_walks.cpp
+++ b/libgalois/src/analytics/random_walks/random_walks.cpp
@@ -479,6 +479,8 @@ InitializeDegrees(const Graph& graph, katana::LargeArray<uint64_t>* degree) {
 template <typename Algorithm>
 static katana::Result<std::vector<std::vector<uint32_t>>>
 RandomWalksWithWrap(katana::PropertyGraph* pg, RandomWalksPlan plan) {
+  katana::ReportPageAllocGuard page_alloc;
+
   if (auto res = katana::SortAllEdgesByDest(pg); !res) {
     return res.error();
   }
@@ -506,8 +508,6 @@ RandomWalksWithWrap(katana::PropertyGraph* pg, RandomWalksPlan plan) {
   execTime.start();
   katana::InsertBag<std::vector<uint32_t>> walks;
   algo(graph, &walks, degree);
-  execTime.stop();
-
   execTime.stop();
 
   degree.destroy();

--- a/libgalois/src/analytics/sssp/sssp.cpp
+++ b/libgalois/src/analytics/sssp/sssp.cpp
@@ -20,6 +20,7 @@
 #include "katana/analytics/sssp/sssp.h"
 
 #include "katana/Reduction.h"
+#include "katana/Statistics.h"
 #include "katana/TypedPropertyGraph.h"
 #include "katana/analytics/BfsSsspImplementationBase.h"
 #include "katana/gstl.h"
@@ -414,6 +415,7 @@ public:
 
     size_t approxNodeData = graph.size() * 64;
     katana::EnsurePreallocated(1, approxNodeData);
+    katana::ReportPageAllocGuard page_alloc;
 
     katana::LargeArray<std::atomic<Weight>> node_data;
     katana::LargeArray<Weight> edge_data;

--- a/libgalois/src/analytics/triangle_count/triangle_count.cpp
+++ b/libgalois/src/analytics/triangle_count/triangle_count.cpp
@@ -330,7 +330,7 @@ katana::analytics::TriangleCount(
   timer_graph_read.stop();
 
   katana::EnsurePreallocated(1, 16 * (pg->num_nodes() + pg->num_edges()));
-  katana::reportPageAlloc("TriangleCount_MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   size_t total_count;
   katana::StatTimer execTime("TriangleCount", "TriangleCount");
@@ -349,8 +349,6 @@ katana::analytics::TriangleCount(
     return katana::ErrorCode::InvalidArgument;
   }
   execTime.stop();
-
-  katana::reportPageAlloc("TriangleCount_MeminfoPost");
 
   return total_count;
 }

--- a/libgalois/test/morph-graph.cpp
+++ b/libgalois/test/morph-graph.cpp
@@ -75,7 +75,7 @@ run(Graph& g, katana::StatTimer& timer, std::string prompt) {
       120 * f.sizeEdges() *
       sizeof(typename Graph::edge_data_type);  // 120*|E|*sizeof(E)
   katana::Prealloc(1, approxGraphSize);
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   timer.start();
   katana::profileVtune(
@@ -84,8 +84,6 @@ run(Graph& g, katana::StatTimer& timer, std::string prompt) {
       },
       "Construct MorphGraph");
   timer.stop();
-
-  katana::reportPageAlloc("MeminfoPost");
 
   initGraph(g);
   traverseGraph(g);

--- a/lonestar/analytics/cpu/bfs/bfs_cli.cpp
+++ b/lonestar/analytics/cpu/bfs/bfs_cli.cpp
@@ -142,8 +142,6 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("failed to set report: {}", reportNode);
   }
 
-  katana::reportPageAlloc("MeminfoPre");
-
   std::vector<uint32_t> startNodes;
   if (!startNodesFile.getValue().empty()) {
     std::ifstream file(startNodesFile);
@@ -171,8 +169,6 @@ main(int argc, char** argv) {
     if (auto r = Bfs(pg.get(), start_node, node_distance_prop, plan); !r) {
       KATANA_LOG_FATAL("Failed to run bfs {}", r.error());
     }
-
-    katana::reportPageAlloc("MeminfoPost");
 
     auto r = pg->GetNodePropertyTyped<uint32_t>(node_distance_prop);
     if (!r) {

--- a/lonestar/analytics/cpu/bipart/Bipart.cpp
+++ b/lonestar/analytics/cpu/bipart/Bipart.cpp
@@ -594,13 +594,13 @@ main(int argc, char** argv) {
   GraphStat(*graph);
 
   katana::Prealloc(katana::numPagePoolAllocTotal() * 20);
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   create_partition_time.start();
   CreateKPartitions(&metis_graph);
   create_partition_time.stop();
 
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
   total_time.stop();
 
   if (!output_file_name.empty()) {

--- a/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
+++ b/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
@@ -147,8 +147,6 @@ main(int argc, char** argv) {
     abort();
   }
 
-  katana::reportPageAlloc("MeminfoPre");
-
   std::cout << "Running " << AlgorithmName(algo) << " algorithm\n";
 
   ConnectedComponentsPlan plan = ConnectedComponentsPlan();
@@ -221,7 +219,6 @@ main(int argc, char** argv) {
   }
   auto stats = stats_result.value();
   stats.Print();
-  katana::reportPageAlloc("MeminfoPost");
 
   if (!skipVerify) {
     if (ConnectedComponentsAssertValid(pg.get(), "component")) {

--- a/lonestar/analytics/cpu/gmetis/GMetis.cpp
+++ b/lonestar/analytics/cpu/gmetis/GMetis.cpp
@@ -31,6 +31,7 @@
 
 #include "Metis.h"
 #include "katana/ReadGraph.h"
+#include "katana/Statistics.h"
 #include "katana/Timer.h"
 //#include "GraphReader.h"
 #include "Lonestar/BoilerPlate.h"
@@ -201,14 +202,14 @@ main(int argc, char** argv) {
   std::cout << "\n";
 
   katana::Prealloc(katana::numPagePoolAllocTotal() * 5);
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   katana::StatTimer execTime("Timer_0");
   execTime.start();
   Partition(&metisGraph, numPartitions);
   execTime.stop();
 
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
   std::cout << "Total edge cut: " << computeCut(graph) << "\n";
 

--- a/lonestar/analytics/cpu/jaccard/jaccard_cli.cpp
+++ b/lonestar/analytics/cpu/jaccard/jaccard_cli.cpp
@@ -76,21 +76,12 @@ main(int argc, char** argv) {
     abort();
   }
 
-  katana::reportPageAlloc("MeminfoPre");
-
-  katana::StatTimer execTime("Timer_0");
-  execTime.start();
-
   if (auto r = katana::analytics::Jaccard(
           pg.get(), base_node, output_property_name,
           katana::analytics::JaccardPlan());
       !r) {
     KATANA_LOG_FATAL("Jaccard failed: {}", r.error());
   }
-
-  execTime.stop();
-
-  katana::reportPageAlloc("MeminfoPost");
 
   auto pg_result = katana::TypedPropertyGraph<NodeData, EdgeData>::Make(
       pg.get(), {output_property_name}, {});

--- a/lonestar/analytics/cpu/k-core/kcore_cli.cpp
+++ b/lonestar/analytics/cpu/k-core/kcore_cli.cpp
@@ -94,8 +94,6 @@ main(int argc, char** argv) {
 
   std::cout << "Running " << AlgorithmName(algo) << "\n";
 
-  katana::reportPageAlloc("MeminfoPre");
-
   KCorePlan plan = KCorePlan();
   switch (algo) {
   case KCorePlan::kSynchronous:

--- a/lonestar/analytics/cpu/k-shortest-paths/SSSP.cpp
+++ b/lonestar/analytics/cpu/k-shortest-paths/SSSP.cpp
@@ -357,7 +357,7 @@ main(int argc, char** argv) {
 
   size_t approxNodeData = graph.size() * 64;
   katana::Prealloc(1, approxNodeData);
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   if (algoSSSP == deltaStep || algoSSSP == deltaTile) {
     katana::gInfo("Using delta-step of ", (1 << stepShift), "\n");
@@ -370,7 +370,7 @@ main(int argc, char** argv) {
 
   katana::gInfo("Running ", ALGO_NAMES_SSSP[algoSSSP], " algorithm\n");
 
-  katana::StatTimer execTime("Timer_0");
+  katana::StatTimer execTime("SSSP");
   execTime.start();
 
   katana::InsertBag<std::pair<uint32_t, Path*>> paths;
@@ -417,6 +417,7 @@ main(int argc, char** argv) {
   }
 
   execTime.stop();
+  page_alloc.Report();
 
   if (reachable) {
     std::multimap<uint32_t, Path*> paths_map;
@@ -424,8 +425,6 @@ main(int argc, char** argv) {
     for (auto pair : paths) {
       paths_map.insert(std::make_pair(pair.first, pair.second));
     }
-
-    katana::reportPageAlloc("MeminfoPost");
 
     katana::gPrint("Node ", report, " has these k paths:\n");
 

--- a/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
+++ b/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
@@ -510,7 +510,7 @@ main(int argc, char** argv) {
 
   size_t approxNodeData = graph.size() * 64;
   katana::Prealloc(1, approxNodeData);
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   if (algo == deltaStep || algo == deltaTile) {
     katana::gInfo("Using delta-step of ", (1 << stepShift), "\n");
@@ -526,16 +526,16 @@ main(int argc, char** argv) {
 
   katana::gInfo("Running ", ALGO_NAMES[algo], " algorithm\n");
 
-  katana::StatTimer execTime("Timer_0");
+  katana::StatTimer execTime("SSSP");
   execTime.start();
 
   std::vector<std::vector<std::pair<GNode, uint32_t>>> k_paths;
   YenKSP(&graph, source, report, k_paths);
 
   execTime.stop();
+  page_alloc.Report();
 
   PrintKPaths(k_paths);
-  katana::reportPageAlloc("MeminfoPost");
 
   totalTime.stop();
 

--- a/lonestar/analytics/cpu/k-truss/k_truss_cli.cpp
+++ b/lonestar/analytics/cpu/k-truss/k_truss_cli.cpp
@@ -95,8 +95,6 @@ main(int argc, char** argv) {
 
   std::cout << "Running " << AlgorithmName(algo) << "\n";
 
-  katana::reportPageAlloc("MeminfoPre");
-
   KTrussPlan plan = KTrussPlan();
   switch (algo) {
   case KTrussPlan::kBsp:

--- a/lonestar/analytics/cpu/preflowpush/Preflowpush.cpp
+++ b/lonestar/analytics/cpu/preflowpush/Preflowpush.cpp
@@ -836,14 +836,14 @@ main(int argc, char** argv) {
             << "\n";
 
   katana::Prealloc(1, app.graph.size());
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   katana::StatTimer execTime("Timer_0");
   execTime.start();
   app.run();
   execTime.stop();
 
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
   std::cout << "Flow is " << app.graph.getData(app.sink).excess << "\n";
 

--- a/lonestar/analytics/cpu/random-walks/random_walks_cli.cpp
+++ b/lonestar/analytics/cpu/random-walks/random_walks_cli.cpp
@@ -117,8 +117,6 @@ main(int argc, char** argv) {
   std::cout << "Read " << pg->topology().num_nodes() << " nodes, "
             << pg->topology().num_edges() << " edges\n";
 
-  katana::reportPageAlloc("MeminfoPre");
-
   std::cout << "Running " << AlgorithmName(algo) << " algorithm\n";
 
   RandomWalksPlan plan = RandomWalksPlan();

--- a/lonestar/analytics/cpu/spanningtree/Boruvka.cpp
+++ b/lonestar/analytics/cpu/spanningtree/Boruvka.cpp
@@ -391,14 +391,14 @@ run() {
   Tinitial.stop();
 
   katana::Prealloc(8, 16 * (algo.graph.size() + algo.graph.sizeEdges()));
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
-  katana::StatTimer execTime("Timer_0");
+  katana::StatTimer execTime("Boruvka");
   execTime.start();
   katana::profileVtune([&](void) { algo(); }, "boruvka");
   execTime.stop();
 
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
   auto get_weight = [](const Edge& e) { return *e.weight; };
 

--- a/lonestar/analytics/cpu/sssp/sssp_cli.cpp
+++ b/lonestar/analytics/cpu/sssp/sssp_cli.cpp
@@ -171,8 +171,6 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("failed to set report: {}", reportNode);
   }
 
-  katana::reportPageAlloc("MeminfoPre");
-
   std::vector<uint32_t> startNodes;
   if (!startNodesFile.getValue().empty()) {
     std::ifstream file(startNodesFile);

--- a/lonestar/tutorial_examples/CountLevels.cpp
+++ b/lonestar/tutorial_examples/CountLevels.cpp
@@ -23,6 +23,7 @@
 #include "katana/Galois.h"
 #include "katana/LCGraph.h"
 #include "katana/Reduction.h"
+#include "katana/Statistics.h"
 #include "katana/Timer.h"
 
 static const char* name = "Count levels";
@@ -135,7 +136,7 @@ main(int argc, char** argv) {
 
   katana::Prealloc(
       5, 2 * graph.size() * sizeof(typename Graph::node_data_type));
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   katana::do_all(
       katana::iterate(graph),
@@ -163,7 +164,7 @@ main(int argc, char** argv) {
   const auto& counts = countLevels(graph);
   T.stop();
 
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
 #if DEBUG
   for (auto n : graph) {

--- a/lonestar/tutorial_examples/ExampleTriangleCount.cpp
+++ b/lonestar/tutorial_examples/ExampleTriangleCount.cpp
@@ -304,13 +304,13 @@ main(int argc, char** argv) {
   timer_graph_read.stop();
 
   katana::Prealloc(1, 16 * (graph.num_nodes() + graph.num_edges()));
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
 
   katana::gInfo("Starting triangle counting...");
 
   katana::StatTimer execTime("Timer_0");
   execTime.start();
-  // case by case preAlloc to avoid allocating unnecessarily
+
   switch (algo) {
   case nodeiterator:
     NodeIteratingAlgo(graph);
@@ -325,7 +325,7 @@ main(int argc, char** argv) {
   }
   execTime.stop();
 
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
   totalTime.stop();
 

--- a/lonestar/tutorial_examples/SpanningTree.cpp
+++ b/lonestar/tutorial_examples/SpanningTree.cpp
@@ -120,7 +120,7 @@ main(int argc, char** argv) {
     sdata.setComponent(sdata.findAndCompress());
   };
 
-  katana::reportPageAlloc("MeminfoPre");
+  katana::ReportPageAllocGuard page_alloc;
   katana::StatTimer T;
   T.start();
   switch (algo) {
@@ -211,7 +211,7 @@ main(int argc, char** argv) {
     std::cerr << "Unknown algo: " << algo << "\n";
   }
   T.stop();
-  katana::reportPageAlloc("MeminfoPost");
+  page_alloc.Report();
 
   /* Verification Routines */
   auto is_bad_graph = [&](const GNode& n) {


### PR DESCRIPTION
Push prealloc reporting to analytics library where it can be used by all
callers rather than keeping reporting to only the command-line
interface.

Along the way, make execution timer names more consistent.