### PR TITLE
build: Avoid CMake whitespace syntax warning

### DIFF
--- a/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
+++ b/cmake/Modules/KatanaPythonSetupSubdirectory.cmake
@@ -303,8 +303,8 @@ function(add_python_setuptools_target TARGET_NAME)
 for f in ${dir}/build/lib* ${dir}/python; do
   python_path_additions=\${python_path_additions:+\$python_path_additions:}$f
 done
-if [ "$python_path_additions" ]; then
-  export PYTHONPATH=\$python_path_additions\${PYTHONPATH:+:\$PYTHONPATH}
+if [ \"$python_path_additions\" ]; then
+  export PYTHONPATH=$python_path_additions\${PYTHONPATH:+:\$PYTHONPATH}
 fi
 ")
     else()


### PR DESCRIPTION
```
Avoid warnings like:

  CMake Warning (dev) at cmake/Modules/KatanaPythonSetupSubdirectory.cmake:306:
    Syntax Warning in cmake code at column 7

    Argument not separated from preceding token by whitespace.
  Call Stack (most recent call first):
    cmake/Modules/KatanaBuildCommon.cmake:6 (include)
    CMakeLists.txt:24 (include)
  This warning is for project developers.  Use -Wno-dev to suppress it.

  CMake Warning (dev) at cmake/Modules/KatanaPythonSetupSubdirectory.cmake:306:
    Syntax Warning in cmake code at column 29

    Argument not separated from preceding token by whitespace.
```