### PR TITLE
KATANA_LOG_DEBUG_ASSERT -> KATANA_LOG_DEBUG_VASSERT

### DIFF
--- a/libgalois/include/katana/ArrowRandomAccessBuilder.h
+++ b/libgalois/include/katana/ArrowRandomAccessBuilder.h
@@ -24,7 +24,8 @@ public:
   }
 
   reference operator[](size_t index) {
-    KATANA_LOG_DEBUG_ASSERT(index < size());
+    KATANA_LOG_DEBUG_VASSERT(
+        index < size(), "index: {}, size: {}", index, size());
     return static_cast<ValueType*>(data_.data())[index];
   }
 
@@ -70,7 +71,8 @@ public:
   // 1) builder[index] = value; where it creates a non-null entry
   // 2) value = builder[index]; ONLY IF option 1 has already used that index
   reference operator[](size_t index) {
-    KATANA_LOG_DEBUG_ASSERT(index < size());
+    KATANA_LOG_DEBUG_VASSERT(
+        index < size(), "index: {}, size: {}", index, size());
     valid_[index] = true;
     return reinterpret_cast<ValueType*>(data_.data())[index];
   }


### PR DESCRIPTION
A few ASSERTS in the random access arrow builder would be more
informative for debugging if they were VASSERTS.

I made this change for my own debugging and thought I would share the love.