### PR TITLE
tsuba: don't use `katana::Result` in future

### DIFF
--- a/libsupport/src/Result.cpp
+++ b/libsupport/src/Result.cpp
@@ -70,6 +70,9 @@ thread_local katana::ErrorInfo::Context kContext;
 
 }  // namespace
 
+katana::ErrorInfo::ErrorInfo(const CopyableErrorInfo& cei)
+    : ErrorInfo(cei.error_code(), cei.message()) {}
+
 static_assert(
     fmt::inline_buffer_size > katana::ErrorInfo::kContextSize / 2,
     "libfmt buffer size is small relative to max ErrorInfo context size");
@@ -100,6 +103,9 @@ katana::ErrorInfo::SpillMessage() {
   }
 }
 
+/// Doxygen cannot match this definition with its declaration in Result.h
+/// \cond DO_NOT_DOCUMENT
+// TODO(ddn): Revisit
 void
 katana::ErrorInfo::Prepend(const char* begin, const char* end) {
   CheckContext();
@@ -116,9 +122,6 @@ katana::ErrorInfo::Prepend(const char* begin, const char* end) {
   context_.second = context_.first->size();
 }
 
-/// Doxygen cannot match this definition with its declaration in Result.h
-/// \cond DO_NOT_DOCUMENT
-// TODO(ddn): Revisit
 std::ostream&
 katana::ErrorInfo::Write(std::ostream& out) const {
   if ((context_.first && context_.first != &kContext) ||
@@ -158,5 +161,10 @@ katana::CopyableErrorInfo::Write(std::ostream& out) const {
 
 katana::Result<void>
 katana::ResultSuccess() {
+  return BOOST_OUTCOME_V2_NAMESPACE::success();
+}
+
+katana::CopyableResult<void>
+katana::CopyableResultSuccess() {
   return BOOST_OUTCOME_V2_NAMESPACE::success();
 }

--- a/libtsuba/include/tsuba/AsyncOpGroup.h
+++ b/libtsuba/include/tsuba/AsyncOpGroup.h
@@ -11,16 +11,16 @@ namespace tsuba {
 class AsyncOpGroup {
 public:
   struct AsyncOp {
-    std::future<katana::Result<void>> result;
+    std::future<katana::CopyableResult<void>> result;
     std::string location;
-    std::function<katana::Result<void>()> on_complete;
+    std::function<katana::CopyableResult<void>()> on_complete;
   };
 
   /// Add future to the list of futures this descriptor will wait for, note
   /// the file name for debugging.
   void AddOp(
-      std::future<katana::Result<void>> future, std::string file,
-      const std::function<katana::Result<void>()>& on_complete);
+      std::future<katana::CopyableResult<void>> future, std::string file,
+      const std::function<katana::CopyableResult<void>()>& on_complete);
 
   /// Wait until all operations this descriptor knows about have completed
   katana::Result<void> Finish();
@@ -31,7 +31,7 @@ private:
   std::list<AsyncOp> pending_ops_;
   uint64_t errors_{0};
   uint64_t total_{0};
-  katana::Result<void> last_error_{katana::ResultSuccess()};
+  katana::CopyableErrorInfo last_error_;
 };
 
 }  // namespace tsuba

--- a/libtsuba/include/tsuba/FileFrame.h
+++ b/libtsuba/include/tsuba/FileFrame.h
@@ -67,7 +67,7 @@ public:
   katana::Result<void> Destroy();
 
   katana::Result<void> Persist();
-  std::future<katana::Result<void>> PersistAsync();
+  std::future<katana::CopyableResult<void>> PersistAsync();
 
   uint64_t map_size() const { return map_size_; }
 

--- a/libtsuba/include/tsuba/FileStorage.h
+++ b/libtsuba/include/tsuba/FileStorage.h
@@ -49,12 +49,12 @@ public:
   virtual uint32_t Priority() const { return 0; }
 
   // get on future can potentially block (bulk synchronous parallel)
-  virtual std::future<katana::Result<void>> PutAsync(
+  virtual std::future<katana::CopyableResult<void>> PutAsync(
       const std::string& uri, const uint8_t* data, uint64_t size) = 0;
-  virtual std::future<katana::Result<void>> GetAsync(
+  virtual std::future<katana::CopyableResult<void>> GetAsync(
       const std::string& uri, uint64_t start, uint64_t size,
       uint8_t* result_buf) = 0;
-  virtual std::future<katana::Result<void>> ListAsync(
+  virtual std::future<katana::CopyableResult<void>> ListAsync(
       const std::string& directory, std::vector<std::string>* list,
       std::vector<uint64_t>* size) = 0;
   virtual katana::Result<void> Delete(

--- a/libtsuba/include/tsuba/FileView.h
+++ b/libtsuba/include/tsuba/FileView.h
@@ -18,7 +18,7 @@ class KATANA_EXPORT FileView : public arrow::io::RandomAccessFile {
   struct FillingRange {
     uint64_t first_page;
     uint64_t last_page;
-    std::future<katana::Result<void>> work;
+    std::future<katana::CopyableResult<void>> work;
   };
 
   uint8_t* map_start_{nullptr};

--- a/libtsuba/include/tsuba/WriteGroup.h
+++ b/libtsuba/include/tsuba/WriteGroup.h
@@ -16,7 +16,7 @@ namespace tsuba {
 /// that they have all completed
 class WriteGroup {
   struct AsyncOp {
-    std::future<katana::Result<void>> result;
+    std::future<katana::CopyableResult<void>> result;
     std::string location;
     uint64_t accounted_size;
   };
@@ -54,7 +54,7 @@ public:
   /// the file name for debugging. If the operation is associated with a file
   /// frame that we are responsible for, note the size
   void AddOp(
-      std::future<katana::Result<void>> future, std::string file,
+      std::future<katana::CopyableResult<void>> future, std::string file,
       uint64_t accounted_size = 0);
 };
 

--- a/libtsuba/include/tsuba/file.h
+++ b/libtsuba/include/tsuba/file.h
@@ -36,7 +36,11 @@ struct StatBuf {
 KATANA_EXPORT katana::Result<void> FileStat(
     const std::string& uri, StatBuf* s_buf);
 
-// Take whatever is in @data and put it a file called @uri
+/// Take whatever is in a buffer and put it in the file
+///
+/// \param uri the destination file to fill with data
+/// \param data a pointer to the buffer containing data
+/// \param size the length of the buffer
 KATANA_EXPORT katana::Result<void> FileStore(
     const std::string& uri, const void* data, uint64_t size);
 
@@ -65,8 +69,12 @@ KATANA_EXPORT katana::Result<void> FileRemoteCopy(
     const std::string& source_uri, const std::string& dest_uri, uint64_t begin,
     uint64_t size);
 
-// Take whatever is in @data and start putting it a the file called @uri
-KATANA_EXPORT std::future<katana::Result<void>> FileStoreAsync(
+/// Take whatever is in a buffer and put it in the file
+///
+/// \param uri the destination file to fill with data
+/// \param data a pointer to the buffer containing data
+/// \param size the length of the buffer
+KATANA_EXPORT std::future<katana::CopyableResult<void>> FileStoreAsync(
     const std::string& uri, const void* data, uint64_t size);
 
 // read a part of the file into a caller defined buffer
@@ -82,7 +90,7 @@ FileGet(const StrType& uri, T* obj) {
 }
 
 // start reading a part of the file into a caller defined buffer
-KATANA_EXPORT std::future<katana::Result<void>> FileGetAsync(
+KATANA_EXPORT std::future<katana::CopyableResult<void>> FileGetAsync(
     const std::string& uri, void* result_buffer, uint64_t begin, uint64_t size);
 
 /// List the set of files in a directory
@@ -94,7 +102,7 @@ KATANA_EXPORT std::future<katana::Result<void>> FileGetAsync(
 ///
 /// \return future; files will be in `list` after this object
 /// reports its return value
-KATANA_EXPORT std::future<katana::Result<void>> FileListAsync(
+KATANA_EXPORT std::future<katana::CopyableResult<void>> FileListAsync(
     const std::string& directory, std::vector<std::string>* list,
     std::vector<uint64_t>* size = nullptr);
 

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -82,10 +82,11 @@ tsuba::AddProperties(
   for (const tsuba::PropStorageInfo& prop : properties) {
     const std::string& name = prop.name;
     const katana::Uri& path = uri.Join(prop.path);
-    std::future<katana::Result<std::shared_ptr<arrow::Table>>> future =
+    std::future<katana::CopyableResult<std::shared_ptr<arrow::Table>>> future =
         std::async(
             std::launch::async,
-            [name, path]() -> katana::Result<std::shared_ptr<arrow::Table>> {
+            [name,
+             path]() -> katana::CopyableResult<std::shared_ptr<arrow::Table>> {
               auto load_result = LoadProperties(name, path);
               if (!load_result) {
                 return load_result.error().WithContext(
@@ -95,12 +96,12 @@ tsuba::AddProperties(
             });
     auto on_complete = [add_fn,
                         name](const std::shared_ptr<arrow::Table>& props)
-        -> katana::Result<void> {
+        -> katana::CopyableResult<void> {
       auto add_result = add_fn(props);
       if (!add_result) {
         return add_result.error().WithContext("adding {}", std::quoted(name));
       }
-      return katana::ResultSuccess();
+      return katana::CopyableResultSuccess();
     };
     if (grp) {
       grp->AddReturnsOp<std::shared_ptr<arrow::Table>>(
@@ -132,11 +133,11 @@ tsuba::AddPropertySlice(
   for (const tsuba::PropStorageInfo& prop : properties) {
     const std::string& name = prop.name;
     const katana::Uri& path = dir.Join(prop.path);
-    std::future<katana::Result<std::shared_ptr<arrow::Table>>> future =
+    std::future<katana::CopyableResult<std::shared_ptr<arrow::Table>>> future =
         std::async(
             std::launch::async,
             [name, path, begin,
-             size]() -> katana::Result<std::shared_ptr<arrow::Table>> {
+             size]() -> katana::CopyableResult<std::shared_ptr<arrow::Table>> {
               auto load_result = LoadPropertySlice(name, path, begin, size);
               if (!load_result) {
                 return load_result.error().WithContext(
@@ -146,12 +147,12 @@ tsuba::AddPropertySlice(
             });
     auto on_complete = [add_fn,
                         name](const std::shared_ptr<arrow::Table>& props)
-        -> katana::Result<void> {
+        -> katana::CopyableResult<void> {
       auto add_result = add_fn(props);
       if (!add_result) {
         return add_result.error().WithContext("adding {}", std::quoted(name));
       }
-      return katana::ResultSuccess();
+      return katana::CopyableResultSuccess();
     };
     if (grp) {
       grp->AddReturnsOp<std::shared_ptr<arrow::Table>>(

--- a/libtsuba/src/AsyncOpGroup.cpp
+++ b/libtsuba/src/AsyncOpGroup.cpp
@@ -31,17 +31,17 @@ tsuba::AsyncOpGroup::Finish() {
   }
 
   if (errors_ > 0) {
-    return last_error_.error().WithContext(
+    return last_error_.WithContext(
         "{} of {} async write ops returned errors", errors_, total_);
   }
 
-  return last_error_;
+  return katana::ResultSuccess();
 }
 
 void
 tsuba::AsyncOpGroup::AddOp(
-    std::future<katana::Result<void>> future, std::string file,
-    const std::function<katana::Result<void>()>& on_complete) {
+    std::future<katana::CopyableResult<void>> future, std::string file,
+    const std::function<katana::CopyableResult<void>()>& on_complete) {
   pending_ops_.emplace_back(AsyncOp{
       .result = std::move(future),
       .location = std::move(file),

--- a/libtsuba/src/FileFrame.cpp
+++ b/libtsuba/src/FileFrame.cpp
@@ -120,17 +120,19 @@ FileFrame::Persist() {
   return katana::ResultSuccess();
 }
 
-std::future<katana::Result<void>>
+std::future<katana::CopyableResult<void>>
 FileFrame::PersistAsync() {
   if (!valid_) {
-    return std::async(std::launch::deferred, []() -> katana::Result<void> {
-      return KATANA_ERROR(ErrorCode::InvalidArgument, "not bound");
-    });
+    return std::async(
+        std::launch::deferred, []() -> katana::CopyableResult<void> {
+          return KATANA_ERROR(ErrorCode::InvalidArgument, "not bound");
+        });
   }
   if (path_.empty()) {
-    return std::async(std::launch::deferred, []() -> katana::Result<void> {
-      return KATANA_ERROR(ErrorCode::InvalidArgument, "no path provided");
-    });
+    return std::async(
+        std::launch::deferred, []() -> katana::CopyableResult<void> {
+          return KATANA_ERROR(ErrorCode::InvalidArgument, "no path provided");
+        });
   }
   return tsuba::FileStoreAsync(path_, map_start_, cursor_);
 }

--- a/libtsuba/src/LocalStorage.cpp
+++ b/libtsuba/src/LocalStorage.cpp
@@ -121,7 +121,7 @@ tsuba::LocalStorage::Stat(const std::string& uri, StatBuf* s_buf) {
 }
 
 // Current implementation is not async
-std::future<katana::Result<void>>
+std::future<katana::CopyableResult<void>>
 tsuba::LocalStorage::ListAsync(
     const std::string& uri, std::vector<std::string>* list,
     std::vector<uint64_t>* size) {
@@ -134,15 +134,16 @@ tsuba::LocalStorage::ListAsync(
   if ((dirp = opendir(dirname.c_str())) == nullptr) {
     if (errno == ENOENT) {
       // other storage backends are flat and so return an empty list here
-      return std::async(std::launch::deferred, []() -> katana::Result<void> {
-        return katana::ResultSuccess();
-      });
+      return std::async(
+          std::launch::deferred, []() -> katana::CopyableResult<void> {
+            return katana::CopyableResultSuccess();
+          });
     }
 
     std::error_code ec = katana::ResultErrno();
 
     return std::async(
-        std::launch::deferred, [ec, dirname]() -> katana::Result<void> {
+        std::launch::deferred, [ec, dirname]() -> katana::CopyableResult<void> {
           return KATANA_ERROR(
               ErrorCode::LocalStorageError, "open dir failed: {}: {}", dirname,
               ec.message());
@@ -176,7 +177,7 @@ tsuba::LocalStorage::ListAsync(
     std::error_code ec = katana::ResultErrno();
 
     return std::async(
-        std::launch::deferred, [ec, dirname]() -> katana::Result<void> {
+        std::launch::deferred, [ec, dirname]() -> katana::CopyableResult<void> {
           return KATANA_ERROR(
               ErrorCode::LocalStorageError, "readdir failed: {}: {}", dirname,
               ec.message());
@@ -185,9 +186,10 @@ tsuba::LocalStorage::ListAsync(
 
   (void)closedir(dirp);
 
-  return std::async(std::launch::deferred, []() -> katana::Result<void> {
-    return katana::ResultSuccess();
-  });
+  return std::async(
+      std::launch::deferred, []() -> katana::CopyableResult<void> {
+        return katana::CopyableResultSuccess();
+      });
 }
 
 katana::Result<void>

--- a/libtsuba/src/ReadGroup.cpp
+++ b/libtsuba/src/ReadGroup.cpp
@@ -2,8 +2,8 @@
 
 void
 tsuba::ReadGroup::AddOp(
-    std::future<katana::Result<void>> future, std::string file,
-    const std::function<katana::Result<void>()>& on_complete) {
+    std::future<katana::CopyableResult<void>> future, std::string file,
+    const std::function<katana::CopyableResult<void>()>& on_complete) {
   async_op_group_.AddOp(std::move(future), std::move(file), on_complete);
 }
 

--- a/libtsuba/src/WriteGroup.cpp
+++ b/libtsuba/src/WriteGroup.cpp
@@ -33,7 +33,7 @@ WriteGroup::Finish() {
 
 void
 WriteGroup::AddOp(
-    std::future<katana::Result<void>> future, std::string file,
+    std::future<katana::CopyableResult<void>> future, std::string file,
     uint64_t accounted_size) {
   if (accounted_size > kMaxOutstandingSize) {
     accounted_size = kMaxOutstandingSize;
@@ -49,9 +49,9 @@ WriteGroup::AddOp(
   }
   async_op_group_.AddOp(
       std::move(future), std::move(file),
-      [wg = this, accounted_size]() -> katana::Result<void> {
+      [wg = this, accounted_size]() -> katana::CopyableResult<void> {
         wg->outstanding_size_ -= accounted_size;
-        return katana::ResultSuccess();
+        return katana::CopyableResultSuccess();
       });
 }
 

--- a/libtsuba/src/file.cpp
+++ b/libtsuba/src/file.cpp
@@ -25,7 +25,7 @@ tsuba::FileStore(const std::string& uri, const void* data, uint64_t size) {
   return FS(uri)->PutMultiSync(uri, static_cast<const uint8_t*>(data), size);
 }
 
-std::future<katana::Result<void>>
+std::future<katana::CopyableResult<void>>
 tsuba::FileStoreAsync(const std::string& uri, const void* data, uint64_t size) {
   return FS(uri)->PutAsync(uri, static_cast<const uint8_t*>(data), size);
 }
@@ -38,7 +38,7 @@ tsuba::FileGet(
       uri, begin, size, static_cast<uint8_t*>(result_buffer));
 }
 
-std::future<katana::Result<void>>
+std::future<katana::CopyableResult<void>>
 tsuba::FileGetAsync(
     const std::string& uri, void* result_buffer, uint64_t begin,
     uint64_t size) {
@@ -66,7 +66,7 @@ tsuba::FileStat(const std::string& uri, StatBuf* s_buf) {
   return FS(uri)->Stat(uri, s_buf);
 }
 
-std::future<katana::Result<void>>
+std::future<katana::CopyableResult<void>>
 tsuba::FileListAsync(
     const std::string& directory, std::vector<std::string>* list,
     std::vector<uint64_t>* size) {


### PR DESCRIPTION
Thread local context doesn't work when passing values between threads.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>

Closes #227