### PR TITLE
Do not export Unchunk, eliminate Shuffle

### DIFF
--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -18,14 +18,6 @@
 
 namespace katana {
 
-KATANA_EXPORT ErrorCode ArrowToKatana(arrow::StatusCode code);
-
-inline ErrorCode
-ArrowToKatana(arrow::Status st) {
-  KATANA_LOG_DEBUG_ASSERT(!st.ok());
-  return ArrowToKatana(st.code());
-}
-
 /// Perform a safe cast from \param gen_array to \tparam ArrowArrayType
 /// calls the array's `View()` member first to make sure cast is safe.
 template <typename ArrowArrayType>
@@ -288,15 +280,10 @@ TableBuilder::AddColumn(const ColumnOptions& options) {
 ////////////////////////////////////////////
 // Arrow utilities
 
-/// Combine chunks of ChunkedArray into a single Array
-KATANA_EXPORT Result<std::shared_ptr<arrow::Array>> Unchunk(
-    const std::shared_ptr<arrow::ChunkedArray>& original);
-/// Return a randomly shuffled version of a ChunkedArray
-KATANA_EXPORT Result<std::shared_ptr<arrow::ChunkedArray>> Shuffle(
-    const std::shared_ptr<arrow::ChunkedArray>& original);
 /// Return a ChunkeArray of Nulls of the given type and length
 KATANA_EXPORT std::shared_ptr<arrow::ChunkedArray> NullChunkedArray(
     const std::shared_ptr<arrow::DataType>& type, int64_t length);
+
 /// Print the differences between two ChunkedArrays only using
 /// about approx_total_characters
 KATANA_EXPORT void DiffFormatTo(

--- a/libsupport/src/ArrowInterchange.cpp
+++ b/libsupport/src/ArrowInterchange.cpp
@@ -70,32 +70,15 @@ ApproxArrayDataMemUse(const std::shared_ptr<arrow::ArrayData>& data) {
   return total_mem_use;
 }
 
-}  // anonymous namespace
-
 katana::Result<std::shared_ptr<arrow::Array>>
-katana::Unchunk(const std::shared_ptr<arrow::ChunkedArray>& original) {
+Unchunk(const std::shared_ptr<arrow::ChunkedArray>& original) {
   std::shared_ptr<arrow::Array> indices = KATANA_CHECKED(Indices(original));
   std::shared_ptr<arrow::ChunkedArray> chunked =
       KATANA_CHECKED(IndexedTake(original, indices));
   return chunked->chunk(0);
 }
 
-katana::Result<std::shared_ptr<arrow::ChunkedArray>>
-katana::Shuffle(const std::shared_ptr<arrow::ChunkedArray>& original) {
-  int64_t length = original->length();
-  // Build indices array, reusable across properties
-  std::vector<uint64_t> indices_vec(length);
-  // fills the vector from 0 to indices_vec.size()-1
-  std::iota(indices_vec.begin(), indices_vec.end(), 0);
-  std::shuffle(indices_vec.begin(), indices_vec.end(), katana::GetGenerator());
-  arrow::CTypeTraits<int64_t>::BuilderType builder;
-  KATANA_CHECKED(builder.Reserve(length));
-  for (int64_t i = 0; i < length; ++i) {
-    builder.UnsafeAppend(indices_vec[i]);
-  }
-  std::shared_ptr<arrow::Array> indices = KATANA_CHECKED(builder.Finish());
-  return IndexedTake(original, indices);
-}
+}  // anonymous namespace
 
 std::shared_ptr<arrow::ChunkedArray>
 katana::NullChunkedArray(


### PR DESCRIPTION
We no longer use Shuffle for testing and only use Unchunk internally to
ArrowInterchange.

This is a rare case of eliminating use in enterprise first, then garbage collecting from open later.