### PR TITLE
Add a count type to OpaqueID

### DIFF
--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -7,6 +7,19 @@
 
 namespace katana {
 
+// The count_traits are here to support the Count type within OpaqueIDs
+// Default count type is size_t
+template <class T, class = void>
+struct count_traits {
+  using Count = size_t;
+};
+
+// If value type is integral, use the unsigned version of it for Count
+template <class T>
+struct count_traits<T, typename std::enable_if_t<std::is_integral_v<T>>> {
+  using Count = std::make_unsigned_t<T>;
+};
+
 /// Base class for opaque ID types.
 ///
 /// Opaque ID types are:
@@ -45,6 +58,8 @@ struct OpaqueID {
   // TODO(amp): We need some check that _IDType is a subtype of
   //  OpaqueID<_IDType, _Value>. There doesn't seem to be any way to do that.
   using ValueType = _Value;
+
+  using Count = typename count_traits<_Value>::Count;
 
 protected:
   ValueType value_;


### PR DESCRIPTION
I add a Count type to Opaque types that is the unsigned version of the value type if the value type is integral, and `size_t `otherwise.  Yes, I can cross off baby steps toward template metaprogramming from my bucket list.  

@arthurp, I tried to use `std::conditional`, but I could not get it to work.  My attempt looked like this and it failed when _Value was a non-integral type.
```
using Count = std::conditional<
   std::is_integral_v<_Value>,
   typename std::enable_if<
      std::is_integral_v<_Value>, std::make_unsigned_t<_Value>>,
   size_t>;

```