### PR TITLE
Add GCP support to RDG Migration script (scripts/migrate_rdgs.py)

### DIFF
--- a/scripts/migrate_rdgs_requirements.txt
+++ b/scripts/migrate_rdgs_requirements.txt
@@ -1,0 +1,3 @@
+google-cloud-storage==1.38.0
+google-api-python-client==2.7.0
+boto3


### PR DESCRIPTION
Adds GCP support to the RDG migration script.

Also, adds a migrate_rdgs_requirements.txt file for users to install script requirements.

Usage:
```
pip3 install -r scripts/migrate_rdgs_requirements.txt
./scripts/migrate_rdgs.py --gs gs://bucket-with-old-rdgs/rdg_dir/ > rdg_migration_script.sh
cat rdg_migration_script.sh
source rdg_migration_script.sh
```