### PR TITLE
Pin sphinx to < 4

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -50,6 +50,6 @@ dependencies:
  - python=3.8.* *_cpython
  - setuptools
  - shellcheck
- - sphinx>=3.5.1
+ - sphinx>=3.5.1,<4
  - sphinx-tabs>=2.1.0
  - zlib>=1.2.11

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - pydata-sphinx-theme>=0.6.3
     - pygithub
     - python {{ python }}
-    - sphinx>=3.5.1
+    - sphinx>=3.5.1,<4
     - sphinx-tabs>=2.1.0
   host:
     - jinja2
@@ -109,7 +109,7 @@ outputs:
         - breathe>=4.30
         - doxygen
         - pydata-sphinx-theme>=0.6.3
-        - sphinx>=3.5.1
+        - sphinx>=3.5.1,<4
         - sphinx-tabs>=2.1.0
       host:
         - {{ pin_subpackage('katana-cpp', exact=True) }}


### PR DESCRIPTION
4.1.0 fails for unknown reasons. We should upgrade eventually.