### PR TITLE
galois/PropertyGraph: tweak interfaces to allow updates

### DIFF
--- a/libgalois/include/katana/ArrowRandomAccessBuilder.h
+++ b/libgalois/include/katana/ArrowRandomAccessBuilder.h
@@ -75,6 +75,11 @@ public:
     return reinterpret_cast<ValueType*>(data_.data())[index];
   }
 
+  void UnsetValue(size_t index) {
+    KATANA_LOG_DEBUG_ASSERT(index < size());
+    valid_[index] = false;
+  }
+
   bool IsValid(size_t index) { return valid_[index]; }
 
   size_t size() const { return data_.size(); }
@@ -161,6 +166,8 @@ public:
   void SetValue(size_t index, value_type value) {
     builder_.SetValue(index, value);
   }
+
+  void UnsetValue(size_t index) { builder_.UnsetValue(index); }
 
   value_type& operator[](size_t index) { return builder_[index]; }
 

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -458,14 +458,10 @@ katana::PropertyGraph::Copy(
 
 katana::Result<void>
 katana::PropertyGraph::ConstructTypeSetIDs() {
-  if ((!node_type_name_to_type_set_ids_.empty()) ||
-      (!node_type_set_id_to_type_names_.empty()) ||
-      (!edge_type_name_to_type_set_ids_.empty()) ||
-      (!edge_type_set_id_to_type_names_.empty())) {
-    return KATANA_ERROR(
-        ErrorCode::AssertionFailed,
-        "ConstructTypeSetIDs() should not called more than once");
-  }
+  node_type_name_to_type_set_ids_.clear();
+  node_type_set_id_to_type_names_.clear();
+  edge_type_name_to_type_set_ids_.clear();
+  edge_type_set_id_to_type_names_.clear();
 
   static_assert(kUnknownType == 0);
   node_type_set_id_to_type_names_.push_back(


### PR DESCRIPTION
I want to support updates of properties that do not change the topology
without repartitioning. To do that, I needed to tweak a few things.

The first is that I need to be able to un-set a property. To support
that I added a `SetNull` member to `ArrowRandomAccessBuilder`.

The second is that when I tweak a property graph then try to build an
attributed graph from it, this type labels function is called again. I
modified the semantics to re-compute the types rather than complain
since I believe those semantics are correct. When I update the
properties I may have changed some labels so types should be
re-computed.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>