### PR TITLE
Fix regression in libtsuba caused by removing code which was marked a…

### DIFF
--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -38,6 +38,10 @@ set_common_katana_library_options(tsuba ALWAYS_SHARED)
 
 target_link_libraries(tsuba PUBLIC katana_support)
 
+if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
 install(
   DIRECTORY include/
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -15,6 +15,14 @@ namespace {
 
 // TODO (witchel) these key are deprecated as part of parquet
 const char* kTopologyPathKey = "kg.v1.topology.path";
+const char* kNodePropertyPathKey = "kg.v1.node_property.path";
+const char* kNodePropertyNameKey = "kg.v1.node_property.name";
+const char* kEdgePropertyPathKey = "kg.v1.edge_property.path";
+const char* kEdgePropertyNameKey = "kg.v1.edge_property.name";
+const char* kPartPropertyPathKey = "kg.v1.part_property.path";
+const char* kPartPropertyNameKey = "kg.v1.part_property.name";
+const char* kPartOtherMetadataKey = "kg.v1.other_part_metadata.key";
+
 const char* kNodePropertyKey = "kg.v1.node_property";
 const char* kEdgePropertyKey = "kg.v1.edge_property";
 const char* kPartPropertyFilesKey = "kg.v1.part_property_files";
@@ -25,10 +33,142 @@ const char* kPartProperyMetaKey = "kg.v1.part_property_meta";
 //constexpr std::string_view  local_to_global_prop_name = "local_to_global_id";
 
 // special partition property names
+// TODO (witchel) Deprecated.  Remove with ReadMetadataParquet, below
+katana::Result<std::vector<tsuba::PropStorageInfo>>
+MakeProperties(std::vector<std::string>&& values) {
+  std::vector v = std::move(values);
+
+  if ((v.size() % 2) != 0) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::InvalidArgument,
+        "failed: number of values {} is not even", v.size());
+  }
+
+  std::vector<tsuba::PropStorageInfo> prop_info_list;
+  std::unordered_set<std::string> names;
+  prop_info_list.reserve(v.size() / 2);
+
+  for (size_t i = 0, n = v.size(); i < n; i += 2) {
+    const auto& name = v[i];
+    const auto& path = v[i + 1];
+
+    names.insert(name);
+
+    prop_info_list.emplace_back(tsuba::PropStorageInfo{
+        .name = name,
+        .path = path,
+    });
+  }
+
+  KATANA_LOG_DEBUG_ASSERT(names.size() == prop_info_list.size());
+
+  return prop_info_list;
+}
 
 }  // namespace
 
 namespace tsuba {
+
+
+// TODO (witchel) Deprecated.  Remove when input graphs don't use parquet metadata
+/// ReadMetadata reads metadata from a Parquet file and returns the extracted
+/// property graph specific fields as well as the unparsed fields.
+///
+/// The order of metadata fields is significant, and repeated metadata fields
+/// are used to encode lists of values.
+katana::Result<RDGPartHeader>
+RDGPartHeader::MakeParquet(const katana::Uri& partition_path) {
+  auto fv = std::make_shared<FileView>();
+  if (auto res = fv->Bind(partition_path.string(), false); !res) {
+    return res.error().WithContext(
+        "cannot open {}: {}", partition_path.string(), res.error());
+  }
+
+  if (fv->size() == 0) {
+    return RDGPartHeader{};
+  }
+
+  std::shared_ptr<parquet::FileMetaData> md;
+  try {
+    md = parquet::ReadMetaData(fv);
+  } catch (const std::exception& exp) {
+    return KATANA_ERROR(
+        ErrorCode::ArrowError, "arrow error reading {}: {}",
+        partition_path.string(), exp.what());
+  }
+
+  const std::shared_ptr<const arrow::KeyValueMetadata>& kv_metadata =
+      md->key_value_metadata();
+
+  if (!kv_metadata) {
+    return ErrorCode::InvalidArgument;
+  }
+
+  std::vector<std::string> node_values;
+  std::vector<std::string> edge_values;
+  std::vector<std::string> part_values;
+  std::vector<std::pair<std::string, std::string>> other_metadata;
+  std::string topology_path;
+  for (int64_t i = 0, n = kv_metadata->size(); i < n; ++i) {
+    const std::string& k = kv_metadata->key(i);
+    const std::string& v = kv_metadata->value(i);
+
+    if (k == kNodePropertyPathKey || k == kNodePropertyNameKey) {
+      node_values.emplace_back(v);
+    } else if (k == kEdgePropertyPathKey || k == kEdgePropertyNameKey) {
+      edge_values.emplace_back(v);
+    } else if (k == kPartPropertyPathKey || k == kPartPropertyNameKey) {
+      part_values.emplace_back(v);
+    } else if (k == kTopologyPathKey) {
+      if (!topology_path.empty()) {
+        return ErrorCode::InvalidArgument;
+      }
+      topology_path = v;
+    } else {
+      other_metadata.emplace_back(std::make_pair(k, v));
+    }
+  }
+
+  auto node_prop_info_list_result = MakeProperties(std::move(node_values));
+  if (!node_prop_info_list_result) {
+    return node_prop_info_list_result.error();
+  }
+
+  auto edge_prop_info_list_result = MakeProperties(std::move(edge_values));
+  if (!edge_prop_info_list_result) {
+    return edge_prop_info_list_result.error();
+  }
+
+  auto part_prop_info_list_result = MakeProperties(std::move(part_values));
+  if (!part_prop_info_list_result) {
+    return part_prop_info_list_result.error();
+  }
+
+  // these are always persisted
+  for (auto& prop : part_prop_info_list_result.value()) {
+    prop.persist = true;
+  }
+
+  PartitionMetadata part_metadata;
+  for (const auto& [k, v] : other_metadata) {
+    if (k == kPartOtherMetadataKey) {
+      if (auto res = katana::JsonParse(v, &part_metadata); !res) {
+        return res.error();
+      }
+    }
+  }
+
+  RDGPartHeader header;
+
+  header.node_prop_info_list_ = std::move(node_prop_info_list_result.value());
+  header.edge_prop_info_list_ = std::move(edge_prop_info_list_result.value());
+  header.part_prop_info_list_ = std::move(part_prop_info_list_result.value());
+  header.topology_path_ = std::move(topology_path);
+  header.metadata_ = std::move(part_metadata);
+
+  return RDGPartHeader(std::move(header));
+}
+
 
 katana::Result<RDGPartHeader>
 RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
@@ -51,11 +191,22 @@ RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
 katana::Result<RDGPartHeader>
 RDGPartHeader::Make(const katana::Uri& partition_path) {
   katana::Result<RDGPartHeader> res = MakeJson(partition_path);
-  if (!res) {
-    return res.error();
+
+  if (res) {
+    return res;
   }
-  return res;
+
+  KATANA_LOG_WARN("failed to parse JSON RDGPartHeader: {}", res.error());
+  KATANA_LOG_WARN("falling back on Parquet (deprecated)");
+
+  try {
+    return MakeParquet(partition_path);
+  } catch (const std::exception& exp) {
+    return KATANA_ERROR(
+        ErrorCode::ArrowError, "arrow exception: {}", exp.what());
+  }
 }
+
 
 katana::Result<void>
 RDGPartHeader::Write(

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -129,6 +129,8 @@ public:
 private:
   static katana::Result<RDGPartHeader> MakeJson(
       const katana::Uri& partition_path);
+  static katana::Result<RDGPartHeader> MakeParquet(
+      const katana::Uri& partition_path);
 
   std::vector<PropStorageInfo> part_prop_info_list_;
   std::vector<PropStorageInfo> node_prop_info_list_;

--- a/libtsuba/test/CMakeLists.txt
+++ b/libtsuba/test/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_executable(test_RDGPartHeader test_RDGPartHeader.cpp)
+target_link_libraries(test_RDGPartHeader tsuba)
+target_include_directories(test_RDGPartHeader PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+)
+
+set(md_formats json parquet)
+foreach(format ${md_formats})
+  set(header_path s3://katana-ci/tsuba-tests/rdg-headers/${format}_header)
+  set(test_name test_${format}_rdgpartheader)
+  add_test(NAME ${test_name}  COMMAND "$<TARGET_FILE:test_RDGPartHeader>" ${header_path})
+  set_tests_properties(${test_name}
+    PROPERTIES
+      ENVIRONMENT KATANA_DO_NOT_BIND_THREADS=1)
+  set_tests_properties(${test_name}
+    PROPERTIES
+    LABELS quick)
+endforeach()
+
+

--- a/libtsuba/test/test_RDGPartHeader.cpp
+++ b/libtsuba/test/test_RDGPartHeader.cpp
@@ -1,0 +1,21 @@
+#include "RDGPartHeader.h"
+#include "katana/Uri.h"
+#include "tsuba/tsuba.h"
+int
+main(int argc, char** md_paths) {
+  if (argc < 2) {
+    KATANA_LOG_FATAL("usage: {} MD_PATHS...", md_paths[0]);
+  }
+  if (auto res = tsuba::Init(); !res) {
+    KATANA_LOG_FATAL("tsuba::Init: {}", res.error());
+  }
+  for (int i = 1; i < argc; i++) {
+    char* md_path = md_paths[i];
+    auto header_uri_res = katana::Uri::Make(md_path);
+    katana::Uri header_uri_Val = header_uri_res.value();
+    if (auto header = tsuba::RDGPartHeader::Make(header_uri_Val); !header) {
+      KATANA_LOG_FATAL("Failed to load RDGPartHeader: {}", md_path);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
…s deprecated but with active users.

Add unit tests to prevent future silent regressions.