### PR TITLE
[KAT-716] [RFC-ENG-027] Result Propagation with Raising Macros

### DIFF
--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -275,9 +275,9 @@ extract_result_value(Result<void>&&) {
 
 }  // namespace internal
 
-#define KATANA_CHECK_NAME(x, y) x##y
+#define KATANA_CHECKED_NAME(x, y) x##y
 
-#define KATANA_CHECK_IMPL(result_name, expression, ...)                        \
+#define KATANA_CHECKED_IMPL(result_name, expression, ...)                      \
   ({                                                                           \
     auto result_name = (expression);                                           \
     if (!result_name) {                                                        \
@@ -287,12 +287,13 @@ extract_result_value(Result<void>&&) {
         ::katana::internal::extract_result_value(std::move(result_name)));     \
   })
 
-#define KATANA_CHECK_CONTEXT(expression, ...)                                  \
-  KATANA_CHECK_IMPL(                                                           \
-      KATANA_CHECK_NAME(_error_or_value, __COUNTER__), expression,             \
+#define KATANA_CHECKED_CONTEXT(expression, ...)                                \
+  KATANA_CHECKED_IMPL(                                                         \
+      KATANA_CHECKED_NAME(_error_or_value, __COUNTER__), expression,           \
       __VA_ARGS__)
 
-#define KATANA_CHECK(expression) KATANA_CHECK_CONTEXT(expression, "backtrace")
+#define KATANA_CHECKED(expression)                                             \
+  KATANA_CHECKED_CONTEXT(expression, "backtrace")
 
 }  // namespace katana
 

--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -266,6 +266,17 @@ struct is_result : std::false_type {};
 template <class T>
 struct is_result<Result<T>> : std::true_type {};
 
+template <class T>
+std::enable_if_t<!std::is_same<T, void>::value, T&&>
+extract_value(Result<T>&& result) {
+  return std::move(result.value());
+}
+
+inline int
+extract_value(Result<void>&&) {
+  return 0;
+}
+
 #define KATANA_CHECK_NAME(x, y) x##y
 
 #define KATANA_CHECK_IMPL(result_name, expression)                             \
@@ -277,7 +288,7 @@ struct is_result<Result<T>> : std::true_type {};
     if (!result_name) {                                                        \
       return result_name.error().WithContext("here");                          \
     }                                                                          \
-    std::move(result_name);                                                    \
+    std::move(::katana::extract_value(std::move(result_name)));                \
   })
 
 #define KATANA_CHECK(expression)                                               \

--- a/libsupport/src/Http.cpp
+++ b/libsupport/src/Http.cpp
@@ -43,9 +43,9 @@ public:
       return katana::ErrorCode::HttpError;
     }
     CurlHandle handle(curl);
-    KATANA_CHECK(handle.SetOpt(CURLOPT_URL, url.c_str()));
-    KATANA_CHECK(handle.SetOpt(CURLOPT_WRITEDATA, response));
-    KATANA_CHECK(handle.SetOpt(CURLOPT_WRITEFUNCTION, WriteDataToVectorCB));
+    KATANA_CHECKED(handle.SetOpt(CURLOPT_URL, url.c_str()));
+    KATANA_CHECKED(handle.SetOpt(CURLOPT_WRITEDATA, response));
+    KATANA_CHECKED(handle.SetOpt(CURLOPT_WRITEFUNCTION, WriteDataToVectorCB));
     return CurlHandle(std::move(handle));
   }
 
@@ -75,7 +75,7 @@ public:
 
   katana::Result<void> Perform() {
     if (headers_ != nullptr) {
-      KATANA_CHECK(SetOpt(CURLOPT_HTTPHEADER, headers_));
+      KATANA_CHECKED(SetOpt(CURLOPT_HTTPHEADER, headers_));
     }
     CURLcode request_res = curl_easy_perform(handle_);
     if (request_res != CURLE_OK) {
@@ -105,8 +105,8 @@ public:
 
 katana::Result<void>
 HttpUploadCommon(CurlHandle&& holder, const std::string& data) {
-  KATANA_CHECK(holder.SetOpt(CURLOPT_POSTFIELDS, data.c_str()));
-  KATANA_CHECK(holder.SetOpt(CURLOPT_POSTFIELDSIZE, data.size()));
+  KATANA_CHECKED(holder.SetOpt(CURLOPT_POSTFIELDS, data.c_str()));
+  KATANA_CHECKED(holder.SetOpt(CURLOPT_POSTFIELDSIZE, data.size()));
   holder.SetHeader("Content-Type: application/json");
   holder.SetHeader("Accept: application/json");
   return holder.Perform();
@@ -116,9 +116,9 @@ HttpUploadCommon(CurlHandle&& holder, const std::string& data) {
 
 katana::Result<void>
 katana::HttpGet(const std::string& url, std::vector<char>* response) {
-  CurlHandle curl = KATANA_CHECK(CurlHandle::Make(url, response));
-  KATANA_CHECK(curl.SetOpt(CURLOPT_HTTPGET, 1L));
-  KATANA_CHECK_CONTEXT(curl.Perform(), "GET failed for url: {}", url);
+  CurlHandle curl = KATANA_CHECKED(CurlHandle::Make(url, response));
+  KATANA_CHECKED(curl.SetOpt(CURLOPT_HTTPGET, 1L));
+  KATANA_CHECKED_CONTEXT(curl.Perform(), "GET failed for url: {}", url);
   return katana::ResultSuccess();
 }
 
@@ -126,9 +126,9 @@ katana::Result<void>
 katana::HttpPost(
     const std::string& url, const std::string& data,
     std::vector<char>* response) {
-  CurlHandle handle = KATANA_CHECK_CONTEXT(
+  CurlHandle handle = KATANA_CHECKED_CONTEXT(
       CurlHandle::Make(url, response), "POST failed for url: {}", url);
-  KATANA_CHECK_CONTEXT(
+  KATANA_CHECKED_CONTEXT(
       HttpUploadCommon(std::move(handle), data), "POST failed for url: {}",
       url);
   return katana::ResultSuccess();
@@ -136,9 +136,9 @@ katana::HttpPost(
 
 katana::Result<void>
 katana::HttpDelete(const std::string& url, std::vector<char>* response) {
-  CurlHandle curl = KATANA_CHECK(CurlHandle::Make(url, response));
-  KATANA_CHECK(curl.SetOpt(CURLOPT_CUSTOMREQUEST, "DELETE"));
-  KATANA_CHECK_CONTEXT(curl.Perform(), "DELETE failed for url: {}", url);
+  CurlHandle curl = KATANA_CHECKED(CurlHandle::Make(url, response));
+  KATANA_CHECKED(curl.SetOpt(CURLOPT_CUSTOMREQUEST, "DELETE"));
+  KATANA_CHECKED_CONTEXT(curl.Perform(), "DELETE failed for url: {}", url);
   return katana::ResultSuccess();
 }
 
@@ -146,9 +146,9 @@ katana::Result<void>
 katana::HttpPut(
     const std::string& url, const std::string& data,
     std::vector<char>* response) {
-  CurlHandle curl = KATANA_CHECK(CurlHandle::Make(url, response));
-  KATANA_CHECK(curl.SetOpt(CURLOPT_CUSTOMREQUEST, "PUT"));
-  KATANA_CHECK_CONTEXT(
+  CurlHandle curl = KATANA_CHECKED(CurlHandle::Make(url, response));
+  KATANA_CHECKED(curl.SetOpt(CURLOPT_CUSTOMREQUEST, "PUT"));
+  KATANA_CHECKED_CONTEXT(
       HttpUploadCommon(std::move(curl), data), "PUT failed for url: {}", url);
   return katana::ResultSuccess();
 }

--- a/libsupport/src/Http.cpp
+++ b/libsupport/src/Http.cpp
@@ -114,8 +114,7 @@ HttpUploadCommon(CurlHandle&& holder, const std::string& data) {
 
 katana::Result<void>
 katana::HttpGet(const std::string& url, std::vector<char>* response) {
-  CurlHandle curl =
-      std::move(KATANA_CHECK(CurlHandle::Make(url, response)).value());
+  CurlHandle curl = KATANA_CHECK(CurlHandle::Make(url, response));
   KATANA_CHECK(curl.SetOpt(CURLOPT_HTTPGET, 1L));
   if (auto res = curl.Perform(); !res) {
     KATANA_LOG_DEBUG("GET failed for url: {}", url);
@@ -143,8 +142,7 @@ katana::HttpPost(
 
 katana::Result<void>
 katana::HttpDelete(const std::string& url, std::vector<char>* response) {
-  CurlHandle curl =
-      std::move(KATANA_CHECK(CurlHandle::Make(url, response)).value());
+  CurlHandle curl = KATANA_CHECK(CurlHandle::Make(url, response));
   KATANA_CHECK(curl.SetOpt(CURLOPT_CUSTOMREQUEST, "DELETE"));
 
   if (auto res = curl.Perform(); !res) {
@@ -158,8 +156,7 @@ katana::Result<void>
 katana::HttpPut(
     const std::string& url, const std::string& data,
     std::vector<char>* response) {
-  CurlHandle curl =
-      std::move(KATANA_CHECK(CurlHandle::Make(url, response)).value());
+  CurlHandle curl = KATANA_CHECK(CurlHandle::Make(url, response));
   KATANA_CHECK(curl.SetOpt(CURLOPT_CUSTOMREQUEST, "PUT"));
 
   if (auto res = HttpUploadCommon(std::move(curl), data); !res) {


### PR DESCRIPTION
[RFC-ENG-027](https://docs.google.com/document/d/1WIqCUZKik_klt1lF0Sdlixy9eUCIZi_5rZnEhtN4x60/edit?usp=sharing)
Introduces the `KATANA_CHECKED` macro, which can be used with `katana::Result` to automatically propagate the error to the caller if one occurs. This is accomplished using a Statement Expression, as suggested by @aneeshdurg in the RFC.

Http.cpp is modified using the new macro as an example.