### PR TITLE
Use uint64_t for num_(nodes|edges)

### DIFF
--- a/libgalois/include/katana/LC_CSR_Graph.h
+++ b/libgalois/include/katana/LC_CSR_Graph.h
@@ -300,8 +300,8 @@ public:
 
   GraphNode getEdgeDst(edge_iterator ni) const { return edgeDst[*ni]; }
 
-  size_t size() const { return numNodes; }
-  size_t sizeEdges() const { return numEdges; }
+  uint64_t size() const { return numNodes; }
+  uint64_t sizeEdges() const { return numEdges; }
 
   uint64_t num_nodes() const { return numNodes; }
   uint64_t num_edges() const { return numEdges; }
@@ -414,7 +414,7 @@ public:
    */
   void sortAllEdgesByDst(MethodFlag mflag = MethodFlag::WRITE) {
     katana::do_all(
-        katana::iterate(size_t{0}, this->size()),
+        katana::iterate(uint64_t{0}, this->size()),
         [=](GraphNode N) { this->sortEdgesByDst(N, mflag); },
         katana::no_stats(), katana::steal());
   }


### PR DESCRIPTION
The actual counts being returned were already stored as `uint64_t`, but were being implicitly cast to `size_t`. On a machine where `size_t == uint64_t` that isn't an issue, but being explicit is probably better. Long term, making sure we use opaque IDs for things like this would be even better.