### PR TITLE
ArrayFromScalars accepts nullptr scalars

### DIFF
--- a/libsupport/include/katana/ArrowVisitor.h
+++ b/libsupport/include/katana/ArrowVisitor.h
@@ -332,6 +332,7 @@ private:
 ////////////////////////////////////////////
 // Visitor-based utility
 /// Take a vector of scalars of type data_type and return an Array
+/// scalars vector can contain nullptr entries
 KATANA_EXPORT Result<std::shared_ptr<arrow::Array>> ArrayFromScalars(
     const std::vector<std::shared_ptr<arrow::Scalar>>& scalars,
     const std::shared_ptr<arrow::DataType>& type);

--- a/libsupport/src/ArrowVisitor.cpp
+++ b/libsupport/src/ArrowVisitor.cpp
@@ -30,7 +30,7 @@ struct ToArrayVisitor {
 
     KATANA_CHECKED(builder->Reserve(scalars.size()));
     for (const auto& scalar : scalars) {
-      if (scalar->is_valid) {
+      if (scalar != nullptr && scalar->is_valid) {
         const ScalarType* typed_scalar = static_cast<ScalarType*>(scalar.get());
         builder->UnsafeAppend(typed_scalar->value);
       } else {
@@ -46,7 +46,7 @@ struct ToArrayVisitor {
     using ScalarType = typename arrow::TypeTraits<ArrowType>::ScalarType;
     // same as above, but with string_view and Append instead of UnsafeAppend
     for (const auto& scalar : scalars) {
-      if (scalar->is_valid) {
+      if (scalar != nullptr && scalar->is_valid) {
         // ->value->ToString() works, scalar->ToString() yields "..."
         const ScalarType* typed_scalar = static_cast<ScalarType*>(scalar.get());
         if (auto res = builder->Append(
@@ -77,7 +77,7 @@ struct ToArrayVisitor {
     // use a visitor to traverse more complex types
     katana::AppendScalarToBuilder visitor(builder);
     for (const auto& scalar : scalars) {
-      if (scalar->is_valid) {
+      if (scalar != nullptr && scalar->is_valid) {
         const ScalarType* typed_scalar = static_cast<ScalarType*>(scalar.get());
         KATANA_CHECKED(visitor.Call<ArrowType>(*typed_scalar));
       } else {


### PR DESCRIPTION
Before #1521

ArrayFromScalars is an important function both for GraphUpdate and for the partitioner.  This change to allow nullptrs in the input array allows me a simple optimization.  I think this PR is pretty simple and it is needed by #1521.

Daniel, I want to parallelize the main loop in this function, but we can't because the threading library is in libgalois and this loop is in libsupport.  We will probably migrate threading to libsupport (Amber was on board for doing it).