### PR TITLE
Hack to fix conda build failure caused by incorrect libthrift dep

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -5,6 +5,8 @@ channels:
  - conda-forge
 dependencies:
  - arrow-cpp<3.0.0a0
+ # TODO(amp): Remove as soon as libthrift/arrow-cpp are fixed. https://github.com/conda-forge/arrow-cpp-feedstock/issues/461
+ - libthrift 0.14.1
  - backward-cpp>=1.4
  - benchmark
  - black=19.10

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - jinja2
     - cython>=0.29.12
     - pyarrow {{ arrow_cpp }}
+    # TODO(amp): Remove as soon as libthrift/arrow-cpp are fixed. https://github.com/conda-forge/arrow-cpp-feedstock/issues/461
+    - libthrift 0.14.1
     - numba>=0.50,<1.0a0
     - python {{ python }}
     - sphinx>=3.5.1
@@ -64,6 +66,8 @@ outputs:
       host:
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
+        # TODO(amp): Remove as soon as libthrift/arrow-cpp are fixed. https://github.com/conda-forge/arrow-cpp-feedstock/issues/461
+        - libthrift 0.14.1
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
@@ -78,6 +82,8 @@ outputs:
       run:
         - boost-cpp
         - arrow-cpp
+        # TODO(amp): Remove as soon as libthrift/arrow-cpp are fixed. https://github.com/conda-forge/arrow-cpp-feedstock/issues/461
+        - libthrift 0.14.1
         - fmt
         - nlohmann_json
         - libcurl


### PR DESCRIPTION
This may not need to be merged if https://github.com/conda-forge/arrow-cpp-feedstock/issues/461 is fixed before we have problems.
