### PR TITLE
python: Fix warnings in generated cython code.

### DIFF
--- a/python/katana/datastructures.pyx.jinja
+++ b/python/katana/datastructures.pyx.jinja
@@ -37,6 +37,8 @@ __all__ = ["InsertBag", "NUMAArray", "AllocationPolicy"]
 {% macro wrap_insert_bag(inst) %}
 {% set underlying_type %}datastructures.InsertBag[{{inst.element_c_type}}]{% endset -%}
 {% set class_name %}InsertBag_{{inst.element_c_type}}{% endset -%}
+
+
 @cython.freelist(2)
 cdef class {{class_name}}_Iterator:
     def __next__(self):
@@ -50,6 +52,7 @@ cdef class {{class_name}}_Iterator:
         {% else %}
         return v
         {% endif %}
+
 
 cdef class {{class_name}}:
     """
@@ -138,6 +141,8 @@ class AllocationPolicy(Enum):
 # inst.element_c_type, inst.element_py_type, inst.element_format_code
 {% set underlying_type %}datastructures.NUMAArray[{{inst.element_c_type}}]{% endset -%}
 {% set class_name %}NUMAArray_{{inst.element_c_type}}{% endset -%}
+
+
 @cython.freelist(2)
 cdef class {{class_name}}_Iterator:
     def __next__(self):
@@ -151,6 +156,7 @@ cdef class {{class_name}}_Iterator:
         {% else %}
         return v
         {% endif %}
+
 
 cdef class {{class_name}}:
     """
@@ -195,7 +201,7 @@ cdef class {{class_name}}:
 
         Set an element of the array. This may be called from numba code and is not bounds check in that context.
         """
-        if i < 0 or i >= self.underlying.size():
+        if i >= self.underlying.size():
             raise IndexError(i)
 {%- if inst.by_pointer %}
         arr = argument_to_ndarray_dtype(v, self.dtype)
@@ -210,7 +216,7 @@ cdef class {{class_name}}:
 
         Get an element of the array. This may be called from numba code and is not bounds check in that context.
         """
-        if i < 0 or i >= self.underlying.size():
+        if i >= self.underlying.size():
             raise IndexError(i)
         v = {% if inst.by_pointer %}&{% else %}<{{inst.element_c_type}}>{% endif %}self.underlying[i]
         {% if inst.by_pointer %}


### PR DESCRIPTION
There are still -Wmaybe-uninitialized warnings, but those are
benign and hard to avoid. They are caused because in the exception
case some functions return an uninitialized structure. However
these functions are annotated with except * so the caller always
checks for exeptions, so it will never use the return value if
an exception was thrown.

We could disable -Wmaybe-uninitialized entirely, but it is possible
to write incorrect code in Cython that has initialization issues.
So having this warning can be useful.