### PR TITLE
[KAT-1006, KAT-1007] logging: add first iteration of tracer logic

### DIFF
--- a/libgalois/src/SharedMemSys.cpp
+++ b/libgalois/src/SharedMemSys.cpp
@@ -20,6 +20,7 @@
 #include "katana/SharedMemSys.h"
 
 #include "katana/CommBackend.h"
+#include "katana/JSONTracer.h"
 #include "katana/Logging.h"
 #include "katana/Plugin.h"
 #include "katana/SharedMem.h"
@@ -43,6 +44,7 @@ katana::SharedMemSys::SharedMemSys() : impl_(std::make_unique<Impl>()) {
   if (auto init_good = tsuba::Init(&comm_backend); !init_good) {
     KATANA_LOG_FATAL("tsuba::Init: {}", init_good.error());
   }
+  katana::ProgressTracer::SetProgressTracer(katana::JSONTracer::Make());
 
   katana::internal::setSysStatManager(&impl_->stat_manager);
 }
@@ -54,6 +56,7 @@ katana::SharedMemSys::~SharedMemSys() {
   if (auto fini_good = tsuba::Fini(); !fini_good) {
     KATANA_LOG_ERROR("tsuba::Fini: {}", fini_good.error());
   }
+  katana::ProgressTracer::GetProgressTracer().Close();
   // This will finalize plugins irreversibly, reinitialization may not work.
   FinalizePlugins();
 }

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -15,10 +15,12 @@ set(sources
         src/HostAllocator.cpp
         src/HTTP.cpp
         src/JSON.cpp
+        src/JSONTracer.cpp
         src/Logging.cpp
         src/Random.cpp
         src/Result.cpp
         src/Plugin.cpp
+        src/ProgressTracer.cpp
         src/Signals.cpp
         src/Strings.cpp
         src/URI.cpp

--- a/libsupport/include/katana/JSONTracer.h
+++ b/libsupport/include/katana/JSONTracer.h
@@ -20,12 +20,11 @@ public:
   static std::unique_ptr<JSONTracer> Make(
       uint32_t host_id = 0, uint32_t num_hosts = 1);
 
-  std::shared_ptr<ProgressSpan> StartSpan(
+  std::unique_ptr<ProgressSpan> StartSpan(
       const std::string& span_name, bool ignore_active_span) override;
-  std::shared_ptr<ProgressSpan> StartSpan(
-      const std::string& span_name,
-      const std::shared_ptr<ProgressSpan>& child_of) override;
-  std::shared_ptr<ProgressSpan> StartSpan(
+  std::unique_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name, ProgressSpan& child_of) override;
+  std::unique_ptr<ProgressSpan> StartSpan(
       const std::string& span_name, const ProgressContext& child_of) override;
 
   std::string Inject(const ProgressContext& ctx) override;
@@ -54,15 +53,16 @@ private:
 class KATANA_EXPORT JSONSpan : public ProgressSpan {
   friend JSONTracer;
 
-  JSONSpan(const std::string& span_name, std::shared_ptr<ProgressSpan> parent);
+  JSONSpan(const std::string& span_name, ProgressSpan* parent);
   JSONSpan(const std::string& span_name, const ProgressContext& parent);
-  static std::shared_ptr<ProgressSpan> Make(
-      const std::string& span_name,
-      const std::shared_ptr<ProgressSpan>& parent);
-  static std::shared_ptr<ProgressSpan> Make(
+  static std::unique_ptr<ProgressSpan> Make(
+      const std::string& span_name, ProgressSpan* parent);
+  static std::unique_ptr<ProgressSpan> Make(
       const std::string& span_name, const ProgressContext& parent);
 
 public:
+  ~JSONSpan() override { Finish(); }
+
   void Close() override;
 
   void SetTags(const Tags& tags) override;

--- a/libsupport/include/katana/JSONTracer.h
+++ b/libsupport/include/katana/JSONTracer.h
@@ -1,0 +1,82 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_JSONTRACER_H_
+#define KATANA_LIBSUPPORT_KATANA_JSONTRACER_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "katana/ProgressTracer.h"
+#include "katana/config.h"
+
+namespace katana {
+
+class KATANA_EXPORT JSONTracer : public ProgressTracer {
+  JSONTracer(uint32_t host_id = 0, uint32_t num_hosts = 1)
+      : ProgressTracer(host_id, num_hosts) {}
+
+public:
+  static std::unique_ptr<JSONTracer> Make(
+      uint32_t host_id = 0, uint32_t num_hosts = 1);
+
+  std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name, bool ignore_active_span) override;
+  std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name,
+      const std::shared_ptr<ProgressSpan>& child_of) override;
+  std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name, const ProgressContext& child_of) override;
+
+  std::string Inject(const ProgressContext& ctx) override;
+  std::unique_ptr<ProgressContext> Extract(const std::string& carrier) override;
+
+  void Close() override {}
+};
+
+class KATANA_EXPORT JSONContext : public ProgressContext {
+  friend class JSONTracer;
+  friend class JSONSpan;
+
+  JSONContext(const std::string& trace_id, const std::string& span_id)
+      : trace_id_(trace_id), span_id_(span_id) {}
+
+public:
+  std::unique_ptr<ProgressContext> Clone() const noexcept override;
+  std::string GetTraceID() const noexcept override { return trace_id_; }
+  std::string GetSpanID() const noexcept override { return span_id_; }
+
+private:
+  std::string trace_id_;
+  std::string span_id_;
+};
+
+class KATANA_EXPORT JSONSpan : public ProgressSpan {
+  friend JSONTracer;
+
+  JSONSpan(const std::string& span_name, std::shared_ptr<ProgressSpan> parent);
+  JSONSpan(const std::string& span_name, const ProgressContext& parent);
+  static std::shared_ptr<ProgressSpan> Make(
+      const std::string& span_name,
+      const std::shared_ptr<ProgressSpan>& parent);
+  static std::shared_ptr<ProgressSpan> Make(
+      const std::string& span_name, const ProgressContext& parent);
+
+public:
+  void Close() override;
+
+  void SetTags(const Tags& tags) override;
+
+  void Log(const std::string& message, const Tags& tags = {}) override;
+
+  const ProgressContext& GetContext() const noexcept override {
+    return context_;
+  }
+
+private:
+  JSONContext context_;
+};
+
+}  // namespace katana
+
+#endif

--- a/libsupport/include/katana/ProgressTracer.h
+++ b/libsupport/include/katana/ProgressTracer.h
@@ -1,0 +1,233 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_PROGRESSTRACER_H_
+#define KATANA_LIBSUPPORT_KATANA_PROGRESSTRACER_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "katana/Result.h"
+#include "katana/config.h"
+
+/// This tracer does not currently support thread-local tracers or concurrency controls
+/// Functions should only be used in a single-threaded context
+///
+/// Best Practices:
+///   If possible always avoid creating raw ProgressSpans from ProgressTracer
+///   If possible always use ProgressScopes to handle ProgressSpans
+///   Only use 1 ProgressTracer in an execution, so they should be created at entry points
+///   Use ProgressScope's RAII to handle early returns (i.e. due to errors)
+///   Raw ProgressSpans should be used for special scenarios like tracing asynchronous calls
+///
+/// Notes:
+///   SharedMemSys and DistMemSys will initialize the global ProgressTracer to a JsonTracer
+///     later it will be set to a No-op Tracer, on Fini or the destructor they will call
+///     Close on the global ProgressTracer
+///   This prevents GetProgressTracer() from returning nullptr and ensures Tracers are closed
+///
+///   ProgressScope's will only close their ProgressSpan when their ProgressSpan is the active span
+///   This means that if a user exclusively uses ProgressScopes,
+///   Then parent ProgressSpans will not be closed until their child ProgressSpan's close
+///   i.e.
+///   {
+///      auto scope1 = tracer->StartActiveSpan("1");
+///      auto scope2 = tracer->StartActiveSpan("2");
+///      if (err) { return; }
+///      scope2.Close();
+///      auto scope3 = tracer->StartActiveSpan("3");
+///   }
+///   Always results in scope2's ProgressSpan finishing before scope1's
+///   and scope3's ProgressSpan finishing before scope1's if there is no error
+
+namespace katana {
+
+// This is needed to properly handle being passed const char* values
+// Once we submodule OpenTracing this will be removed and their Value class used instead
+// TODO(Patrick)
+using variant_type = std::variant<
+    bool, int, int64_t, uint32_t, uint64_t, float, double, std::string,
+    const char*>;
+class Value : public variant_type {
+public:
+  Value(bool x) noexcept : variant_type(x) {}
+  Value(int x) noexcept : variant_type(static_cast<int64_t>(x)) {}
+  Value(int64_t x) noexcept : variant_type(x) {}
+  Value(uint32_t x) noexcept : variant_type(static_cast<uint64_t>(x)) {}
+  Value(uint64_t x) noexcept : variant_type(x) {}
+  Value(double x) noexcept : variant_type(x) {}
+  Value(std::string x) noexcept : variant_type(x) {}
+  Value(const char* s) noexcept : variant_type(std::string(s)) {}
+};
+using Tags = std::vector<std::pair<std::string, Value>>;
+
+class ProgressScope;
+class ProgressSpan;
+class ProgressContext;
+
+class KATANA_EXPORT ProgressTracer {
+  friend class ProgressSpan;
+
+  void SetSpan(std::shared_ptr<ProgressSpan> span);
+
+protected:
+  ProgressTracer(uint32_t host_id, uint32_t num_hosts)
+      : host_id_(host_id), num_hosts_(num_hosts) {}
+
+public:
+  virtual ~ProgressTracer() = default;
+
+  static ProgressTracer& GetProgressTracer() { return *tracer_; }
+  static void SetProgressTracer(std::unique_ptr<ProgressTracer> tracer);
+
+  // StartActiveSpan creates a new span. If there is not an active span,
+  // create a new top-level span. Otherwise, this function creates a child
+  // span of the active span. By default, the returned scope will finish
+  // the span on close. To change this behavior, set finish_on_close to false.
+  ProgressScope StartActiveSpan(
+      const std::string& span_name, bool finish_on_close = true);
+  ProgressScope StartActiveSpan(
+      const std::string& span_name, const ProgressContext& child_of,
+      bool finish_on_close = true);
+
+  /// Set the current active thread-local span to provided span
+  /// Returns a ProgressScope
+  /// Can specify to not finish the span when the scope goes out of scope
+  /// by RAII by setting finish_on_close=false
+  /// Throws a fatal error if called with a nullptr span
+  ProgressScope SetActiveSpan(
+      std::shared_ptr<ProgressSpan> span, bool finish_on_close = true);
+
+  /// Create a new top level span if ignore_active_span=true and
+  /// no child_of value is given
+  /// Otherwise creates a child span of the child_of span or active span
+  /// Should only be used to handle multiple active spans simultaneously
+  virtual std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name, bool ignore_active_span) = 0;
+  std::shared_ptr<ProgressSpan> StartSpan(const std::string& span_name) {
+    return StartSpan(span_name, false);
+  }
+  virtual std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name,
+      const std::shared_ptr<ProgressSpan>& child_of) = 0;
+  virtual std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name, const ProgressContext& child_of) = 0;
+
+  // For passing spans across process/host boundaries
+  // These functions are needed, but are implemented now for
+  // debugging purposes, they will be replaced
+  // Extract returns a nullptr on failure
+  virtual std::string Inject(const ProgressContext& ctx) = 0;
+  virtual std::unique_ptr<ProgressContext> Extract(
+      const std::string& carrier) = 0;
+
+  /// Get the current scope’s span to add tagging/logging without having
+  /// to pass around scopes/spans as parameters
+  virtual std::shared_ptr<ProgressSpan> GetActiveSpan();
+  uint32_t GetHostID() { return host_id_; }
+  uint32_t GetNumHosts() { return num_hosts_; }
+
+  /// Close is called when a tracer is finished processing spans
+  /// This should be called to ensure any and all buffered spans are
+  /// flushed
+  virtual void Close() = 0;
+
+private:
+  static std::unique_ptr<ProgressTracer> tracer_;
+
+  std::shared_ptr<ProgressSpan> active_span_ = nullptr;
+  uint32_t host_id_;
+  uint32_t num_hosts_;
+};
+
+class KATANA_EXPORT ProgressScope {
+  friend class ProgressTracer;
+
+  ProgressScope(std::shared_ptr<ProgressSpan> span, bool finish_on_close)
+      : span_(span), finish_on_close_(finish_on_close) {}
+
+public:
+  ~ProgressScope();
+  ProgressScope(const ProgressScope&) = delete;
+  ProgressScope(ProgressScope&&) = delete;
+  ProgressScope& operator=(const ProgressScope&) = delete;
+  ProgressScope& operator=(ProgressScope&&) = delete;
+
+  /// Get the scope’s underlying span to add tagging/logging,
+  /// span relationships, and handle multiple active spans at a time
+  ProgressSpan& span() { return *span_; }
+
+  /// Closes the underlying ProgressSpan if the ProgressScope was created
+  /// with the flag finish_on_close=true
+  /// Note that this will only close the underlying ProgressSpan when all
+  /// of its active children ProgressSpans have been finished
+  /// This will be called by RAII if it has not already been called
+  void Close();
+
+private:
+  std::shared_ptr<ProgressSpan> span_;
+  bool finish_on_close_ = false;
+};
+
+class KATANA_EXPORT ProgressContext {
+public:
+  virtual ~ProgressContext() = default;
+  virtual std::unique_ptr<ProgressContext> Clone() const noexcept = 0;
+  virtual std::string GetTraceID() const noexcept;
+  virtual std::string GetSpanID() const noexcept;
+};
+
+class KATANA_EXPORT ProgressSpan {
+  friend class ProgressTracer;
+  friend class ProgressScope;
+
+  void SetActive();
+  void MarkScopeClosed();
+  virtual void Close() = 0;
+
+protected:
+  ProgressSpan(std::shared_ptr<ProgressSpan> parent) : parent_(parent) {}
+
+public:
+  virtual ~ProgressSpan() = default;
+
+  /// Adds a tag to the span.
+  virtual void SetTags(const Tags& tags) = 0;
+  void SetError() { SetTags({{"error", true}}); }
+
+  /// Output logging as well as standard metrics and extra stats
+  /// Current standard metrics: max_mem, mem, host, and timestamp.
+  virtual void Log(const std::string& message, const Tags& tags) = 0;
+  void Log(const std::string& message) { Log(message, {}); }
+  void LogError(const std::string& message) {
+    Log(message, {{"event", "error"}});
+  }
+  void LogError(const std::string& message, const ErrorInfo& error);
+
+  /// Get span's context for propagating across process boundaries
+  virtual const ProgressContext& GetContext() const noexcept = 0;
+
+  virtual bool ScopeClosed();
+
+  /// Every ProgressSpan started must be finished
+  ///
+  /// If the ProgressScope for this ProgressSpan was created with
+  /// finish_on_close=true then this will be called via the
+  /// ProgressScope’s RAII if Close() has not already been called
+  ///
+  /// If there is an unclosed ProgressSpan at the end of
+  /// execution then a warning will be given
+  /// Note that this immediately finishes the span regardless of it
+  /// having unfinished children ProgressSpans
+  void Finish();
+
+private:
+  std::shared_ptr<ProgressSpan> parent_ = nullptr;
+  bool is_active_span_ = false;
+  bool finished_ = false;
+  bool scope_closed_ = false;
+};
+
+}  // namespace katana
+
+#endif

--- a/libsupport/src/JSONTracer.cpp
+++ b/libsupport/src/JSONTracer.cpp
@@ -1,0 +1,398 @@
+#include "katana/JSONTracer.h"
+
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <regex>
+
+#include <arrow/memory_pool.h>
+
+#include "katana/Time.h"
+
+#if __linux__
+#include <sys/sysinfo.h>
+#endif
+
+namespace {
+
+const std::regex kRssRegex("^Rss\\w+:\\s+([0-9]+) kB");
+
+struct HostStats {
+  long nprocs{};
+  long ram_gb{};
+  std::string hostname;
+};
+
+#if __linux__
+
+uint64_t
+ParseProcSelfRssBytes() {
+  std::ifstream proc_self("/proc/self/status");
+
+  // there are 3 relevant vals: RssAnon, RssFile, RssShmem
+  uint32_t rss_vals = 3;
+  uint64_t total_mem = 0;
+  std::string line;
+  while (std::getline(proc_self, line) && rss_vals > 0) {
+    std::smatch sub_match;
+    if (!std::regex_match(line, sub_match, kRssRegex)) {
+      continue;
+    }
+    std::string val = sub_match[1];
+    total_mem += std::strtol(val.c_str(), nullptr, 0);
+    rss_vals -= 1;
+  }
+  if (rss_vals != 0) {
+    KATANA_LOG_ERROR("parsing /proc/self/status for memory failed");
+  }
+  return total_mem * 1024;
+}
+
+HostStats
+GetHostStats() {
+  HostStats stats;
+
+  struct sysinfo info;
+  sysinfo(&info);
+
+  char hostname[256];
+  gethostname(hostname, 256);
+
+  stats.ram_gb = info.totalram / 1024 / 1024 / 1024;
+  stats.nprocs = get_nprocs();
+  stats.hostname = hostname;
+
+  return stats;
+}
+
+#else
+
+uint64_t
+ParseProcSelfRssBytes() {
+  KATANA_WARN_ONCE(
+      "calculating resident set size is not implemented for this platform");
+  return 0;
+}
+
+HostStats
+GetHostStats() {
+  KATANA_WARN_ONCE("getting host stats is not implemented for this platform");
+  HostStats stats;
+  return stats;
+}
+
+#endif
+
+// TODO (Patrick)
+// This function is included for debugging purposes while
+// the tracing infrastructure is added and tested
+uint32_t id = 0;
+std::string
+GenerateID(uint32_t host_id) {
+  id++;
+  return std::to_string(host_id * 1000 + id);
+}
+
+std::string
+GetValue(const katana::Value& value) {
+  if (std::holds_alternative<std::string>(value)) {
+    return "\"" + std::get<std::string>(value) + "\"";
+  } else if (std::holds_alternative<int64_t>(value)) {
+    return std::to_string(std::get<int64_t>(value));
+  } else if (std::holds_alternative<double>(value)) {
+    return std::to_string(std::get<double>(value));
+  } else if (std::holds_alternative<bool>(value)) {
+    return std::get<bool>(value) ? "true" : "false";
+  } else if (std::holds_alternative<uint64_t>(value)) {
+    return std::to_string(std::get<uint64_t>(value));
+  }
+  return std::string{};
+}
+
+std::string
+GetSpanJSON(
+    const std::string& span_id, const std::string& span_name = std::string(),
+    const std::string& parent_span_id = std::string()) {
+  fmt::memory_buffer buf;
+  if (span_name.empty() && parent_span_id.empty()) {
+    fmt::format_to(
+        std::back_inserter(buf), "\"span_data\":{{\"span_id\":\"{}\"}}",
+        span_id);
+  } else {
+    fmt::format_to(
+        std::back_inserter(buf),
+        "\"span_data\":{{\"span_id\":\"{}\",\"span_name\":\"{}\",\"parent_id\":"
+        "\"{}\"}}",
+        span_id, span_name, parent_span_id);
+  }
+  return fmt::to_string(buf);
+}
+
+std::string
+GetSpanJSON(const std::string& span_id, bool finish) {
+  fmt::memory_buffer buf;
+  if (finish) {
+    fmt::format_to(
+        std::back_inserter(buf),
+        "\"span_data\":{{\"span_id\":\"{}\",\"finished\":true}}", span_id);
+  } else {
+    fmt::format_to(
+        std::back_inserter(buf), "\"span_data\":{{\"span_id\":\"{}\"}}",
+        span_id);
+  }
+  return fmt::to_string(buf);
+}
+
+std::string
+GetHostStatsJSON() {
+  fmt::memory_buffer buf;
+  HostStats host_stats = GetHostStats();
+  auto& tracer = katana::ProgressTracer::GetProgressTracer();
+
+  fmt::format_to(
+      std::back_inserter(buf),
+      "\"host_data\":{{\"hosts\":{},\"hostname\":\"{}\",\"hardware_threads\":{}"
+      ",\"ram_gb\":"
+      "{}}}",
+      tracer.GetNumHosts(), host_stats.hostname, host_stats.nprocs,
+      host_stats.ram_gb);
+
+  return fmt::to_string(buf);
+}
+
+std::string
+GetTagsJSON(const katana::Tags& tags) {
+  if (tags.empty()) {
+    return std::string{};
+  }
+  fmt::memory_buffer buf;
+
+  fmt::format_to(std::back_inserter(buf), "\"tags\":[");
+  for (uint32_t i = 0; i < tags.size(); i++) {
+    const std::pair<std::string, katana::Value>& tag = tags[i];
+
+    if (i != 0) {
+      fmt::format_to(std::back_inserter(buf), ",");
+    }
+    fmt::format_to(
+        std::back_inserter(buf), "{{\"name\":\"{}\",\"value\":{}}}", tag.first,
+        GetValue(tag.second));
+  }
+  fmt::format_to(std::back_inserter(buf), "]");
+  return fmt::to_string(buf);
+}
+
+std::string
+GetLogJSON(const std::string& message) {
+  fmt::memory_buffer buf;
+  struct rusage rusage;
+  getrusage(RUSAGE_SELF, &rusage);
+
+  auto usec_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                     katana::Now().time_since_epoch())
+                     .count();
+  fmt::format_to(
+      std::back_inserter(buf),
+      "\"log\":{{\"msg\":\"{}\",\"timestamp_us\":{},\"max_mem_gb\":{:.3f}"
+      ","
+      "\"mem_gb\":{:.3f},\"arrow_mem_gb\":{:.3f}}}",
+      message, usec_ts, rusage.ru_maxrss / 1024.0 / 1024.0,
+      ParseProcSelfRssBytes() / 1024.0 / 1024.0 / 1024.0,
+      arrow::default_memory_pool()->bytes_allocated() / 1024.0 / 1024.0 /
+          1024.0);
+
+  return fmt::to_string(buf);
+}
+
+std::string
+BuildJSON(
+    const std::string& trace_id, const std::string& span_data,
+    const std::string& log_data, const std::string& tag_data,
+    const std::string& host_data) {
+  fmt::memory_buffer buf;
+  uint32_t host_id = katana::ProgressTracer::GetProgressTracer().GetHostID();
+  static auto begin = katana::Now();
+  auto msec_since_begin = katana::UsSince(begin) / 1000;
+
+  fmt::format_to(
+      std::back_inserter(buf),
+      "{{\"trace_id\":\"{}\",\"host\":{},\"offset_ms\":{},{}", trace_id,
+      host_id, msec_since_begin, span_data);
+  if (!log_data.empty()) {
+    fmt::format_to(std::back_inserter(buf), ",{}", log_data);
+  }
+  if (!tag_data.empty()) {
+    fmt::format_to(std::back_inserter(buf), ",{}", tag_data);
+  }
+  if (!host_data.empty()) {
+    fmt::format_to(std::back_inserter(buf), ",{}", host_data);
+  }
+  fmt::format_to(std::back_inserter(buf), "}}\n");
+  return fmt::to_string(buf);
+}
+
+}  // namespace
+
+std::unique_ptr<katana::JSONTracer>
+katana::JSONTracer::Make(uint32_t host_id, uint32_t num_hosts) {
+  JSONTracer tracer{host_id, num_hosts};
+  return std::make_unique<JSONTracer>(std::move(tracer));
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::JSONTracer::StartSpan(
+    const std::string& span_name, bool ignore_active_span) {
+  if (ignore_active_span) {
+    return JSONSpan::Make(span_name, std::shared_ptr<JSONSpan>{nullptr});
+  }
+  return JSONSpan::Make(
+      span_name, ProgressTracer::GetProgressTracer().GetActiveSpan());
+}
+std::shared_ptr<katana::ProgressSpan>
+katana::JSONTracer::StartSpan(
+    const std::string& span_name,
+    const std::shared_ptr<katana::ProgressSpan>& child_of) {
+  return JSONSpan::Make(span_name, child_of);
+}
+std::shared_ptr<katana::ProgressSpan>
+katana::JSONTracer::StartSpan(
+    const std::string& span_name, const katana::ProgressContext& child_of) {
+  return JSONSpan::Make(span_name, child_of);
+}
+
+std::string
+katana::JSONTracer::Inject(const katana::ProgressContext& ctx) {
+  return ctx.GetTraceID() + "," + ctx.GetSpanID();
+}
+
+std::unique_ptr<katana::ProgressContext>
+katana::JSONTracer::Extract(const std::string& carrier) {
+  size_t split = carrier.find(",");
+  if (split == std::string::npos) {
+    return nullptr;
+  } else {
+    std::string trace_id = carrier.substr(0, split);
+    std::string span_id = carrier.substr(split + 1);
+    JSONContext context{trace_id, span_id};
+    return std::make_unique<JSONContext>(std::move(context));
+  }
+}
+
+std::unique_ptr<katana::ProgressContext>
+katana::JSONContext::Clone() const noexcept {
+  JSONContext ctx{trace_id_, span_id_};
+  return std::make_unique<JSONContext>(std::move(ctx));
+}
+
+katana::JSONSpan::JSONSpan(
+    const std::string& span_name, std::shared_ptr<katana::ProgressSpan> parent)
+    : ProgressSpan(parent), context_(JSONContext{"", ""}) {
+  auto& tracer = ProgressTracer::GetProgressTracer();
+
+  std::string parent_span_id{"null"};
+  std::string trace_id;
+  std::string host_data;
+  if (parent != nullptr) {
+    auto parent_span = std::static_pointer_cast<JSONSpan>(parent);
+    parent_span_id = parent_span->GetContext().GetSpanID();
+    trace_id = parent_span->GetContext().GetTraceID();
+  } else {
+    trace_id = GenerateID(tracer.GetHostID());
+    host_data = GetHostStatsJSON();
+  }
+  std::string span_id = GenerateID(tracer.GetHostID());
+  context_ = JSONContext(trace_id, span_id);
+
+  std::string message{"start"};
+
+  std::string span_data = GetSpanJSON(span_id, span_name, parent_span_id);
+  std::string log_data = GetLogJSON(message);
+  std::string tag_data;
+
+  std::string output_json =
+      BuildJSON(trace_id, span_data, log_data, tag_data, host_data);
+
+  std::cerr << output_json;
+}
+
+katana::JSONSpan::JSONSpan(
+    const std::string& span_name, const katana::ProgressContext& parent)
+    : ProgressSpan(nullptr), context_(JSONContext{"", ""}) {
+  auto& tracer = ProgressTracer::GetProgressTracer();
+
+  std::string parent_span_id = parent.GetSpanID();
+  std::string trace_id = parent.GetTraceID();
+  std::string span_id = GenerateID(tracer.GetHostID());
+  context_ = JSONContext(trace_id, span_id);
+
+  std::string message{"start"};
+
+  std::string host_data = GetHostStatsJSON();
+  std::string span_data = GetSpanJSON(span_id, span_name, parent_span_id);
+  std::string log_data = GetLogJSON(message);
+  std::string tag_data;
+
+  std::string output_json =
+      BuildJSON(trace_id, span_data, log_data, tag_data, host_data);
+
+  std::cerr << output_json;
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::JSONSpan::Make(
+    const std::string& span_name,
+    const std::shared_ptr<katana::ProgressSpan>& parent) {
+  JSONSpan span{span_name, parent};
+  return std::make_shared<JSONSpan>(std::move(span));
+}
+std::shared_ptr<katana::ProgressSpan>
+katana::JSONSpan::Make(
+    const std::string& span_name, const katana::ProgressContext& parent) {
+  JSONSpan span{span_name, parent};
+  return std::make_shared<JSONSpan>(std::move(span));
+}
+
+void
+katana::JSONSpan::Close() {
+  std::string message{"finished"};
+
+  std::string span_data = GetSpanJSON(GetContext().GetSpanID(), true);
+  std::string log_data = GetLogJSON(message);
+  std::string tag_data;
+  std::string host_data;
+
+  std::string output_json = BuildJSON(
+      GetContext().GetTraceID(), span_data, log_data, tag_data, host_data);
+
+  std::cerr << output_json;
+}
+
+void
+katana::JSONSpan::SetTags(const katana::Tags& tags) {
+  std::string span_data = GetSpanJSON(GetContext().GetSpanID());
+  std::string log_data;
+  std::string tag_data = GetTagsJSON(tags);
+  std::string host_data;
+
+  std::string output_json = BuildJSON(
+      GetContext().GetTraceID(), span_data, log_data, tag_data, host_data);
+
+  std::cerr << output_json;
+}
+
+void
+katana::JSONSpan::Log(const std::string& message, const katana::Tags& tags) {
+  std::string span_data = GetSpanJSON(GetContext().GetSpanID());
+  std::string log_data = GetLogJSON(message);
+  std::string tag_data = GetTagsJSON(tags);
+  std::string host_data;
+
+  std::string output_json = BuildJSON(
+      GetContext().GetTraceID(), span_data, log_data, tag_data, host_data);
+
+  std::cerr << output_json;
+}

--- a/libsupport/src/ProgressTracer.cpp
+++ b/libsupport/src/ProgressTracer.cpp
@@ -1,0 +1,116 @@
+#include "katana/ProgressTracer.h"
+
+#include "katana/Logging.h"
+
+std::unique_ptr<katana::ProgressTracer> katana::ProgressTracer::tracer_ =
+    nullptr;
+
+void
+katana::ProgressTracer::SetProgressTracer(
+    std::unique_ptr<katana::ProgressTracer> tracer) {
+  ProgressTracer::tracer_ = std::move(tracer);
+}
+
+void
+katana::ProgressTracer::SetSpan(std::shared_ptr<katana::ProgressSpan> span) {
+  if (span != nullptr) {
+    span->SetActive();
+  }
+  active_span_ = span;
+  if (active_span_ != nullptr && active_span_->ScopeClosed()) {
+    active_span_->Finish();
+  }
+}
+
+katana::ProgressScope
+katana::ProgressTracer::StartActiveSpan(
+    const std::string& span_name, bool finish_on_close) {
+  return SetActiveSpan(StartSpan(span_name), finish_on_close);
+}
+katana::ProgressScope
+katana::ProgressTracer::StartActiveSpan(
+    const std::string& span_name, const katana::ProgressContext& child_of,
+    bool finish_on_close) {
+  return SetActiveSpan(StartSpan(span_name, child_of), finish_on_close);
+}
+
+katana::ProgressScope
+katana::ProgressTracer::SetActiveSpan(
+    std::shared_ptr<katana::ProgressSpan> span, bool finish_on_close) {
+  if (span == nullptr) {
+    KATANA_LOG_FATAL("nullptr span given to Tracer's SetActiveSpan");
+  }
+  span->SetActive();
+  active_span_ = span;
+  return ProgressScope(span, finish_on_close);
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::ProgressTracer::GetActiveSpan() {
+  return active_span_;
+}
+
+katana::ProgressScope::~ProgressScope() {
+  if (span_ != nullptr && finish_on_close_) {
+    Close();
+  }
+}
+
+void
+katana::ProgressScope::Close() {
+  if (finish_on_close_) {
+    span_->MarkScopeClosed();
+  }
+}
+
+std::string
+katana::ProgressContext::GetTraceID() const noexcept {
+  return std::string{};
+}
+
+std::string
+katana::ProgressContext::GetSpanID() const noexcept {
+  return std::string{};
+}
+
+void
+katana::ProgressSpan::MarkScopeClosed() {
+  scope_closed_ = true;
+  if (is_active_span_) {
+    Finish();
+  }
+}
+
+void
+katana::ProgressSpan::SetActive() {
+  std::shared_ptr<ProgressSpan> active =
+      ProgressTracer::GetProgressTracer().GetActiveSpan();
+  if (active != nullptr) {
+    active->is_active_span_ = false;
+  }
+  is_active_span_ = true;
+}
+
+void
+katana::ProgressSpan::LogError(
+    const std::string& message, const katana::ErrorInfo& error) {
+  Log(message, {{"event", "error"},
+                {"error.kind", error.error_code().message()},
+                {"error.context", fmt::format("{}", error)}});
+}
+
+bool
+katana::ProgressSpan::ScopeClosed() {
+  return scope_closed_;
+}
+
+void
+katana::ProgressSpan::Finish() {
+  if (!finished_) {
+    finished_ = true;
+    Close();
+    if (is_active_span_) {
+      ProgressTracer::GetProgressTracer().SetSpan(parent_);
+    }
+  }
+}

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -16,6 +16,7 @@ function(add_unit_test name)
     )
 endfunction()
 
+add_unit_test(tracing)
 add_unit_test(bitmath)
 add_unit_test(env)
 add_unit_test(logging)

--- a/libsupport/test/tracing.cpp
+++ b/libsupport/test/tracing.cpp
@@ -1,0 +1,64 @@
+#include "katana/JSONTracer.h"
+
+katana::Result<void>
+CreateError() {
+  katana::ProgressTracer::GetProgressTracer().StartActiveSpan("getting error");
+  return KATANA_ERROR(
+      katana::ErrorCode::ArrowError, "failed to make fixed size type");
+}
+
+katana::Result<void>
+GetError() {
+  katana::ProgressTracer::GetProgressTracer().StartActiveSpan("passing error");
+  return CreateError().error().WithContext("passed along by GetError");
+}
+
+int
+main() {
+  katana::ProgressTracer::SetProgressTracer(katana::JSONTracer::Make());
+  auto& tracer = katana::ProgressTracer::GetProgressTracer();
+  auto scope = tracer.StartActiveSpan("first span");
+  scope.span().SetTags(
+      {{"life", static_cast<uint32_t>(42)},
+       {"type", "test"},
+       {"real", false},
+       {"somethin", 2.0},
+       {"hello", std::string{"world"}}});
+
+  {
+    auto list_scope = tracer.StartActiveSpan("reading query list");
+    list_scope.span().Log("query parsed", {{"query", "CREATE"}, {"ops", 4}});
+
+    for (auto i = 0; i < 2; i++) {
+      auto query_scope = tracer.StartActiveSpan("running query");
+      auto writing_scope = tracer.StartActiveSpan("writing query results");
+      writing_scope.span().LogError("error writing", GetError().error());
+      writing_scope.span().SetError();
+    }
+    auto span = tracer.StartSpan("is not initially active");
+    auto span_scope = tracer.SetActiveSpan(span);
+    auto no_raii_scope = tracer.StartActiveSpan("no raii", false);
+  }
+  tracer.GetActiveSpan()->Log("no raii is the active span");
+  tracer.GetActiveSpan()->Finish();
+
+  scope.Close();
+  auto scope2 = tracer.StartActiveSpan("first span of second trace", false);
+  std::string carrier = tracer.Inject(scope2.span().GetContext());
+  std::unique_ptr<katana::ProgressContext> ctx = tracer.Extract(carrier);
+  scope2.span().Log(
+      "testing contexts",
+      {{"trace_id", ctx->GetTraceID()}, {"span_id", ctx->GetSpanID()}});
+  scope2.Close();  // this does nothing since open_on_close was set to false
+
+  auto root_span = tracer.StartSpan("root span of new trace", true);
+  auto scope3 = tracer.SetActiveSpan(root_span);
+  tracer.GetActiveSpan()->Log("the new root span of trace 3 is active");
+
+  auto scope2_child =
+      tracer.StartActiveSpan("child of trace 2's root by context", *ctx);
+  tracer.GetActiveSpan()->Log("child span of trace 2 is active");
+  scope2_child.Close();
+  root_span->Finish();
+  scope2.span().Finish();
+}

--- a/scripts/assemble_trace.py
+++ b/scripts/assemble_trace.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+
+import argparse
+import fileinput
+import json
+
+
+class Reference:
+    def __init__(self, ref_type, trace_id, span_id):
+        self.ref_type = ref_type
+        self.trace_id = trace_id
+        self.span_id = span_id
+
+    def get_json(self):
+        ref = dict()
+        ref["refType"] = self.ref_type
+        ref["traceID"] = self.trace_id
+        ref["spanID"] = self.span_id
+
+        return ref
+
+
+class Tag:
+    def __init__(self, tag, value="", tag_type=""):
+        if isinstance(tag, str):
+            self.key = tag
+            self.tag_type = tag_type
+            self.value = value
+        else:
+            self.key = tag["name"]
+            self.tag_type = "string"
+            self.value = tag["value"]
+            if isinstance(self.value, bool):
+                self.tag_type = "bool"
+            elif isinstance(self.value, int):
+                self.tag_type = "int64"
+            elif isinstance(self.value, float):
+                self.tag_type = "float64"
+
+    def get_json(self):
+        tag = dict()
+        tag["key"] = self.key
+        tag["type"] = self.tag_type
+        tag["value"] = self.value
+
+        return tag
+
+
+class Log:
+    def __init__(self, log, tag_fields):
+        fields = []
+        fields.append(Tag("message", log["msg"], "string"))
+        for field in tag_fields:
+            fields.append(Tag(field))
+        fields.append(Tag("max_mem_gb", log["max_mem_gb"], "float64"))
+        fields.append(Tag("mem_gb", log["mem_gb"], "float64"))
+        fields.append(Tag("arrow_mem_gb", log["arrow_mem_gb"], "float64"))
+
+        self.timestamp = log["timestamp_us"]
+        self.fields = fields
+
+    def correct_timestamp(self, start_timestamp):
+        self.timestamp += start_timestamp
+
+    def get_json(self):
+        log = dict()
+        log["timestamp"] = self.timestamp
+
+        fields = []
+        for field in self.fields:
+            fields.append(field.get_json())
+        log["fields"] = fields
+
+        return log
+
+
+class Span:
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, trace_id, span_id, host_id):
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self.host_id = host_id
+        self.name = ""
+        self.start = -1
+        self.finish = -1
+        self.refs = []
+        self.tags = []
+        self.logs = []
+
+    def update_span_data(self, span_data, timestamp):
+        if "span_name" in span_data:
+            self.name = span_data["span_name"]
+            self.start = timestamp
+            parent = span_data["parent_id"]
+            if parent != "null":
+                self.refs.append(Reference("CHILD_OF", self.trace_id, parent))
+        if "finished" in span_data:
+            self.finish = timestamp
+
+    def add_tags(self, tags):
+        for tag in tags:
+            self.tags.append(Tag(tag))
+
+    def add_log(self, log, tags):
+        self.logs.append(Log(log, tags))
+
+    def correct_timestamps(self, start_timestamp):
+        self.start += start_timestamp
+        self.finish += start_timestamp
+        for log in self.logs:
+            log.correct_timestamp(start_timestamp)
+
+    def get_json(self):
+        span = dict()
+        span["traceID"] = self.trace_id
+        span["spanID"] = self.span_id
+        span["flags"] = 1
+        span["operationName"] = self.name
+
+        refs = []
+        for ref in self.refs:
+            refs.append(ref.get_json())
+        span["references"] = refs
+
+        span["startTime"] = self.start
+        span["duration"] = self.finish - self.start
+
+        tags = []
+        for tag in self.tags:
+            tags.append(tag.get_json())
+        span["tags"] = tags
+
+        logs = []
+        for log in self.logs:
+            logs.append(log.get_json())
+        span["logs"] = logs
+
+        span["processID"] = str(self.host_id)
+        span["warnings"] = None
+
+        return span
+
+
+class Process:
+    def __init__(self, name):
+        self.name = name
+        self.tags = []
+
+    def add_tag(self, tag):
+        self.tags.append(tag)
+
+    def get_json(self):
+        process = dict()
+        process["serviceName"] = "katana"
+
+        tags = []
+        for tag in self.tags:
+            tags.append(tag.get_json())
+        process["tags"] = tags
+
+        return process
+
+
+class Trace:
+    def __init__(self, trace_id):
+        self.trace_id = trace_id
+        self.spans = dict()
+        self.processes = dict()
+
+    def update_trace_data(self, host_id, trace_data):
+        if str(host_id) not in self.processes:
+            process = Process(str(host_id))
+            process.add_tag(Tag("host_id", host_id, "int64"))
+            process.add_tag(Tag("hardware_threads", trace_data["hardware_threads"], "int64"))
+            process.add_tag(Tag("ram_gb", trace_data["ram_gb"], "int64"))
+            process.add_tag(Tag("hostname", trace_data["hostname"], "string"))
+            process.add_tag(Tag("num_hosts", trace_data["hosts"], "int64"))
+            self.processes[str(host_id)] = process
+
+    def get_json(self):
+        trace = dict()
+        trace["traceID"] = self.trace_id
+
+        spans = []
+        for _, span in self.spans.items():
+            spans.append(span.get_json())
+        trace["spans"] = spans
+
+        processes = dict()
+        for process_id, process in self.processes.items():
+            processes[process_id] = process.get_json()
+        trace["processes"] = processes
+
+        trace["warnings"] = None
+
+        return trace
+
+
+def get_traces_json(traces):
+    traces_json = dict()
+
+    trace_jsons = []
+    for _, trace in traces.items():
+        trace_jsons.append(trace.get_json())
+    traces_json["data"] = trace_jsons
+
+    traces_json["total"] = 0
+    traces_json["limit"] = 0
+    traces_json["offset"] = 0
+    traces_json["errors"] = None
+
+    return traces_json
+
+
+def assemble_traces(args):
+    traces = dict()
+
+    stream = len(args.log) == 0
+    for line in fileinput.input(args.log[0] if not stream else ("-",)):
+        try:
+            json_line = json.loads(line.strip())
+            trace_id = json_line["trace_id"]
+            if trace_id not in traces.keys():
+                traces[trace_id] = Trace(trace_id)
+            trace = traces[trace_id]
+
+            if "host_data" in json_line:
+                trace.update_trace_data(json_line["host"], json_line["host_data"])
+
+            span_id = json_line["span_data"]["span_id"]
+            if span_id not in trace.spans.keys():
+                trace.spans[span_id] = Span(trace_id, span_id, json_line["host"])
+            span = trace.spans[span_id]
+
+            if "log" in json_line:
+                span.update_span_data(json_line["span_data"], json_line["log"]["timestamp_us"])
+                tags = []
+                if "tags" in json_line:
+                    tags = json_line["tags"]
+                span.add_log(json_line["log"], tags)
+            elif "tags" in json_line:
+                span.add_tags(json_line["tags"])
+        except ValueError:
+            pass
+    return traces
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log", metavar="FILE", nargs="*", help="Log to read, if none provided reads from stdin")
+    parser.add_argument("--outfile", metavar="FILE", help="File to write assembled trace to")
+    args = parser.parse_args()
+
+    traces = assemble_traces(args)
+    traces_json = get_traces_json(traces)
+
+    with open(args.outfile, "w") as outfile:
+        outfile.write(json.dumps(traces_json, indent=2))


### PR DESCRIPTION
Add tracer logic for Katana and a basic Json tracer for testing
This work is based on RFC-034

This code is still in development and many parts are intentionally left underdeveloped to help testing and debugging the infrastructure.  The next step is to test this on distributed workloads and then add an OpenTracer backend to replace JsonTracer.