### PR TITLE
Restrict prop graph topology interface

### DIFF
--- a/libgalois/include/katana/GraphHelpers.h
+++ b/libgalois/include/katana/GraphHelpers.h
@@ -32,11 +32,10 @@ namespace katana {
 
 namespace internal {
 
-using edge_iterator = boost::counting_iterator<uint32_t>;
 template <typename GraphTy>
-inline edge_iterator
+inline GraphTopology::edge_iterator
 edge_begin(GraphTy& graph, uint32_t N) {
-  return (N > 0) ? graph.topology().out_indices->Value(N - 1) : 0;
+  return graph.topology().edge_begin(N);
 }
 
 /**
@@ -47,9 +46,9 @@ edge_begin(GraphTy& graph, uint32_t N) {
  * of the next node (or an "end" iterator if there is no next node)
  */
 template <typename GraphTy>
-inline edge_iterator
+inline GraphTopology::edge_iterator
 edge_end(GraphTy& graph, uint32_t N) {
-  return graph.topology().out_indices->Value(N);
+  return graph.topology().edge_end(N);
 }
 
 template <typename Ty>

--- a/libgalois/include/katana/NUMAArray.h
+++ b/libgalois/include/katana/NUMAArray.h
@@ -216,6 +216,34 @@ public:
   // The following methods are not shared with void specialization
   const_pointer data() const { return data_; }
   pointer data() { return data_; }
+
+  /**
+   * equal_to operator. WARNING: Expensive, O(n) cost of checking two arrays
+   * element by element
+   * @param left: first array
+   * @param right: second array
+   * @returns true if arrays are element-wise equal
+   */
+  friend bool operator==(const NUMAArray& left, const NUMAArray& right) {
+    if (&left == &right) {
+      return true;
+    }
+    if (left.size() != right.size()) {
+      return false;
+    }
+    // if sizes are equal and data pointers are same then arrays are equal
+    if (left.data() == right.data()) {
+      return true;
+    }
+
+    for (size_t i = 0, sz = left.size(); i < sz; ++i) {
+      if (left[i] != right[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 };
 
 //! Void specialization

--- a/libgalois/include/katana/ParallelSTL.h
+++ b/libgalois/include/katana/ParallelSTL.h
@@ -434,7 +434,9 @@ iota(const ForwardIt& first, const ForwardIt& last, const T& start_val) {
   on_each([&](unsigned tid, unsigned total) {
     auto [begin, end] = block_range(first, last, tid, total);
     diff_type offset = std::distance(first, begin);
-    std::iota(begin, end, start_val + static_cast<T>(offset));
+    std::iota(
+        begin, end,
+        static_cast<value_type>(start_val) + static_cast<value_type>(offset));
   });
 }
 

--- a/libgalois/include/katana/ParallelSTL.h
+++ b/libgalois/include/katana/ParallelSTL.h
@@ -419,6 +419,39 @@ transform(
   return d_first + std::distance(first, last);
 }
 
+template <typename ForwardIt, typename T>
+void
+iota(const ForwardIt& first, const ForwardIt& last, const T& start_val) {
+  using diff_type = typename std::iterator_traits<ForwardIt>::difference_type;
+  using value_type = typename std::iterator_traits<ForwardIt>::value_type;
+  static_assert(
+      std::is_convertible_v<T, value_type>,
+      "Can't convert start_val to iterator's value_type");
+  static_assert(
+      std::is_arithmetic_v<T> && std::is_arithmetic_v<value_type>,
+      "iota only supported for numeric types");
+
+  on_each([&](unsigned tid, unsigned total) {
+    auto [begin, end] = block_range(first, last, tid, total);
+    diff_type offset = std::distance(first, begin);
+    std::iota(begin, end, start_val + static_cast<T>(offset));
+  });
+}
+
+template <typename ForwardIt, typename T>
+void
+fill(const ForwardIt& first, const ForwardIt& last, const T& val) {
+  using value_type = typename std::iterator_traits<ForwardIt>::value_type;
+  static_assert(
+      std::is_convertible_v<T, value_type>,
+      "Can't convert param val to iterator's value_type");
+
+  on_each([&](unsigned tid, unsigned total) {
+    auto [begin, end] = block_range(first, last, tid, total);
+    std::fill(begin, end, val);
+  });
+}
+
 template <class InputIt, class OutputIt>
 OutputIt
 copy(InputIt first, InputIt last, OutputIt d_first) {

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -18,6 +18,17 @@
 
 namespace katana {
 
+// TODO(amber): find a better place to put this
+template <
+    typename T,
+    typename __Unused = std::enable_if_t<std::is_arithmetic<T>::value>>
+auto
+ProjectAsArrowArray(const T* buf, const size_t len) noexcept {
+  using ArrowDataType = typename arrow::CTypeTraits<T>::ArrowType;
+  using ArrowArrayType = arrow::NumericArray<ArrowDataType>;
+  return std::make_shared<ArrowArrayType>(len, arrow::Buffer::Wrap(buf, len));
+}
+
 /// A graph topology represents the adjacency information for a graph in CSR
 /// format.
 class KATANA_EXPORT GraphTopology {
@@ -31,120 +42,102 @@ public:
   using iterator = node_iterator;
 
   GraphTopology() = default;
+  GraphTopology(GraphTopology&&) = default;
+  GraphTopology& operator=(GraphTopology&&) = default;
 
   GraphTopology(const GraphTopology&) = delete;
   GraphTopology& operator=(const GraphTopology&) = delete;
 
   GraphTopology(
       const Edge* adj_indices, size_t numNodes, const Node* dests,
-      size_t numEdges);
+      size_t numEdges) noexcept;
 
   GraphTopology(NUMAArray<Edge>&& adj_indices, NUMAArray<Node>&& dests) noexcept
-      : adj_indices_(std::move(adj_indices)),
-        dests_(std::move(dests)),
-        out_indices(LargeToArrowArray(adj_indices_)),
-        out_dests(LargeToArrowArray(dests_)) {}
+      : adj_indices_(std::move(adj_indices)), dests_(std::move(dests)) {}
 
-  static std::unique_ptr<GraphTopology> Copy(
-      const GraphTopology& that) noexcept;
+  static GraphTopology Copy(const GraphTopology& that) noexcept;
 
-  /*
-   * TODO(amber): consider re-enabling these in the near future
-  GraphTopology(GraphTopology&& that):
-    adj_indices_(std::move(that.adj_indices_)),
-    dests_(std::move(that.dests)),
-    out_indices(LargeToArrowArray(adj_indices_)),
-    out_dests(LargeToArrowArray(dests_))
-  {}
+  uint64_t num_nodes() const noexcept { return adj_indices_.size(); }
 
-  GraphTopology& operator = (GraphTopology&& that) {
-    adj_indices_ = std::move(that.adj_indices_);
-    dests_ = std::move(that.dests_);
-    out_indices = LargeToArrowArray(adj_indices_);
-    out_dests = LargeToArrowArray(dests_);
-    return *this;
-  }
-  */
+  uint64_t num_edges() const noexcept { return dests_.size(); }
 
-  uint64_t num_nodes() const { return adj_indices_.size(); }
+  const Edge* adj_data() const noexcept { return &adj_indices_[0]; }
 
-  uint64_t num_edges() const { return dests_.size(); }
+  const Node* dest_data() const noexcept { return &dests_[0]; }
 
-  bool Equals(const GraphTopology& other) const {
-    return out_indices->Equals(*other.out_indices) &&
-           out_dests->Equals(*other.out_dests);
+  /**
+   * Checks equality against another instance of GraphTopology.
+   * WARNING: Expensive operation due to element-wise checks on large arrays
+   * @param that: GraphTopology instance to compare against
+   * @returns true if topology arrays are equal
+   */
+  bool Equals(const GraphTopology& that) const noexcept {
+    if (this == &that) {
+      return true;
+    }
+    if (num_nodes() != that.num_nodes()) {
+      return false;
+    }
+    if (num_edges() != that.num_edges()) {
+      return false;
+    }
+
+    return adj_indices_ == that.adj_indices_ && dests_ == that.dests_;
   }
 
   // Edge accessors
 
-  // TODO(amp): [[deprecated("use edges(node)")]]
-  std::pair<Edge, Edge> edge_range(Node node_id) const {
-    KATANA_LOG_DEBUG_ASSERT(node_id < adj_indices_.size());
-    auto edge_start = node_id > 0 ? adj_indices_[node_id - 1] : 0;
-    auto edge_end = adj_indices_[node_id];
-    return std::make_pair(edge_start, edge_end);
+  edge_iterator edge_begin(Node node) const noexcept {
+    return edge_iterator{node > 0 ? adj_indices_[node - 1] : 0};
+  }
+
+  edge_iterator edge_end(Node node) const noexcept {
+    return edge_iterator{adj_indices_[node]};
   }
 
   /// Gets the edge range of some node.
   ///
   /// \param node an iterator pointing to the node to get the edge range of
   /// \returns iterable edge range for node.
-  edges_range edges(const node_iterator& node) const { return edges(*node); }
+  edges_range edges(const node_iterator& node) const noexcept {
+    return edges(*node);
+  }
   // TODO(amp): [[deprecated("use edges(Node node)")]]
 
   /// Gets the edge range of some node.
   ///
   /// \param node node to get the edge range of
   /// \returns iterable edge range for node.
-  edges_range edges(Node node) const {
-    auto [begin_edge, end_edge] = edge_range(node);
-    return MakeStandardRange<edge_iterator>(begin_edge, end_edge);
+  edges_range edges(Node node) const noexcept {
+    return MakeStandardRange<edge_iterator>(edge_begin(node), edge_end(node));
   }
 
-  Node edge_dest(Edge edge_id) const {
+  Node edge_dest(Edge edge_id) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(edge_id < dests_.size());
     return dests_[edge_id];
   }
 
-  nodes_range nodes(Node begin, Node end) const {
+  Node edge_dest(const edge_iterator ei) const noexcept {
+    return edge_dest(*ei);
+  }
+
+  nodes_range nodes(Node begin, Node end) const noexcept {
     return MakeStandardRange<node_iterator>(begin, end);
   }
 
   // Standard container concepts
 
-  node_iterator begin() const { return node_iterator(0); }
+  node_iterator begin() const noexcept { return node_iterator(0); }
 
-  node_iterator end() const { return node_iterator(num_nodes()); }
+  node_iterator end() const noexcept { return node_iterator(num_nodes()); }
 
-  size_t size() const { return num_nodes(); }
+  size_t size() const noexcept { return num_nodes(); }
 
-  bool empty() const { return num_nodes() == 0; }
+  bool empty() const noexcept { return num_nodes() == 0; }
 
 private:
-  // TODO: generalize to typename T
-  static std::shared_ptr<arrow::UInt64Array> LargeToArrowArray(
-      NUMAArray<uint64_t>& lg_arr) noexcept {
-    return std::make_shared<arrow::UInt64Array>(
-        lg_arr.size(),
-        arrow::MutableBuffer::Wrap(lg_arr.data(), lg_arr.size()));
-  }
-
-  static std::shared_ptr<arrow::UInt32Array> LargeToArrowArray(
-      NUMAArray<uint32_t>& lg_arr) noexcept {
-    return std::make_shared<arrow::UInt32Array>(
-        lg_arr.size(),
-        arrow::MutableBuffer::Wrap(lg_arr.data(), lg_arr.size()));
-  }
-
   NUMAArray<Edge> adj_indices_;
   NUMAArray<Node> dests_;
-
-public:
-  // TODO(amber): make these private in the near future. No other class should
-  // access these directly. Instead provide access methods. Also, can't move these
-  // up due to member declaration & initialization order. out_indices depends on adj_indices_
-  std::shared_ptr<arrow::UInt64Array> out_indices;
-  std::shared_ptr<arrow::UInt32Array> out_dests;
 };
 
 /// A property graph is a graph that has properties associated with its nodes
@@ -207,10 +200,7 @@ private:
 
   tsuba::RDG rdg_;
   std::unique_ptr<tsuba::RDGFile> file_;
-
-  // The topology is either backed by rdg_ or shared with the
-  // caller of SetTopology.
-  std::unique_ptr<GraphTopology> topology_ = std::make_unique<GraphTopology>();
+  GraphTopology topology_;
 
   /// A map from the node TypeSetID to
   /// the set of the node type names it contains
@@ -325,8 +315,14 @@ public:
   PropertyGraph() = default;
 
   PropertyGraph(
-      std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg,
-      std::unique_ptr<GraphTopology> topo_to_assign);
+      std::unique_ptr<tsuba::RDGFile>&& rdg_file, tsuba::RDG&& rdg,
+      GraphTopology&& topo) noexcept
+      : rdg_(std::move(rdg)),
+        file_(std::move(rdg_file)),
+        topology_(std::move(topo)) {}
+
+  PropertyGraph(katana::GraphTopology&& topo_to_assign) noexcept
+      : rdg_(), file_(), topology_(std::move(topo_to_assign)) {}
 
   /// Make a property graph from a constructed RDG. Take ownership of the RDG
   /// and its underlying resources.
@@ -337,6 +333,10 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const std::string& rdg_name,
       const tsuba::RDGLoadOptions& opts = tsuba::RDGLoadOptions());
+
+  /// Make a property graph from topology
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      GraphTopology&& topo_to_assign);
 
   /// \return A copy of this with the same set of properties. The copy shares no
   ///       state with this.
@@ -621,10 +621,7 @@ public:
     return rdg_.MarkEdgePropertiesPersistent(persist_edge_props);
   }
 
-  const GraphTopology& topology() const noexcept {
-    KATANA_LOG_DEBUG_ASSERT(topology_);
-    return *topology_;
-  }
+  const GraphTopology& topology() const noexcept { return topology_; }
 
   /// Add Node properties that do not exist in the current graph
   Result<void> AddNodeProperties(const std::shared_ptr<arrow::Table>& props);
@@ -670,16 +667,6 @@ public:
         .remove_property_int = &PropertyGraph::RemoveEdgeProperty,
         .remove_property_str = &PropertyGraph::RemoveEdgeProperty,
     };
-  }
-
-  // This one copies the topology
-  Result<void> SetTopology(const GraphTopology& topology);
-
-  // This one takes over an existing topology through move operation
-  Result<void> SetTopology(
-      std::unique_ptr<GraphTopology>&& topo_to_assign) noexcept {
-    topology_ = std::move(topo_to_assign);
-    return katana::ResultSuccess();
   }
 
   /// Return the node property table for local nodes
@@ -731,20 +718,23 @@ public:
 ///
 /// Returns the permutation vector (mapping from old
 /// indices to the new indices) which results due to the sorting.
-KATANA_EXPORT Result<std::shared_ptr<arrow::UInt64Array>> SortAllEdgesByDest(
-    PropertyGraph* pg);
+KATANA_EXPORT Result<std::unique_ptr<katana::NUMAArray<uint64_t>>>
+SortAllEdgesByDest(PropertyGraph* pg);
 
 /// FindEdgeSortedByDest finds the "node_to_find" id in the
 /// sorted edgelist of the "node" using binary search.
 ///
 /// This returns the matched edge index if 'node_to_find' is present
 /// in the edgelist of 'node' else edge end if 'node_to_find' is not found.
+// TODO(amber): make this a method of a sorted topology class in the near future
+// TODO(amber): this method should return an edge_iterator
 KATANA_EXPORT GraphTopology::Edge FindEdgeSortedByDest(
     const PropertyGraph* graph, GraphTopology::Node node,
     GraphTopology::Node node_to_find);
 
 /// Relabel all nodes in the graph by sorting in the descending
 /// order by node degree.
+// TODO(amber): this method should return a new sorted topology
 KATANA_EXPORT Result<void> SortNodesByDegree(PropertyGraph* pg);
 
 /// Creates in-memory symmetric (or undirected) graph.
@@ -758,7 +748,7 @@ KATANA_EXPORT Result<void> SortNodesByDegree(PropertyGraph* pg);
 /// The generated symmetric graph may have duplicate edges.
 /// \param pg The original property graph
 /// \return The new symmetric property graph by adding reverse edges
-// TODO(gill): Add edge properties for the new reversed edges.
+// TODO(amber): this function should return a new topology
 KATANA_EXPORT Result<std::unique_ptr<katana::PropertyGraph>>
 CreateSymmetricGraph(PropertyGraph* pg);
 
@@ -773,7 +763,7 @@ CreateSymmetricGraph(PropertyGraph* pg);
 /// \param topology The original property graph topology
 /// \return The new transposed property graph by reversing the edges
 // TODO(lhc): hack for bfs-direct-opt
-// TODO(gill): Add tranposed edge properties as well.
+// TODO(amber): this function should return a new topology
 KATANA_EXPORT Result<std::unique_ptr<PropertyGraph>>
 CreateTransposeGraphTopology(const GraphTopology& topology);
 

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -61,9 +61,9 @@ public:
 
   uint64_t num_edges() const noexcept { return dests_.size(); }
 
-  const Edge* adj_data() const noexcept { return &adj_indices_[0]; }
+  const Edge* adj_data() const noexcept { return adj_indices_.data(); }
 
-  const Node* dest_data() const noexcept { return &dests_[0]; }
+  const Node* dest_data() const noexcept { return dests_.data(); }
 
   /**
    * Checks equality against another instance of GraphTopology.
@@ -717,7 +717,7 @@ public:
 /// IDs (ascending order).
 ///
 /// Returns the permutation vector (mapping from old
-/// indices to the new indices) which results due to the sorting.
+/// indices to the new indices) which results due to  sorting.
 KATANA_EXPORT Result<std::unique_ptr<katana::NUMAArray<uint64_t>>>
 SortAllEdgesByDest(PropertyGraph* pg);
 

--- a/libgalois/src/GraphMLSchema.cpp
+++ b/libgalois/src/GraphMLSchema.cpp
@@ -367,9 +367,10 @@ ExtractData(std::shared_ptr<arrow::Array> array, int64_t index) {
   }
 }
 
+template <typename EdgeIterRange>
 bool
-InRange(uint32_t id, const std::pair<uint64_t, uint64_t>& interval) {
-  return interval.first <= id && id < interval.second;
+InRange(uint64_t id, const EdgeIterRange& range) {
+  return *range.begin() <= id && id < *range.end();
 }
 }  // namespace
 
@@ -492,12 +493,11 @@ katana::graphml::ExportGraph(
       sub_indexes[j]++;
     }
 
-    while (!InRange(i, topology.edge_range(src_node))) {
+    while (!InRange(i, topology.edges(src_node))) {
       src_node++;
     }
     std::string src = boost::lexical_cast<std::string>(src_node);
-    std::string dest =
-        boost::lexical_cast<std::string>(topology.out_dests->Value(i));
+    std::string dest = boost::lexical_cast<std::string>(topology.edge_dest(i));
     StartGraphmlEdge(
         writer, boost::lexical_cast<std::string>(i), src, dest, labels);
 

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -27,8 +27,8 @@ GetGraphSize(uint64_t num_nodes, uint64_t num_edges) {
 
 [[maybe_unused]] bool
 CheckTopology(
-    uint64_t* out_indices, uint64_t num_nodes, uint32_t* out_dests,
-    uint64_t num_edges) {
+    const uint64_t* out_indices, const uint64_t num_nodes,
+    const uint32_t* out_dests, const uint64_t num_edges) {
   bool has_bad_adj = false;
 
   katana::do_all(
@@ -69,7 +69,7 @@ CheckTopology(
 ///
 /// Since property graphs store their edge data separately, we will
 /// ignore the size_of_edge_data (data[1]).
-katana::Result<std::unique_ptr<katana::GraphTopology>>
+katana::Result<katana::GraphTopology>
 MapTopology(const tsuba::FileView& file_view) {
   const auto* data = file_view.ptr<uint64_t>();
   if (file_view.size() < 4) {
@@ -91,13 +91,13 @@ MapTopology(const tsuba::FileView& file_view) {
         file_view.size(), expected_size);
   }
 
-  uint64_t* out_indices = const_cast<uint64_t*>(&data[4]);
-  uint32_t* out_dests = reinterpret_cast<uint32_t*>(out_indices + num_nodes);
+  const uint64_t* out_indices = &data[4];
+  const uint32_t* out_dests =
+      reinterpret_cast<const uint32_t*>(out_indices + num_nodes);
 
   KATANA_LOG_DEBUG_ASSERT(
       CheckTopology(out_indices, num_nodes, out_dests, num_edges));
-  return std::make_unique<katana::GraphTopology>(
-      out_indices, num_nodes, out_dests, num_edges);
+  return katana::GraphTopology(out_indices, num_nodes, out_dests, num_edges);
 }
 
 katana::Result<std::unique_ptr<tsuba::FileFrame>>
@@ -106,8 +106,8 @@ WriteTopology(const katana::GraphTopology& topology) {
   if (auto res = ff->Init(); !res) {
     return res.error();
   }
-  uint64_t num_nodes = topology.num_nodes();
-  uint64_t num_edges = topology.num_edges();
+  const uint64_t num_nodes = topology.num_nodes();
+  const uint64_t num_edges = topology.num_edges();
 
   uint64_t data[4] = {1, 0, num_nodes, num_edges};
   arrow::Status aro_sts = ff->Write(&data, 4 * sizeof(uint64_t));
@@ -116,10 +116,9 @@ WriteTopology(const katana::GraphTopology& topology) {
   }
 
   if (num_nodes) {
-    const auto* raw = topology.out_indices->raw_values();
+    const auto* raw = topology.adj_data();
     static_assert(std::is_same_v<std::decay_t<decltype(*raw)>, uint64_t>);
-    auto buf = std::make_shared<arrow::Buffer>(
-        reinterpret_cast<const uint8_t*>(raw), num_nodes * sizeof(uint64_t));
+    auto buf = arrow::Buffer::Wrap(raw, num_nodes);
     aro_sts = ff->Write(buf);
     if (!aro_sts.ok()) {
       return tsuba::ArrowToTsuba(aro_sts.code());
@@ -127,29 +126,15 @@ WriteTopology(const katana::GraphTopology& topology) {
   }
 
   if (num_edges) {
-    const auto* raw = topology.out_dests->raw_values();
+    const auto* raw = topology.dest_data();
     static_assert(std::is_same_v<std::decay_t<decltype(*raw)>, uint32_t>);
-    auto buf = std::make_shared<arrow::Buffer>(
-        reinterpret_cast<const uint8_t*>(raw), num_edges * sizeof(uint32_t));
+    auto buf = arrow::Buffer::Wrap(raw, num_edges);
     aro_sts = ff->Write(buf);
     if (!aro_sts.ok()) {
       return tsuba::ArrowToTsuba(aro_sts.code());
     }
   }
   return std::unique_ptr<tsuba::FileFrame>(std::move(ff));
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-MakePropertyGraph(
-    std::unique_ptr<tsuba::RDGFile> rdg_file,
-    const tsuba::RDGLoadOptions& opts) {
-  auto rdg_result = tsuba::RDG::Make(*rdg_file, opts);
-  if (!rdg_result) {
-    return rdg_result.error();
-  }
-
-  return katana::PropertyGraph::Make(
-      std::move(rdg_file), std::move(rdg_result.value()));
 }
 
 /// Assumes all boolean or uint8 properties are types
@@ -337,41 +322,91 @@ GetUnknownTypeSetIDs(uint64_t num_rows) {
 
 katana::GraphTopology::GraphTopology(
     const Edge* adj_indices, size_t num_nodes, const Node* dests,
-    size_t num_edges) {
+    size_t num_edges) noexcept {
   adj_indices_.allocateInterleaved(num_nodes);
   dests_.allocateInterleaved(num_edges);
 
   katana::ParallelSTL::copy(
       &adj_indices[0], &adj_indices[num_nodes], adj_indices_.begin());
   katana::ParallelSTL::copy(&dests[0], &dests[num_edges], dests_.begin());
-
-  out_indices = GraphTopology::LargeToArrowArray(adj_indices_);
-  out_dests = GraphTopology::LargeToArrowArray(dests_);
 }
 
-std::unique_ptr<katana::GraphTopology>
+katana::GraphTopology
 katana::GraphTopology::Copy(const GraphTopology& that) noexcept {
-  return std::make_unique<katana::GraphTopology>(
+  return katana::GraphTopology(
       that.adj_indices_.data(), that.adj_indices_.size(), that.dests_.data(),
       that.dests_.size());
 }
 
-katana::PropertyGraph::PropertyGraph(
-    std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg,
-    std::unique_ptr<GraphTopology> topo)
-    : rdg_(std::move(rdg)),
-      file_(std::move(rdg_file)),
-      topology_(std::move(topo)) {}
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Make(
+    std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg) {
+  auto topo_result = MapTopology(rdg.topology_file_storage());
+  if (!topo_result) {
+    return topo_result.error();
+  }
+
+  return std::make_unique<PropertyGraph>(
+      std::move(rdg_file), std::move(rdg), std::move(topo_result.value()));
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+MakePropertyGraph(
+    std::unique_ptr<tsuba::RDGFile> rdg_file,
+    const tsuba::RDGLoadOptions& opts) {
+  auto rdg_result = tsuba::RDG::Make(*rdg_file, opts);
+  if (!rdg_result) {
+    return rdg_result.error();
+  }
+
+  return katana::PropertyGraph::Make(
+      std::move(rdg_file), std::move(rdg_result.value()));
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Make(
+    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
+  auto handle = tsuba::Open(rdg_name, tsuba::kReadWrite);
+  if (!handle) {
+    return handle.error();
+  }
+
+  return MakePropertyGraph(
+      std::make_unique<tsuba::RDGFile>(handle.value()), opts);
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Make(katana::GraphTopology&& topo_to_assign) {
+  return std::make_unique<katana::PropertyGraph>(std::move(topo_to_assign));
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Copy() const {
+  return Copy(node_schema()->field_names(), edge_schema()->field_names());
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Copy(
+    const std::vector<std::string>& node_properties,
+    const std::vector<std::string>& edge_properties) const {
+  // TODO(gill): This should copy the RDG in memory without reloading from storage.
+  tsuba::RDGLoadOptions opts;
+  opts.partition_id_to_load = partition_id();
+  opts.node_properties = &node_properties;
+  opts.edge_properties = &edge_properties;
+
+  return Make(rdg_dir(), opts);
+}
 
 katana::Result<void>
 katana::PropertyGraph::Validate() {
   // TODO (thunt) check that arrow table sizes match topology
-  // if (topology_->out_dests &&
-  //    topology_->out_dests->length() != table->num_rows()) {
+  // if (topology_.out_dests &&
+  //    topology_.out_dests->length() != table->num_rows()) {
   //  return ErrorCode::InvalidArgument;
   //}
-  // if (topology_->out_indices &&
-  //    topology_->out_indices->length() != table->num_rows()) {
+  // if (topology_.out_indices &&
+  //    topology_.out_indices->length() != table->num_rows()) {
   //  return ErrorCode::InvalidArgument;
   //}
 
@@ -410,50 +445,6 @@ katana::PropertyGraph::Validate() {
   }
 
   return katana::ResultSuccess();
-}
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Make(
-    std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg) {
-  auto topo_result = MapTopology(rdg.topology_file_storage());
-  if (!topo_result) {
-    return topo_result.error();
-  }
-
-  auto topo =
-      std::unique_ptr<katana::GraphTopology>(std::move(topo_result.value()));
-
-  return std::make_unique<PropertyGraph>(
-      std::move(rdg_file), std::move(rdg), std::move(topo));
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Make(
-    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
-  auto handle = tsuba::Open(rdg_name, tsuba::kReadWrite);
-  if (!handle) {
-    return handle.error();
-  }
-
-  return MakePropertyGraph(
-      std::make_unique<tsuba::RDGFile>(handle.value()), opts);
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Copy() const {
-  return Copy(node_schema()->field_names(), edge_schema()->field_names());
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Copy(
-    const std::vector<std::string>& node_properties,
-    const std::vector<std::string>& edge_properties) const {
-  // TODO(gill): This should copy the RDG in memory without reloading from storage.
-  tsuba::RDGLoadOptions opts;
-  opts.partition_id_to_load = partition_id();
-  opts.node_properties = &node_properties;
-  opts.edge_properties = &edge_properties;
-
-  return Make(rdg_dir(), opts);
 }
 
 katana::Result<void>
@@ -503,7 +494,7 @@ katana::PropertyGraph::DoWrite(
     tsuba::RDGHandle handle, const std::string& command_line,
     tsuba::RDG::RDGVersioningPolicy versioning_action) {
   if (!rdg_.topology_file_storage().Valid()) {
-    auto result = WriteTopology(*topology_);
+    auto result = WriteTopology(topology());
     if (!result) {
       return result.error();
     }
@@ -691,11 +682,10 @@ katana::PropertyGraph::AddNodeProperties(
     KATANA_LOG_DEBUG("adding empty node prop table");
     return ResultSuccess();
   }
-  if (topology_ && topology_->out_indices &&
-      topology_->out_indices->length() != props->num_rows()) {
+  if (topology().num_nodes() != static_cast<uint64_t>(props->num_rows())) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "expected {} rows found {} instead",
-        topology_->out_indices->length(), props->num_rows());
+        topology().num_nodes(), props->num_rows());
   }
   return rdg_.AddNodeProperties(props);
 }
@@ -707,11 +697,10 @@ katana::PropertyGraph::UpsertNodeProperties(
     KATANA_LOG_DEBUG("upsert empty node prop table");
     return ResultSuccess();
   }
-  if (topology_ && topology_->out_indices &&
-      topology_->out_indices->length() != props->num_rows()) {
+  if (topology().num_nodes() != static_cast<uint64_t>(props->num_rows())) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "expected {} rows found {} instead",
-        topology_->out_indices->length(), props->num_rows());
+        topology().num_nodes(), props->num_rows());
   }
   return rdg_.UpsertNodeProperties(props);
 }
@@ -738,11 +727,10 @@ katana::PropertyGraph::AddEdgeProperties(
     KATANA_LOG_DEBUG("adding empty edge prop table");
     return ResultSuccess();
   }
-  if (topology_ && topology_->out_dests &&
-      topology_->out_dests->length() != props->num_rows()) {
+  if (topology().num_edges() != static_cast<uint64_t>(props->num_rows())) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "expected {} rows found {} instead",
-        topology_->out_dests->length(), props->num_rows());
+        topology().num_edges(), props->num_rows());
   }
   return rdg_.AddEdgeProperties(props);
 }
@@ -754,11 +742,10 @@ katana::PropertyGraph::UpsertEdgeProperties(
     KATANA_LOG_DEBUG("upsert empty edge prop table");
     return ResultSuccess();
   }
-  if (topology_ && topology_->out_dests &&
-      topology_->out_dests->length() != props->num_rows()) {
+  if (topology().num_edges() != static_cast<uint64_t>(props->num_rows())) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "expected {} rows found {} instead",
-        topology_->out_dests->length(), props->num_rows());
+        topology().num_edges(), props->num_rows());
   }
   return rdg_.UpsertEdgeProperties(props);
 }
@@ -779,15 +766,6 @@ katana::PropertyGraph::RemoveEdgeProperty(const std::string& prop_name) {
 }
 
 katana::Result<void>
-katana::PropertyGraph::SetTopology(const katana::GraphTopology& topology) {
-  if (auto res = rdg_.UnbindTopologyFileStorage(); !res) {
-    return res.error();
-  }
-  topology_ = GraphTopology::Copy(topology);
-  return katana::ResultSuccess();
-}
-
-katana::Result<void>
 katana::PropertyGraph::InformPath(const std::string& input_path) {
   if (!rdg_.rdg_dir().empty()) {
     KATANA_LOG_DEBUG("rdg dir from {} to {}", rdg_.rdg_dir(), input_path);
@@ -801,94 +779,85 @@ katana::PropertyGraph::InformPath(const std::string& input_path) {
   return ResultSuccess();
 }
 
-katana::Result<std::shared_ptr<arrow::UInt64Array>>
+katana::Result<std::unique_ptr<katana::NUMAArray<uint64_t>>>
 katana::SortAllEdgesByDest(katana::PropertyGraph* pg) {
-  auto view_result_dests =
-      katana::ConstructPropertyView<katana::UInt32Property>(
-          pg->topology().out_dests.get());
-  if (!view_result_dests) {
-    return view_result_dests.error();
-  }
+  // TODO(amber): This function will soon change so that it produces a new sorted
+  // topology instead of modifying an existing one. The const_cast will go away
+  const auto& topo = pg->topology();
 
-  auto out_dests_view = std::move(view_result_dests.value());
+  auto permutation_vec = std::make_unique<katana::NUMAArray<uint64_t>>();
+  permutation_vec->allocateInterleaved(topo.num_edges());
+  katana::ParallelSTL::iota(
+      permutation_vec->begin(), permutation_vec->end(), uint64_t{0});
 
-  arrow::UInt64Builder permutation_vec_builder;
-  if (auto r = permutation_vec_builder.Resize(pg->topology().num_edges());
-      !r.ok()) {
-    return ErrorCode::ArrowError;
-  }
-  // Getting a mutable reference to an index is definitely allowed. It's
-  // less clear if taking a pointer to it and using offsets is officially
-  // supported. But, ArrayBuilder::Advance explicitly mentions memcpy into the
-  // internal buffer. So I think it actually is.
-  uint64_t* permutation_vec_data = &permutation_vec_builder[0];
-  std::iota(
-      permutation_vec_data,
-      permutation_vec_data + permutation_vec_builder.capacity(), uint64_t{0});
-  auto comparator = [&](uint64_t a, uint64_t b) {
-    return out_dests_view[a] < out_dests_view[b];
-  };
+  auto* out_dests_data = const_cast<GraphTopology::Node*>(topo.dest_data());
 
   katana::do_all(
       katana::iterate(uint64_t{0}, pg->topology().num_nodes()),
       [&](uint64_t n) {
-        auto edge_range = pg->topology().edge_range(n);
+        const auto e_beg = *pg->topology().edge_begin(n);
+        const auto e_end = *pg->topology().edge_end(n);
+        // IMPORTANT: Must sort permutation vector before dest array
         std::sort(
-            permutation_vec_data + edge_range.first,
-            permutation_vec_data + edge_range.second, comparator);
+            permutation_vec->begin() + e_beg, permutation_vec->begin() + e_end,
+            [&](uint64_t a, uint64_t b) {
+              return out_dests_data[a] < out_dests_data[b];
+            });
         std::sort(
-            &out_dests_view[0] + edge_range.first,
-            &out_dests_view[0] + edge_range.second);
+            out_dests_data + e_beg, out_dests_data + e_end,
+            std::less<GraphTopology::Node>{});
       },
       katana::steal());
 
-  if (auto r = permutation_vec_builder.Advance(pg->topology().num_edges());
-      !r.ok()) {
-    return ErrorCode::ArrowError;
-  }
-
-  std::shared_ptr<arrow::UInt64Array> out;
-  if (permutation_vec_builder.Finish(&out).ok()) {
-    return out;
-  } else {
-    return ErrorCode::ArrowError;
-  }
+  return std::unique_ptr<katana::NUMAArray<uint64_t>>(
+      std::move(permutation_vec));
 }
 
+// TODO(amber): make this a method of a sorted topology class in the near future
+// TODO(amber): this method should return an edge_iterator
 katana::GraphTopology::Edge
 katana::FindEdgeSortedByDest(
-    const PropertyGraph* graph, GraphTopology::Node node,
-    GraphTopology::Node node_to_find) {
-  auto view_result_dests =
-      katana::ConstructPropertyView<katana::UInt32Property>(
-          graph->topology().out_dests.get());
-  if (!view_result_dests) {
-    KATANA_LOG_FATAL(
-        "Unable to construct property view on topology destinations : {}",
-        view_result_dests.error());
+    const PropertyGraph* graph, const GraphTopology::Node src,
+    const GraphTopology::Node dst) {
+  using edge_iterator = GraphTopology::edge_iterator;
+
+  const auto& topo = graph->topology();
+  const edge_iterator e_beg = topo.edge_begin(src);
+  const edge_iterator e_end = topo.edge_end(src);
+
+  constexpr int BINARY_SEARCH_THRESHOLD = 100;
+
+  if (std::distance(e_beg, e_end) < BINARY_SEARCH_THRESHOLD) {
+    auto iter = std::find_if(e_beg, e_end, [&](const GraphTopology::Edge& e) {
+      return topo.edge_dest(e) == dst;
+    });
+
+    return *iter;
+
+  } else {
+    auto comparator = [&](const GraphTopology::Edge& e,
+                          const GraphTopology::Node& d) {
+      return topo.edge_dest(e) < d;
+    };
+
+    auto iter = std::lower_bound(e_beg, e_end, dst, comparator);
+
+    return topo.edge_dest(iter) == dst ? *iter : *e_end;
   }
-
-  auto out_dests_view = std::move(view_result_dests.value());
-
-  auto edge_range = graph->topology().edge_range(node);
-  using edge_iterator = boost::counting_iterator<uint64_t>;
-  auto edge_matched = std::lower_bound(
-      edge_iterator(edge_range.first), edge_iterator(edge_range.second),
-      node_to_find,
-      [=](edge_iterator e, uint32_t n) { return out_dests_view[*e] < n; });
-
-  return (
-      out_dests_view[*edge_matched] == node_to_find ? *edge_matched
-                                                    : edge_range.second);
 }
 
+// TODO(amber): this method should return a new sorted topology
 katana::Result<void>
 katana::SortNodesByDegree(katana::PropertyGraph* pg) {
-  uint64_t num_nodes = pg->topology().num_nodes();
-  uint64_t num_edges = pg->topology().num_edges();
+  const auto& topo = pg->topology();
+
+  uint64_t num_nodes = topo.num_nodes();
+  uint64_t num_edges = topo.num_edges();
 
   using DegreeNodePair = std::pair<uint64_t, uint32_t>;
-  std::vector<DegreeNodePair> dn_pairs(num_nodes);
+  katana::NUMAArray<DegreeNodePair> dn_pairs;
+  dn_pairs.allocateInterleaved(num_nodes);
+
   katana::do_all(katana::iterate(uint64_t{0}, num_nodes), [&](size_t node) {
     size_t node_degree = pg->edges(node).size();
     dn_pairs[node] = DegreeNodePair(node_degree, node);
@@ -899,9 +868,12 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
       dn_pairs.begin(), dn_pairs.end(), std::greater<DegreeNodePair>());
 
   // create mapping, get degrees out to another vector to get prefix sum
-  std::vector<uint32_t> old_to_new_mapping(num_nodes);
+  katana::NUMAArray<uint32_t> old_to_new_mapping;
+  old_to_new_mapping.allocateInterleaved(num_nodes);
+
   katana::NUMAArray<uint64_t> new_prefix_sum;
-  new_prefix_sum.allocateBlocked(num_nodes);
+  new_prefix_sum.allocateInterleaved(num_nodes);
+
   katana::do_all(katana::iterate(uint64_t{0}, num_nodes), [&](uint64_t index) {
     // save degree, which is pair.first
     new_prefix_sum[index] = dn_pairs[index].first;
@@ -913,23 +885,10 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
       new_prefix_sum.begin(), new_prefix_sum.end(), new_prefix_sum.begin());
 
   katana::NUMAArray<uint32_t> new_out_dest;
-  new_out_dest.allocateBlocked(num_edges);
+  new_out_dest.allocateInterleaved(num_edges);
 
-  auto view_result_indices =
-      ConstructPropertyView<UInt64Property>(pg->topology().out_indices.get());
-  if (!view_result_indices) {
-    return view_result_indices.error();
-  }
-
-  auto out_indices_view = std::move(view_result_indices.value());
-
-  auto view_result_dests =
-      ConstructPropertyView<UInt32Property>(pg->topology().out_dests.get());
-  if (!view_result_dests) {
-    return view_result_dests.error();
-  }
-
-  auto out_dests_view = std::move(view_result_dests.value());
+  auto* out_dests_data = const_cast<GraphTopology::Node*>(topo.dest_data());
+  auto* out_indices_data = const_cast<GraphTopology::Edge*>(topo.adj_data());
 
   katana::do_all(
       katana::iterate(uint64_t{0}, num_nodes),
@@ -941,10 +900,9 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
             (new_node_id == 0) ? 0 : new_prefix_sum[new_node_id - 1];
 
         // construct the graph, reindexing as it goes along
-        auto node_edge_range = pg->topology().edge_range(old_node_id);
-        for (auto e = node_edge_range.first; e != node_edge_range.second; ++e) {
+        for (auto e : topo.edges(old_node_id)) {
           // get destination, reindex
-          uint32_t old_edge_dest = out_dests_view[e];
+          uint32_t old_edge_dest = out_dests_data[e];
           uint32_t new_edge_dest = old_to_new_mapping[old_edge_dest];
 
           new_out_dest[new_out_index] = new_edge_dest;
@@ -958,14 +916,15 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
       katana::steal());
 
   //Update the underlying PropertyGraph topology
+  // TODO(amber): eliminate these copies since we will be returning a new topology
   katana::do_all(
       katana::iterate(uint64_t{0}, num_nodes), [&](uint32_t node_id) {
-        out_indices_view[node_id] = new_prefix_sum[node_id];
+        out_indices_data[node_id] = new_prefix_sum[node_id];
       });
 
   katana::do_all(
       katana::iterate(uint64_t{0}, num_edges), [&](uint32_t edge_id) {
-        out_dests_view[edge_id] = new_out_dest[edge_id];
+        out_dests_data[edge_id] = new_out_dest[edge_id];
       });
 
   return katana::ResultSuccess();
@@ -974,9 +933,8 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
   const GraphTopology& topology = pg->topology();
-  auto symmetric = std::make_unique<katana::PropertyGraph>();
   if (topology.num_nodes() == 0) {
-    return std::unique_ptr<PropertyGraph>(std::move(symmetric));
+    return std::make_unique<PropertyGraph>();
   }
 
   // New symmetric graph topology
@@ -1007,9 +965,8 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
       katana::steal());
 
   // Compute prefix sum
-  for (uint64_t n = 1; n < topology.num_nodes(); ++n) {
-    out_indices[n] += out_indices[n - 1];
-  }
+  katana::ParallelSTL::partial_sum(
+      out_indices.begin(), out_indices.end(), out_indices.begin());
 
   uint64_t num_nodes_symmetric = topology.num_nodes();
   uint64_t num_edges_symmetric = out_indices[num_nodes_symmetric - 1];
@@ -1028,15 +985,12 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
   katana::do_all(
       katana::iterate(uint64_t{0}, topology.num_nodes()),
       [&](uint64_t src) {
-        auto edges = topology.edges(src);
-        // e = start index into edge array for a particular node
-        auto e = edges.begin();
-
         // get all outgoing edges (excluding self edges) of a particular
         // node and add reverse edges.
-        while (e < edges.end()) {
+        for (GraphTopology::Edge e : topology.edges(src)) {
+          // e = start index into edge array for a particular node
           // destination node
-          auto dest = topology.edge_dest(*e);
+          auto dest = topology.edge_dest(e);
 
           // Add original edge
           auto e_new_src = __sync_fetch_and_add(&(out_dests_offset[src]), 1);
@@ -1049,27 +1003,20 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
             out_dests[e_new_dst] = src;
             // TODO(gill) copy edge data to "new" array
           }
-          e++;
         }
       },
       katana::no_stats());
 
-  auto sym_topo = std::make_unique<GraphTopology>(
-      std::move(out_indices), std::move(out_dests));
-
-  auto r = symmetric->SetTopology(std::move(sym_topo));
-  if (!r) {
-    return r.error();
-  }
+  GraphTopology sym_topo(std::move(out_indices), std::move(out_dests));
+  auto symmetric = std::make_unique<katana::PropertyGraph>(std::move(sym_topo));
 
   return std::unique_ptr<PropertyGraph>(std::move(symmetric));
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
-  auto transpose = std::make_unique<katana::PropertyGraph>();
   if (topology.num_nodes() == 0) {
-    return std::unique_ptr<PropertyGraph>(std::move(transpose));
+    return std::make_unique<PropertyGraph>();
   }
 
   katana::NUMAArray<GraphTopology::Edge> out_indices;
@@ -1096,9 +1043,8 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
       katana::no_stats());
 
   // Prefix sum calculation of the edge index array
-  for (uint64_t n = 1; n < topology.num_nodes(); ++n) {
-    out_indices[n] += out_indices[n - 1];
-  }
+  katana::ParallelSTL::partial_sum(
+      out_indices.begin(), out_indices.end(), out_indices.begin());
 
   katana::NUMAArray<uint64_t> out_dests_offset;
   out_dests_offset.allocateInterleaved(topology.num_nodes());
@@ -1114,30 +1060,24 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
   katana::do_all(
       katana::iterate(uint64_t{0}, topology.num_nodes()),
       [&](uint64_t src) {
-        auto edges = topology.edges(src);
-        // e = start index into edge array for a particular node
-        auto e = edges.begin();
-
         // get all outgoing edges of a particular
         // node and reverse the edges.
-        while (e < edges.end()) {
+        for (GraphTopology::Edge e : topology.edges(src)) {
+          // e = start index into edge array for a particular node
           // Destination node
-          auto dest = topology.edge_dest(*e);
+          auto dest = topology.edge_dest(e);
           // Location to save edge
           auto e_new = __sync_fetch_and_add(&(out_dests_offset[dest]), 1);
           // Save src as destination
           out_dests[e_new] = src;
           // TODO (gill) copy edge data to the transposed graph
-          e++;
         }
       },
       katana::no_stats());
 
-  auto transpose_topo = std::make_unique<GraphTopology>(
-      std::move(out_indices), std::move(out_dests));
-  if (auto r = transpose->SetTopology(std::move(transpose_topo)); !r) {
-    return r.error();
-  }
+  GraphTopology transpose_topo{std::move(out_indices), std::move(out_dests)};
+  auto transpose_pg =
+      std::make_unique<katana::PropertyGraph>(std::move(transpose_topo));
 
-  return std::unique_ptr<PropertyGraph>(std::move(transpose));
+  return std::unique_ptr<PropertyGraph>(std::move(transpose_pg));
 }

--- a/libgalois/src/analytics/bfs/bfs.cpp
+++ b/libgalois/src/analytics/bfs/bfs.cpp
@@ -369,9 +369,8 @@ SynchronousDirectOpt(
                 GNode old_parent = ddata;
                 if (__sync_bool_compare_and_swap(&ddata, old_parent, src)) {
                   next_frontier->push(*dst);
-                  auto [begin_edge, end_edge] =
-                      graph.topology().edge_range(*dst);
-                  work_items += end_edge - begin_edge;
+                  auto e_range = graph.topology().edges(*dst);
+                  work_items += std::distance(e_range.begin(), e_range.end());
                 }
               }
             }

--- a/libgalois/test/TestTypedPropertyGraph.h
+++ b/libgalois/test/TestTypedPropertyGraph.h
@@ -75,12 +75,13 @@ MakeFileGraph(size_t num_nodes, size_t num_properties, Policy* policy) {
     indices.push_back(dests.size());
   }
 
-  auto g = std::make_unique<katana::PropertyGraph>();
+  katana::GraphTopology topo{
+      indices.data(), indices.size(), dests.data(), dests.size()};
 
-  auto topo = std::make_unique<katana::GraphTopology>(
-      indices.data(), indices.size(), dests.data(), dests.size());
-  auto set_result = g->SetTopology(std::move(topo));
-  KATANA_LOG_ASSERT(set_result);
+  auto g_res = katana::PropertyGraph::Make(std::move(topo));
+  KATANA_LOG_ASSERT(g_res);
+
+  std::unique_ptr<katana::PropertyGraph> g = std::move(g_res.value());
 
   size_t num_edges = dests.size();
 
@@ -117,8 +118,8 @@ BaselineIterate(katana::PropertyGraph* g, int num_properties) {
   using NodePointer = typename arrow::TypeTraits<NodeArrowType>::CType*;
   using EdgePointer = typename arrow::TypeTraits<EdgeArrowType>::CType*;
 
-  const auto* indices = g->topology().out_indices->raw_values();
-  const auto* dests = g->topology().out_dests->raw_values();
+  const auto* indices = g->topology().adj_data();
+  const auto* dests = g->topology().dest_data();
 
   std::vector<NodePointer> node_data;
   std::vector<EdgePointer> edge_data;

--- a/libgalois/test/property-graph-diff.cpp
+++ b/libgalois/test/property-graph-diff.cpp
@@ -61,7 +61,8 @@ CreateGraph1() {
     KATANA_LOG_FATAL(
         "Failed to construct graph: {}", components_result.error());
   }
-  auto graph_result = components_result.value().ToPropertyGraph();
+  auto graph_result =
+      katana::ConvertToPropertyGraph(std::move(components_result.value()));
   if (!graph_result) {
     KATANA_LOG_FATAL("Failed to construct graph: {}", graph_result.error());
   }
@@ -130,7 +131,8 @@ CreateGraph2() {
     KATANA_LOG_FATAL(
         "Failed to construct graph: {}", components_result.error());
   }
-  auto graph_result = components_result.value().ToPropertyGraph();
+  auto graph_result =
+      katana::ConvertToPropertyGraph(std::move(components_result.value()));
   if (!graph_result) {
     KATANA_LOG_FATAL("Failed to construct graph: {}", graph_result.error());
   }
@@ -191,7 +193,8 @@ CreateGraph3() {
     KATANA_LOG_FATAL(
         "Failed to construct graph: {}", components_result.error());
   }
-  auto graph_result = components_result.value().ToPropertyGraph();
+  auto graph_result =
+      katana::ConvertToPropertyGraph(std::move(components_result.value()));
   if (!graph_result) {
     KATANA_LOG_FATAL("Failed to construct graph: {}", graph_result.error());
   }

--- a/python/katana/_property_graph_numba.pyx.jinja
+++ b/python/katana/_property_graph_numba.pyx.jinja
@@ -1,6 +1,7 @@
 from katana.property_graph import *
 from .cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from libc.stdint cimport uint32_t, uint64_t
+from cython.operator cimport dereference as deref
 
 {% import "numba_wrapper_support.jinja" as numba %}
 
@@ -14,10 +15,10 @@ from libc.stdint cimport uint32_t, uint64_t
     return self.topology().num_edges()
 {% endcall %}
 {% call numba.method_with_body("edge_index", "uint64_t", ["uint64_t"]) %}
-    return self.topology().out_indices.get().Value(arg1)
+    return deref(self.topology().edges(arg1).end())
 {% endcall %}
 {% call numba.method_with_body("get_edge_dest", "uint64_t", ["uint64_t"]) %}
-    return self.topology().out_dests.get().Value(arg1)
+    return self.topology().edge_dest(arg1)
 {% endcall %}
 {% endcall %}
 

--- a/python/katana/analytics/_wrappers.pyx
+++ b/python/katana/analytics/_wrappers.pyx
@@ -3,13 +3,17 @@ Trivial Algorithms
 ------------------
 
 """
+from cython.operator cimport dereference as deref
 from libc.stdint cimport uint32_t, uint64_t
-from libcpp.memory cimport shared_ptr, static_pointer_cast
+from libcpp.memory cimport shared_ptr, static_pointer_cast, unique_ptr
+from libcpp.utility cimport move
 from pyarrow.lib cimport CArray, CUInt64Array, pyarrow_wrap_array
 
 from katana._property_graph cimport PropertyGraph
+from katana.cpp.libgalois.datastructures cimport LargeArray
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, handle_result_void, raise_error_code
+from katana.datastructures cimport LargeArray_uint64_t
 
 
 cdef inline default_value(v, d):
@@ -24,11 +28,18 @@ cdef shared_ptr[CUInt64Array] handle_result_shared_cuint64array(Result[shared_pt
             raise_error_code(res.error())
     return res.value()
 
+cdef unique_ptr[LargeArray[uint64_t]] handle_result_unique_largearray_uint64(Result[unique_ptr[LargeArray[uint64_t]]] res) \
+        nogil except *:
+    if not res.has_value():
+        with gil:
+            raise_error_code(res.error())
+    return move(res.value())
+
 
 # "Algorithms" from PropertyGraph
 
 cdef extern from "katana/PropertyGraph.h" namespace "katana" nogil:
-    Result[shared_ptr[CUInt64Array]] SortAllEdgesByDest(_PropertyGraph* pg);
+    Result[unique_ptr[LargeArray[uint64_t]]] SortAllEdgesByDest(_PropertyGraph* pg);
 
     uint64_t FindEdgeSortedByDest(const _PropertyGraph* graph, uint32_t node, uint32_t node_to_find);
 
@@ -41,10 +52,11 @@ def sort_all_edges_by_dest(PropertyGraph pg):
     :py:func:`find_edge_sorted_by_dest`.
 
     :return: The permutation vector (mapping from old indices to the new indices) which results due to the sorting.
+    :rtype: LargeArray[np.uint64]
     """
     with nogil:
-        res = handle_result_shared_cuint64array(SortAllEdgesByDest(pg.underlying_property_graph()))
-    return pyarrow_wrap_array(static_pointer_cast[CArray, CUInt64Array](res))
+        res = move(handle_result_unique_largearray_uint64(SortAllEdgesByDest(pg.underlying_property_graph())))
+    return LargeArray_uint64_t.make_move(move(deref(res.get())))
 
 
 def find_edge_sorted_by_dest(PropertyGraph pg, uint32_t node, uint32_t node_to_find):

--- a/python/katana/analytics/_wrappers.pyx
+++ b/python/katana/analytics/_wrappers.pyx
@@ -10,10 +10,10 @@ from libcpp.utility cimport move
 from pyarrow.lib cimport CArray, CUInt64Array, pyarrow_wrap_array
 
 from katana._property_graph cimport PropertyGraph
-from katana.cpp.libgalois.datastructures cimport LargeArray
+from katana.cpp.libgalois.datastructures cimport NUMAArray
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, handle_result_void, raise_error_code
-from katana.datastructures cimport LargeArray_uint64_t
+from katana.datastructures cimport NUMAArray_uint64_t
 
 
 cdef inline default_value(v, d):
@@ -28,7 +28,7 @@ cdef shared_ptr[CUInt64Array] handle_result_shared_cuint64array(Result[shared_pt
             raise_error_code(res.error())
     return res.value()
 
-cdef unique_ptr[LargeArray[uint64_t]] handle_result_unique_largearray_uint64(Result[unique_ptr[LargeArray[uint64_t]]] res) \
+cdef unique_ptr[NUMAArray[uint64_t]] handle_result_unique_numaarray_uint64(Result[unique_ptr[NUMAArray[uint64_t]]] res) \
         nogil except *:
     if not res.has_value():
         with gil:
@@ -39,7 +39,7 @@ cdef unique_ptr[LargeArray[uint64_t]] handle_result_unique_largearray_uint64(Res
 # "Algorithms" from PropertyGraph
 
 cdef extern from "katana/PropertyGraph.h" namespace "katana" nogil:
-    Result[unique_ptr[LargeArray[uint64_t]]] SortAllEdgesByDest(_PropertyGraph* pg);
+    Result[unique_ptr[NUMAArray[uint64_t]]] SortAllEdgesByDest(_PropertyGraph* pg);
 
     uint64_t FindEdgeSortedByDest(const _PropertyGraph* graph, uint32_t node, uint32_t node_to_find);
 
@@ -52,11 +52,11 @@ def sort_all_edges_by_dest(PropertyGraph pg):
     :py:func:`find_edge_sorted_by_dest`.
 
     :return: The permutation vector (mapping from old indices to the new indices) which results due to the sorting.
-    :rtype: LargeArray[np.uint64]
+    :rtype: NUMAArray[np.uint64]
     """
     with nogil:
-        res = move(handle_result_unique_largearray_uint64(SortAllEdgesByDest(pg.underlying_property_graph())))
-    return LargeArray_uint64_t.make_move(move(deref(res.get())))
+        res = move(handle_result_unique_numaarray_uint64(SortAllEdgesByDest(pg.underlying_property_graph())))
+    return NUMAArray_uint64_t.make_move(move(deref(res.get())))
 
 
 def find_edge_sorted_by_dest(PropertyGraph pg, uint32_t node, uint32_t node_to_find):

--- a/python/katana/cpp/boost.pxd
+++ b/python/katana/cpp/boost.pxd
@@ -1,0 +1,7 @@
+cdef extern from "boost/iterator/counting_iterator.hpp" namespace "boost" nogil:
+    cppclass counting_iterator[I]:
+        bint operator ==(counting_iterator[I])
+        bint operator !=(counting_iterator[I])
+        counting_iterator[I] operator++()
+        counting_iterator[I] operator--()
+        I operator *()

--- a/python/katana/cpp/libgalois/graphs/Graph.pxd
+++ b/python/katana/cpp/libgalois/graphs/Graph.pxd
@@ -4,6 +4,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 from pyarrow.lib cimport CArray, CChunkedArray, CSchema, CTable, CUInt32Array, CUInt64Array
 
+from katana.cpp.boost cimport counting_iterator
 from katana.cpp.libstd.optional cimport optional
 from katana.cpp.libsupport.result cimport Result
 
@@ -113,11 +114,14 @@ cdef extern from "katana/Graph.h" namespace "katana" nogil:
         edge_data& getEdgeData(edge_iterator)
         edge_data& getEdgeData(edge_iterator, MethodFlag)
 
+    ctypedef uint32_t Node "katana::GraphTopology::Node"
+    ctypedef uint64_t Edge "katana::GraphTopology::Edge"
+
     cppclass GraphTopology:
-        shared_ptr[CUInt64Array] out_indices
-        shared_ptr[CUInt32Array] out_dests
-        uint64_t num_nodes()
-        uint64_t num_edges()
+        StandardRange[counting_iterator[Edge]] edges(Node node) const
+        Node edge_dest(Edge edge_id) const
+        uint64_t num_nodes() const
+        uint64_t num_edges() const
 
     cppclass _PropertyGraph "katana::PropertyGraph":
         PropertyGraph()
@@ -179,5 +183,7 @@ cdef extern from "katana/BuildGraph.h" namespace "katana" nogil:
         Result[unique_ptr[_PropertyGraph]] ToPropertyGraph()
 
 cdef extern from "katana/GraphML.h" namespace "katana" nogil:
+    Result[unique_ptr[_PropertyGraph]] ConvertToPropertyGraph(GraphComponents&& graph_comps);
+
     Result[GraphComponents] ConvertGraphML(
         string input_filename, size_t chunk_size, bint verbose)

--- a/python/katana/datastructures.pxd.jinja
+++ b/python/katana/datastructures.pxd.jinja
@@ -55,6 +55,9 @@ cdef class {{class_name}}:
     cdef {{underlying_type}} underlying
     cdef readonly object dtype
 
+    @staticmethod
+    cdef {{class_name}} make_move({{underlying_type}}&& u, dtype=*)
+
     # Stored here so we can pass out pointers to them.
     cdef Py_ssize_t shape
     cdef Py_ssize_t stride

--- a/python/katana/datastructures.pyx.jinja
+++ b/python/katana/datastructures.pyx.jinja
@@ -23,6 +23,7 @@ from katana.numpy_structs import StructInstance
 from katana.util.template_type import make_template_type1, make_template_type1_with_opaque
 from .cpp.libgalois cimport datastructures
 from libc.stdint cimport uintptr_t
+from libcpp.utility cimport move
 from cython.operator cimport preincrement, dereference as deref
 import cython
 
@@ -155,6 +156,16 @@ cdef class {{class_name}}:
     """
     An array of elements of the same type that are allocated using NUMA aware policies.
     """
+
+    @staticmethod
+    cdef {{class_name}} make_move({{underlying_type}}&& u, dtype=None):
+        self = <{{class_name}}>{{class_name}}.__new__({{class_name}})
+        self.dtype = {{inst.dtype("dtype")}}
+        self.shape = -1
+        self.stride = sizeof({{inst.element_c_type}})
+        self.underlying = move(u)
+        return self
+
     def __init__(self, size=None, policy=None, dtype=None):
         """
         __init__(self, size=None, policy=None)

--- a/python/test/test_cpp_algos.py
+++ b/python/test/test_cpp_algos.py
@@ -79,7 +79,7 @@ def test_sort_all_edges_by_dest(property_graph: PropertyGraph):
     new_dests = [[property_graph.get_edge_dest(e) for e in property_graph.edges(n)] for n in range(NODES_TO_SAMPLE)]
     for n in range(NODES_TO_SAMPLE):
         assert len(original_dests[n]) == len(new_dests[n])
-        my_mapping = [mapping[e].as_py() for e in property_graph.edges(n)]
+        my_mapping = [mapping[e] for e in property_graph.edges(n)]
         for i, _ in enumerate(my_mapping):
             assert original_dests[n][i] == new_dests[n][my_mapping[i] - property_graph.edges(n)[0]]
         original_dests[n].sort()

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -2977,15 +2977,12 @@ struct Gr2Kg : public Conversion {
       }
     }
 
-    auto pg = std::make_unique<katana::PropertyGraph>();
-    auto topo = std::make_unique<katana::GraphTopology>(
-        std::move(out_indices), std::move(out_dests));
-    auto set_result = pg->SetTopology(std::move(topo));
-    if (!set_result) {
-      KATANA_LOG_FATAL(
-          "Failed to set topology for property file graph: {}",
-          set_result.error());
+    katana::GraphTopology topo{std::move(out_indices), std::move(out_dests)};
+    auto pg_res = katana::PropertyGraph::Make(std::move(topo));
+    if (!pg_res) {
+      KATANA_LOG_FATAL("Failed to create PropertyGraph");
     }
+    std::unique_ptr<katana::PropertyGraph> pg = std::move(pg_res.value());
 
     if (EdgeData::has_value) {
       if (auto r = AppendEdgeData<EdgeTy>(pg.get(), out_dests_data); !r) {

--- a/tools/graph-convert/graph-properties-convert-main.cpp
+++ b/tools/graph-convert/graph-properties-convert-main.cpp
@@ -144,7 +144,7 @@ ParseWild() {
       KATANA_LOG_FATAL("Error converting graph: {}", components_result.error());
     }
     if (auto r = katana::WritePropertyGraph(
-            components_result.value(), output_directory);
+            std::move(components_result.value()), output_directory);
         !r) {
       KATANA_LOG_FATAL("Failed to convert property graph: {}", r.error());
     }
@@ -172,7 +172,7 @@ ParseNeo4j() {
       KATANA_LOG_FATAL("Error converting graph: {}", components_result.error());
     }
     if (auto r = katana::WritePropertyGraph(
-            components_result.value(), output_directory);
+            std::move(components_result.value()), output_directory);
         !r) {
       KATANA_LOG_FATAL("Failed to convert property graph: {}", r.error());
     }

--- a/tools/graph-convert/graph-properties-convert-mongodb.cpp
+++ b/tools/graph-convert/graph-properties-convert-mongodb.cpp
@@ -1157,6 +1157,6 @@ katana::ConvertMongoDB(
   if (auto r = builder.Finish(); !r) {
     KATANA_LOG_FATAL("Failed to construct graph: {}", r.error());
   } else {
-    return r.value();
+    return std::move(r.value());
   }
 }

--- a/tools/graph-convert/graph-properties-convert-mysql.cpp
+++ b/tools/graph-convert/graph-properties-convert-mysql.cpp
@@ -896,7 +896,7 @@ katana::ConvertMysql(
   if (!out_result) {
     KATANA_LOG_FATAL("Failed to construct graph: {}", out_result.error());
   }
-  auto out = out_result.value();
+  katana::GraphComponents out = std::move(out_result.value());
   out.Dump();
   return out;
 }

--- a/tools/graph-convert/oplog-rdg.cpp
+++ b/tools/graph-convert/oplog-rdg.cpp
@@ -30,7 +30,9 @@ public:
       KATANA_LOG_FATAL(
           "Failed to construct graph: {}", components_result.error());
     }
-    if (auto r = WritePropertyGraph(components_result.value(), dest_dir); !r) {
+    if (auto r =
+            WritePropertyGraph(std::move(components_result.value()), dest_dir);
+        !r) {
       KATANA_LOG_FATAL("Failed to write graph: {}", r.error());
     }
     fmt::print("RDG written to {}\n", dest_dir);

--- a/tools/graph-convert/test/graph-properties-convert-test.cpp
+++ b/tools/graph-convert/test/graph-properties-convert-test.cpp
@@ -55,6 +55,19 @@ safe_cast(const std::shared_ptr<U>& r) noexcept {
 }
 
 void
+CheckTopology(
+    const katana::GraphComponents& graph, const std::string& indices_expected,
+    const std::string& dests_expected) {
+  auto indices = katana::ProjectAsArrowArray(
+      graph.topology.adj_data(), graph.topology.num_nodes());
+  KATANA_LOG_ASSERT(indices->ToString() == indices_expected);
+
+  auto dests = katana::ProjectAsArrowArray(
+      graph.topology.dest_data(), graph.topology.num_edges());
+  KATANA_LOG_ASSERT(dests->ToString() == dests_expected);
+}
+
+void
 VerifyMovieSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(graph.nodes.properties->num_columns() == 5);
   KATANA_LOG_ASSERT(graph.nodes.labels->num_columns() == 4);
@@ -66,8 +79,8 @@ VerifyMovieSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(graph.edges.properties->num_rows() == 8);
   KATANA_LOG_ASSERT(graph.edges.labels->num_rows() == 8);
 
-  KATANA_LOG_ASSERT(graph.topology->out_indices->length() == 9);
-  KATANA_LOG_ASSERT(graph.topology->out_dests->length() == 8);
+  KATANA_LOG_ASSERT(graph.topology.num_nodes() == 9);
+  KATANA_LOG_ASSERT(graph.topology.num_edges() == 8);
 
   // test node properties
   auto names = safe_cast<arrow::StringArray>(
@@ -308,7 +321,6 @@ VerifyMovieSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(partners->ToString() == partners_expected);
 
   // test topology
-  auto indices = graph.topology->out_indices;
   std::string indices_expected = std::string(
       "[\n\
   0,\n\
@@ -321,9 +333,7 @@ VerifyMovieSet(const katana::GraphComponents& graph) {
   8,\n\
   8\n\
 ]");
-  KATANA_LOG_ASSERT(indices->ToString() == indices_expected);
 
-  auto dests = graph.topology->out_dests;
   std::string dests_expected = std::string(
       "[\n\
   0,\n\
@@ -335,11 +345,12 @@ VerifyMovieSet(const katana::GraphComponents& graph) {
   0,\n\
   0\n\
 ]");
-  KATANA_LOG_ASSERT(dests->ToString() == dests_expected);
+
+  CheckTopology(graph, indices_expected, dests_expected);
 }
 
 void
-VerifyTypesSet(katana::GraphComponents graph) {
+VerifyTypesSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(graph.nodes.properties->num_columns() == 5);
   KATANA_LOG_ASSERT(graph.nodes.labels->num_columns() == 4);
   KATANA_LOG_ASSERT(graph.edges.properties->num_columns() == 4);
@@ -350,8 +361,8 @@ VerifyTypesSet(katana::GraphComponents graph) {
   KATANA_LOG_ASSERT(graph.edges.properties->num_rows() == 8);
   KATANA_LOG_ASSERT(graph.edges.labels->num_rows() == 8);
 
-  KATANA_LOG_ASSERT(graph.topology->out_indices->length() == 9);
-  KATANA_LOG_ASSERT(graph.topology->out_dests->length() == 8);
+  KATANA_LOG_ASSERT(graph.topology.num_nodes() == 9);
+  KATANA_LOG_ASSERT(graph.topology.num_edges() == 8);
 
   // test node properties
   auto names = safe_cast<arrow::StringArray>(
@@ -668,7 +679,6 @@ VerifyTypesSet(katana::GraphComponents graph) {
   KATANA_LOG_ASSERT(partners->ToString() == partners_expected);
 
   // test topology
-  auto indices = graph.topology->out_indices;
   std::string indices_expected = std::string(
       "[\n\
   0,\n\
@@ -681,9 +691,6 @@ VerifyTypesSet(katana::GraphComponents graph) {
   8,\n\
   8\n\
 ]");
-  KATANA_LOG_ASSERT(indices->ToString() == indices_expected);
-
-  auto dests = graph.topology->out_dests;
   std::string dests_expected = std::string(
       "[\n\
   0,\n\
@@ -695,11 +702,11 @@ VerifyTypesSet(katana::GraphComponents graph) {
   0,\n\
   0\n\
 ]");
-  KATANA_LOG_ASSERT(dests->ToString() == dests_expected);
+  CheckTopology(graph, indices_expected, dests_expected);
 }
 
 void
-VerifyChunksSet(katana::GraphComponents graph) {
+VerifyChunksSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(graph.nodes.properties->num_columns() == 5);
   KATANA_LOG_ASSERT(graph.nodes.labels->num_columns() == 4);
   KATANA_LOG_ASSERT(graph.edges.properties->num_columns() == 4);
@@ -710,8 +717,8 @@ VerifyChunksSet(katana::GraphComponents graph) {
   KATANA_LOG_ASSERT(graph.edges.properties->num_rows() == 8);
   KATANA_LOG_ASSERT(graph.edges.labels->num_rows() == 8);
 
-  KATANA_LOG_ASSERT(graph.topology->out_indices->length() == 9);
-  KATANA_LOG_ASSERT(graph.topology->out_dests->length() == 8);
+  KATANA_LOG_ASSERT(graph.topology.num_nodes() == 9);
+  KATANA_LOG_ASSERT(graph.topology.num_edges() == 8);
 
   // test node properties
   auto names = graph.nodes.properties->GetColumnByName("name");
@@ -1113,7 +1120,6 @@ VerifyChunksSet(katana::GraphComponents graph) {
   KATANA_LOG_ASSERT(partners->ToString() == partners_expected);
 
   // test topology
-  auto indices = graph.topology->out_indices;
   std::string indices_expected = std::string(
       "[\n\
   0,\n\
@@ -1126,9 +1132,6 @@ VerifyChunksSet(katana::GraphComponents graph) {
   8,\n\
   8\n\
 ]");
-  KATANA_LOG_ASSERT(indices->ToString() == indices_expected);
-
-  auto dests = graph.topology->out_dests;
   std::string dests_expected = std::string(
       "[\n\
   0,\n\
@@ -1140,7 +1143,7 @@ VerifyChunksSet(katana::GraphComponents graph) {
   0,\n\
   0\n\
 ]");
-  KATANA_LOG_ASSERT(dests->ToString() == dests_expected);
+  CheckTopology(graph, indices_expected, dests_expected);
 }
 
 #if defined(KATANA_MONGOC_FOUND)
@@ -1175,7 +1178,7 @@ GenerateAndConvertBson(size_t chunk_size) {
   if (auto r = builder.Finish(); !r) {
     KATANA_LOG_FATAL("Failed to construct graph: {}", r.error());
   } else {
-    return r.value();
+    return std::move(r.value());
   }
 }
 #endif
@@ -1193,8 +1196,8 @@ VerifyMongodbSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(graph.edges.properties->num_rows() == 1);
   KATANA_LOG_ASSERT(graph.edges.labels->num_rows() == 1);
 
-  KATANA_LOG_ASSERT(graph.topology->out_indices->length() == 2);
-  KATANA_LOG_ASSERT(graph.topology->out_dests->length() == 1);
+  KATANA_LOG_ASSERT(graph.topology.num_nodes() == 2);
+  KATANA_LOG_ASSERT(graph.topology.num_edges() == 1);
 
   // test node properties
   auto names = safe_cast<arrow::StringArray>(
@@ -1244,20 +1247,17 @@ VerifyMongodbSet(const katana::GraphComponents& graph) {
   KATANA_LOG_ASSERT(friends->ToString() == friends_expected);
 
   // test topology
-  auto indices = graph.topology->out_indices;
   std::string indices_expected = std::string(
       "[\n\
   1,\n\
   1\n\
 ]");
-  KATANA_LOG_ASSERT(indices->ToString() == indices_expected);
 
-  auto dests = graph.topology->out_dests;
   std::string dests_expected = std::string(
       "[\n\
   1\n\
 ]");
-  KATANA_LOG_ASSERT(dests->ToString() == dests_expected);
+  CheckTopology(graph, indices_expected, dests_expected);
 }
 #endif
 


### PR DESCRIPTION
Move away from arrow arrays. Restrict access to internals of topology.
Create new graph instead of SetTopology

IMPORTANT: Wait for https://github.com/KatanaGraph/katana-enterprise/pull/1427 before mergin. 