### PR TITLE
Do not use fmt 8.

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -20,7 +20,7 @@ dependencies:
  - doxygen
  - eigen
  - elfutils
- - fmt>=6.2.1
+ - fmt>=6.2.1,<8.0a0
  - isort
  - jinja2
  - jupyter

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - backward-cpp>=1.4
     - boost-cpp>=1.74
     - elfutils
-    - fmt>=6.2.1
+    - fmt>=6.2.1,<8.0a0
     - libcurl>=7.66
     - libxml2>=2.9.10
     - llvm>=8
@@ -71,7 +71,7 @@ outputs:
         - backward-cpp>=1.4
         - boost-cpp>=1.74
         - elfutils
-        - fmt>=6.2.1
+        - fmt>=6.2.1,<8.0a0
         - libcurl>=7.66
         - libxml2>=2.9.10
         - llvm>=8


### PR DESCRIPTION
This will need to be really fixed by eliminating our use of deprecated functions.