### PR TITLE
Introduce explicit Property type

### DIFF
--- a/libgalois/src/analytics/connected_components/connected_components.cpp
+++ b/libgalois/src/analytics/connected_components/connected_components.cpp
@@ -50,10 +50,7 @@ struct ConnectedComponentsNode
 
 struct ConnectedComponentsSerialAlgo {
   using ComponentType = ConnectedComponentsNode*;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<ComponentType>;
-  };
+  struct NodeComponent : katana::PODProperty<uint64_t, ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -98,10 +95,7 @@ struct ConnectedComponentsSerialAlgo {
 
 struct ConnectedComponentsLabelPropAlgo {
   using ComponentType = uint64_t;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<ComponentType>::ArrowType;
-    using ViewType = katana::PODPropertyView<std::atomic<ComponentType>>;
-  };
+  struct NodeComponent : public katana::AtomicPODProperty<ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -153,10 +147,7 @@ struct ConnectedComponentsLabelPropAlgo {
 
 struct ConnectedComponentsSynchronousAlgo {
   using ComponentType = ConnectedComponentsNode*;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<ComponentType>;
-  };
+  struct NodeComponent : public katana::PODProperty<uint64_t, ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -268,10 +259,7 @@ struct ConnectedComponentsSynchronousAlgo {
 
 struct ConnectedComponentsAsynchronousAlgo {
   using ComponentType = ConnectedComponentsNode*;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<ComponentType>;
-  };
+  struct NodeComponent : public katana::PODProperty<uint64_t, ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -333,10 +321,7 @@ struct ConnectedComponentsAsynchronousAlgo {
 
 struct ConnectedComponentsEdgeAsynchronousAlgo {
   using ComponentType = ConnectedComponentsNode*;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<ComponentType>;
-  };
+  struct NodeComponent : public katana::PODProperty<uint64_t, ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -410,10 +395,7 @@ struct ConnectedComponentsEdgeAsynchronousAlgo {
 
 struct ConnectedComponentsBlockedAsynchronousAlgo {
   using ComponentType = ConnectedComponentsNode*;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<ComponentType>;
-  };
+  struct NodeComponent : public katana::PODProperty<uint64_t, ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -508,10 +490,7 @@ struct ConnectedComponentsBlockedAsynchronousAlgo {
 
 struct ConnectedComponentsEdgeTiledAsynchronousAlgo {
   using ComponentType = ConnectedComponentsNode*;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<ComponentType>;
-  };
+  struct NodeComponent : public katana::PODProperty<uint64_t, ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -705,10 +684,8 @@ struct ConnectedComponentsAfforestAlgo {
     }
   };
 
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<NodeAfforest::ComponentType>;
-  };
+  struct NodeComponent
+      : public katana::PODProperty<uint64_t, NodeAfforest::ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;
@@ -854,9 +831,8 @@ struct ConnectedComponentsEdgeAfforestAlgo {
   };
 
   using ComponentType = NodeAfforestEdge::ComponentType;
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<NodeAfforestEdge::ComponentType>;
+  struct NodeComponent
+      : public katana::PODProperty<uint64_t, NodeAfforestEdge::ComponentType> {
   };
 
   using NodeData = std::tuple<NodeComponent>;
@@ -1002,10 +978,8 @@ struct ConnectedComponentsEdgeTiledAfforestAlgo {
     }
   };
 
-  struct NodeComponent {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<NodeAfforest::ComponentType>;
-  };
+  struct NodeComponent
+      : public katana::PODProperty<uint64_t, NodeAfforest::ComponentType> {};
 
   using NodeData = std::tuple<NodeComponent>;
   using EdgeData = std::tuple<>;

--- a/libgalois/src/analytics/independent_set/independent_set.cpp
+++ b/libgalois/src/analytics/independent_set/independent_set.cpp
@@ -56,10 +56,7 @@ enum MatchFlag : char {
 static_assert(sizeof(MatchFlag) == sizeof(uint8_t));
 
 struct SerialAlgo {
-  struct NodeFlag {
-    using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<MatchFlag>;
-  };
+  struct NodeFlag : public katana::PODProperty<uint8_t, MatchFlag> {};
   using NodeData = std::tuple<NodeFlag>;
   using EdgeData = std::tuple<>;
 
@@ -106,10 +103,7 @@ struct SerialAlgo {
 
 template <IndependentSetPlan::Algorithm algo>
 struct TransactionalAlgo {
-  struct NodeFlag {
-    using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<MatchFlag>;
-  };
+  struct NodeFlag : public katana::PODProperty<uint8_t, MatchFlag> {};
   using NodeData = std::tuple<NodeFlag>;
   using EdgeData = std::tuple<>;
 
@@ -198,10 +192,7 @@ struct TransactionalAlgo {
 };
 
 struct PullAlgo {
-  struct NodeFlag {
-    using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<MatchFlag>;
-  };
+  struct NodeFlag : public katana::PODProperty<uint8_t, MatchFlag> {};
   using NodeData = std::tuple<NodeFlag>;
   using EdgeData = std::tuple<>;
 
@@ -332,10 +323,7 @@ const auto kTemporaryYes = uint8_t{0x02};
 const auto kPermanentNo = uint8_t{0x00};
 
 struct PrioAlgo {
-  struct NodeFlag {
-    using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<uint8_t>;
-  };
+  struct NodeFlag : public katana::PODProperty<uint8_t> {};
 
   using NodeData = std::tuple<NodeFlag>;
   using EdgeData = std::tuple<>;
@@ -423,10 +411,7 @@ struct PrioAlgo {
 };
 
 struct EdgeTiledPrioAlgo {
-  struct NodeFlag {
-    using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<uint8_t>;
-  };
+  struct NodeFlag : public katana::PODProperty<uint8_t> {};
 
   using NodeData = std::tuple<NodeFlag>;
   using EdgeData = std::tuple<>;
@@ -577,10 +562,7 @@ struct EdgeTiledPrioAlgo {
 };
 
 struct IsBad {
-  struct NodeFlag {
-    using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<uint8_t>;
-  };
+  struct NodeFlag : public katana::PODProperty<uint8_t> {};
   using NodeData = std::tuple<NodeFlag>;
   using EdgeData = std::tuple<>;
 

--- a/libgalois/src/analytics/k_core/k_core.cpp
+++ b/libgalois/src/analytics/k_core/k_core.cpp
@@ -31,10 +31,7 @@ const int KCorePlan::kChunkSize = 64;
  ******************************************************************************/
 //! Node deadness can be derived from current degree and k value, so no field
 //! necessary.
-struct KCoreNodeCurrentDegree {
-  using ArrowType = arrow::CTypeTraits<uint32_t>::ArrowType;
-  using ViewType = katana::PODPropertyView<std::atomic<uint32_t>>;
-};
+struct KCoreNodeCurrentDegree : public katana::AtomicPODProperty<uint32_t> {};
 
 struct KCoreNodeAlive : public katana::PODProperty<uint32_t> {};
 

--- a/libgalois/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
+++ b/libgalois/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
@@ -27,10 +27,7 @@ namespace {
 constexpr static const unsigned kChunkSize = 64U;
 
 struct LocalClusteringCoefficientAtomics {
-  struct NodeTriangleCount {
-    using ArrowType = arrow::CTypeTraits<uint64_t>::ArrowType;
-    using ViewType = katana::PODPropertyView<std::atomic<uint64_t>>;
-  };
+  struct NodeTriangleCount : public katana::AtomicPODProperty<uint64_t> {};
 
   struct NodeClusteringCoefficient : public katana::PODProperty<double> {};
 

--- a/libgalois/src/analytics/pagerank/pagerank-push.cpp
+++ b/libgalois/src/analytics/pagerank/pagerank-push.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "katana/AtomicHelpers.h"
+#include "katana/Properties.h"
 #include "katana/TypedPropertyGraph.h"
 #include "katana/analytics/Utils.h"
 #include "pagerank-impl.h"
@@ -26,10 +27,7 @@ using katana::atomicAdd;
 
 namespace {
 
-struct NodeResidual {
-  using ArrowType = arrow::CTypeTraits<PRTy>::ArrowType;
-  using ViewType = katana::PODPropertyView<std::atomic<PRTy>>;
-};
+struct NodeResidual : katana::AtomicPODProperty<PRTy> {};
 
 using NodeData = std::tuple<NodeValue, NodeResidual>;
 using EdgeData = std::tuple<>;

--- a/libgalois/src/analytics/sssp/sssp.cpp
+++ b/libgalois/src/analytics/sssp/sssp.cpp
@@ -29,10 +29,7 @@ using namespace katana::analytics;
 namespace {
 
 template <typename Weight>
-struct SsspNodeDistance {
-  using ArrowType = typename arrow::CTypeTraits<Weight>::ArrowType;
-  using ViewType = katana::PODPropertyView<std::atomic<Weight>>;
-};
+struct SsspNodeDistance : public katana::AtomicPODProperty<Weight> {};
 
 template <typename Weight>
 using SsspEdgeWeight = katana::PODProperty<Weight>;

--- a/lonestar/analytics/cpu/k-shortest-paths/SSSP.cpp
+++ b/lonestar/analytics/cpu/k-shortest-paths/SSSP.cpp
@@ -76,15 +76,9 @@ struct Path {
   const Path* last{nullptr};
 };
 
-struct NodeCount {
-  using ArrowType = arrow::CTypeTraits<uint32_t>::ArrowType;
-  using ViewType = katana::PODPropertyView<std::atomic<uint32_t>>;
-};
+struct NodeCount : public katana::AtomicPODProperty<uint32_t> {};
 
-struct NodeMax {
-  using ArrowType = arrow::CTypeTraits<uint32_t>::ArrowType;
-  using ViewType = katana::PODPropertyView<std::atomic<uint32_t>>;
-};
+struct NodeMax : public katana::AtomicPODProperty<uint32_t> {};
 
 using EdgeWeight = katana::UInt32Property;
 

--- a/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
+++ b/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
@@ -23,6 +23,7 @@
 #include "Lonestar/BoilerPlate.h"
 #include "Lonestar/K_SSSP.h"
 #include "katana/AtomicHelpers.h"
+#include "katana/Properties.h"
 #include "katana/TypedPropertyGraph.h"
 
 namespace cll = llvm::cl;
@@ -68,15 +69,9 @@ struct Path {
   const Path* last;
 };
 
-struct NodeDist {
-  using ArrowType = arrow::CTypeTraits<uint32_t>::ArrowType;
-  using ViewType = katana::PODPropertyView<std::atomic<uint32_t>>;
-};
+struct NodeDist : public katana::AtomicPODProperty<uint32_t> {};
 
-struct NodeAlive {
-  using ArrowType = arrow::CTypeTraits<uint8_t>::ArrowType;
-  using ViewType = katana::PODPropertyView<uint8_t>;
-};
+struct NodeAlive : public katana::PODProperty<uint8_t> {};
 
 struct EdgeWeight : public katana::PODProperty<uint32_t> {};
 


### PR DESCRIPTION
Properties still use static dispatch and still accept any type that
models the required features (ArrowType, ViewType, Allocate), but
rearrange the Property interface to look more like simple subclassing,
which should be familiar to more developers.

Update all existing Properties to have Allocate defined. This avoids
needing the metatemplate function HasAllocate