### PR TITLE
[KAT-862] Upgrade to arrow 4.0 and move arrow dependency to APT instead of conan for non-conda builds

### DIFF
--- a/cmake/Modules/KatanaBuildCommon.cmake
+++ b/cmake/Modules/KatanaBuildCommon.cmake
@@ -519,7 +519,7 @@ macro(katana_setup_cpack_component_groups NAME SUFFIX)
   set(CPACK_COMPONENT_TOOLS_PKG_DEPENDS shlib_pkg)
 
   set(CPACK_DEBIAN_PYTHON_PKG_PACKAGE_NAME "python3-${NAME}${SUFFIX}")
-  list(APPEND CPACK_DEBIAN_PYTHON_PKG_PACKAGE_DEPENDS "python3-minimal")
+  list(APPEND CPACK_DEBIAN_PYTHON_PKG_PACKAGE_DEPENDS "python3-minimal" "python3-numpy")
   set(CPACK_RPM_PYTHON_PKG_PACKAGE_NAME "python-${NAME}${SUFFIX}")
 #  To add RPM python support we will need something like: list(APPEND CPACK_RPM_PYTHON_PACKAGE_DEPENDS "[the name of the python3 rpm]")
   # No addition dependencies on apps_pkg since it depends on shlib_pkg

--- a/conda_recipe/conda_build_config.yaml
+++ b/conda_recipe/conda_build_config.yaml
@@ -2,7 +2,7 @@ python:
   - 3.8.* *_cpython
 
 arrow_cpp:
-  - 2
+  - 4
 
 pin_run_as_build:
   arrow-cpp:

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -4,7 +4,7 @@
 channels:
  - conda-forge
 dependencies:
- - arrow-cpp>=2.0,<3.0.0a0
+ - arrow-cpp>=4.0,<5.0.0a0
  - backward-cpp>=1.4
  - benchmark
  - black=19.10

--- a/config/conanfile.py
+++ b/config/conanfile.py
@@ -19,8 +19,6 @@ class KatanaConan(ConanFile):
         "libcurl/7.74.0",
         "nlohmann_json/3.7.3",
         "openssl/1.1.1h",
-        "mongo-c-driver/1.17.2",
-        "snappy/1.1.8",
     )
 
     default_options = {

--- a/config/conanfile.py
+++ b/config/conanfile.py
@@ -7,8 +7,10 @@ from conans.model.version import Version
 class KatanaConan(ConanFile):
     settings = ("os", "compiler", "build_type", "arch")
 
+    # Several packages are installed via APT:
+    #  - arrow
+    #  - llvm
     requires = (
-        "arrow/4.0.0",
         "backward-cpp/1.5",
         "benchmark/1.5.0",
         "boost/1.74.0",
@@ -22,24 +24,6 @@ class KatanaConan(ConanFile):
     )
 
     default_options = {
-        "arrow:filesystem_layer": True,
-        "arrow:parquet": True,
-        "arrow:shared": False,
-        # In general, we prefer to support as many compression algorithms as
-        # possible to tolerate files created by others. bz2, lz4 and zstd cause
-        # some issues with arrow/2.0.0 because arrow's cmake package doesn't
-        # find conan's libraries.
-        #
-        # According to [1], only snappy and gzip are expected to be present.
-        #
-        # [1] https://arrow.apache.org/docs/r/reference/write_parquet.html
-        #
-        # "arrow:with_bz2": True,
-        # "arrow:with_lz4": True,
-        # "arrow:with_zstd": True,
-        "arrow:with_brotli": True,
-        "arrow:with_snappy": True,
-        "arrow:with_zlib": True,
         "libcurl:shared": False,
     }
 

--- a/config/conanfile.py
+++ b/config/conanfile.py
@@ -8,7 +8,7 @@ class KatanaConan(ConanFile):
     settings = ("os", "compiler", "build_type", "arch")
 
     requires = (
-        "arrow/2.0.0",
+        "arrow/4.0.0",
         "backward-cpp/1.5",
         "benchmark/1.5.0",
         "boost/1.74.0",

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -351,7 +351,7 @@ def cythonize(module_list, *, source_root, **kwargs):
     require_python_module("packaging")
     require_python_module("Cython", "0.29.12")
     require_python_module("numpy", "1.10")
-    require_python_module("pyarrow", "1.0", "3.0.dev")
+    require_python_module("pyarrow", "4.0", "5.0.dev")
 
     import Cython.Build
     import numpy

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -13,6 +13,7 @@ function brew_install_if_missing {
   fi
 }
 
+brew_install_if_missing apache-arrow
 brew_install_if_missing autoconf
 brew_install_if_missing automake
 brew_install_if_missing ccache
@@ -24,9 +25,5 @@ brew_install_if_missing shellcheck
 
 brew tap cleishm/neo4j
 brew_install_if_missing libcypher-parser
-
-# https://github.com/KatanaGraph/homebrew-dependencies
-#brew tap KatanaGraph/dependencies
-brew uninstall apache-arrow || true
 
 pip3 install PyGithub packaging


### PR DESCRIPTION
With: https://github.com/KatanaGraph/katana-enterprise/pull/1496

Adds some nasty hacks for Ubuntu 16.04.