### PR TITLE
Add lower bound on conda arrow version.

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -4,7 +4,7 @@
 channels:
  - conda-forge
 dependencies:
- - arrow-cpp<3.0.0a0
+ - arrow-cpp>=2.0,<3.0.0a0
  - backward-cpp>=1.4
  - benchmark
  - black=19.10


### PR DESCRIPTION
This is needed because occationally conda goes crazy and picks
really old version.