### PR TITLE
Resolving snappy conflict

### DIFF
--- a/config/conanfile.py
+++ b/config/conanfile.py
@@ -18,6 +18,7 @@ class KatanaConan(ConanFile):
         "nlohmann_json/3.7.3",
         "openssl/1.1.1h",
         "mongo-c-driver/1.17.2",
+        "snappy/1.1.8",
     )
 
     default_options = {


### PR DESCRIPTION
```
...
snappy/1.1.9: Downloaded recipe revision 0
ERROR: Conflict in mongo-c-driver/1.17.2:
    'mongo-c-driver/1.17.2' requires 'snappy/1.1.9' while 'arrow/2.0.0' requires 'snappy/1.1.8'.
    To fix this conflict you need to override the package 'snappy' in your root package.
...
```