### PR TITLE
[KAT-538] Encapsulate node and edge properties

### DIFF
--- a/libgalois/src/PropertyViews.cpp
+++ b/libgalois/src/PropertyViews.cpp
@@ -11,8 +11,29 @@ katana::internal::ExtractArrays(
     }
     if (column->num_chunks() != 1) {
       // Katana form graphs only contain single chunk property columns.
-      return ErrorCode::TODO;
-      // TODO: Maybe we need an InvalidGraph error
+      return KATANA_ERROR(
+          ErrorCode::NotImplemented, "property is in the wrong format");
+    }
+    ret.emplace_back(column->chunks()[0].get());
+  }
+
+  return ret;
+}
+
+katana::Result<std::vector<arrow::Array*>>
+katana::internal::ExtractArrays(
+    const PropertyGraph::ReadOnlyPropertyView& pview,
+    const std::vector<std::string>& properties) {
+  std::vector<arrow::Array*> ret;
+  for (auto& property : properties) {
+    auto column = pview.GetProperty(property);
+    if (!column) {
+      return ErrorCode::PropertyNotFound;
+    }
+    if (column->num_chunks() != 1) {
+      // Katana form graphs only contain single chunk property columns.
+      return KATANA_ERROR(
+          ErrorCode::NotImplemented, "property is in the wrong format");
     }
     ret.emplace_back(column->chunks()[0].get());
   }

--- a/libgalois/src/analytics/sssp/sssp.cpp
+++ b/libgalois/src/analytics/sssp/sssp.cpp
@@ -529,10 +529,7 @@ SSSPWithWrap(
   if (!graph && graph.error() == katana::ErrorCode::TypeError) {
     KATANA_LOG_DEBUG(
         "Incorrect edge property type: {}",
-        pg->edge_properties()
-            ->GetColumnByName(edge_weight_property_name)
-            ->type()
-            ->ToString());
+        pg->GetEdgeProperty(edge_weight_property_name)->type()->ToString());
   }
   if (!graph) {
     return graph.error();

--- a/libgalois/test/property-file-graph.cpp
+++ b/libgalois/test/property-file-graph.cpp
@@ -89,11 +89,8 @@ TestRoundTrip() {
 
   std::unique_ptr<katana::PropertyGraph> g2 = std::move(make_result.value());
 
-  std::shared_ptr<arrow::Table> node_properties = g2->node_properties();
-  std::shared_ptr<arrow::Table> edge_properties = g2->edge_properties();
-
-  KATANA_LOG_ASSERT(node_properties->num_columns() == 1);
-  KATANA_LOG_ASSERT(edge_properties->num_columns() == 1);
+  KATANA_LOG_ASSERT(g2->GetNumNodeProperties() == 1);
+  KATANA_LOG_ASSERT(g2->GetNumEdgeProperties() == 1);
 
   KATANA_LOG_ASSERT(g2->edge_schema()->field(0)->name() == "edge-name");
   KATANA_LOG_ASSERT(g2->node_schema()->field(0)->name() == "node-name");
@@ -104,10 +101,8 @@ TestRoundTrip() {
   KATANA_LOG_ASSERT(
       g2->node_schema()->field(0)->type()->Equals(arrow::int32()));
 
-  std::shared_ptr<arrow::ChunkedArray> node_property =
-      node_properties->column(0);
-  std::shared_ptr<arrow::ChunkedArray> edge_property =
-      edge_properties->column(0);
+  std::shared_ptr<arrow::ChunkedArray> node_property = g2->GetNodeProperty(0);
+  std::shared_ptr<arrow::ChunkedArray> edge_property = g2->GetEdgeProperty(0);
 
   KATANA_LOG_ASSERT(
       static_cast<size_t>(node_property->length()) == test_length);

--- a/tools/graph-convert/Transforms.cpp
+++ b/tools/graph-convert/Transforms.cpp
@@ -8,7 +8,7 @@ namespace {
 
 void
 ApplyTransform(
-    katana::PropertyGraph::PropertyView view,
+    katana::PropertyGraph::MutablePropertyView view,
     katana::ColumnTransformer* transform) {
   int cur_field = 0;
   int num_fields = view.schema()->num_fields();
@@ -25,7 +25,7 @@ ApplyTransform(
     KATANA_LOG_WARN(
         "applying {} to property {}", transform->name(), field->name());
 
-    std::shared_ptr<arrow::ChunkedArray> property = view.Property(cur_field);
+    std::shared_ptr<arrow::ChunkedArray> property = view.GetProperty(cur_field);
 
     if (auto result = view.RemoveProperty(cur_field); !result) {
       KATANA_LOG_FATAL("failed to remove {}: {}", cur_field, result.error());
@@ -157,7 +157,7 @@ katana::ApplyTransforms(
     const std::vector<std::unique_ptr<katana::ColumnTransformer>>&
         transformers) {
   for (const auto& t : transformers) {
-    ApplyTransform(graph->node_property_view(), t.get());
-    ApplyTransform(graph->edge_property_view(), t.get());
+    ApplyTransform(graph->NodeMutablePropertyView(), t.get());
+    ApplyTransform(graph->EdgeMutablePropertyView(), t.get());
   }
 }


### PR DESCRIPTION
This change encapsulates the node and edge property tables for our graphs.
Exposing the arrow table of properties makes it impossible to change our
representation to keep a subset of properties in memory at once, so we
stop doing that.

There is a dependent PR (https://github.com/KatanaGraph/katana-enterprise/pull/1479) for enterprise that has more detail.