### PR TITLE
Property Graph: multiple topologies

### DIFF
--- a/libgalois/include/katana/GraphHelpers.h
+++ b/libgalois/include/katana/GraphHelpers.h
@@ -35,7 +35,7 @@ namespace internal {
 template <typename GraphTy>
 inline GraphTopology::edge_iterator
 edge_begin(GraphTy& graph, uint32_t N) {
-  return graph.topology().edge_begin(N);
+  return graph.topology().edges(N).begin();
 }
 
 /**
@@ -48,7 +48,7 @@ edge_begin(GraphTy& graph, uint32_t N) {
 template <typename GraphTy>
 inline GraphTopology::edge_iterator
 edge_end(GraphTy& graph, uint32_t N) {
-  return graph.topology().edge_end(N);
+  return graph.topology().edges(N).end();
 }
 
 template <typename Ty>

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -13,6 +13,7 @@
 #include "katana/ArrowInterchange.h"
 #include "katana/Details.h"
 #include "katana/ErrorCode.h"
+#include "katana/Iterators.h"
 #include "katana/NUMAArray.h"
 #include "katana/config.h"
 #include "tsuba/RDG.h"
@@ -30,10 +31,8 @@ ProjectAsArrowArray(const T* buf, const size_t len) noexcept {
   return std::make_shared<ArrowArrayType>(len, arrow::Buffer::Wrap(buf, len));
 }
 
-/// A graph topology represents the adjacency information for a graph in CSR
-/// format.
-class KATANA_EXPORT GraphTopology {
-public:
+/// Types used by all topologies
+struct KATANA_EXPORT GraphTopologyTypes {
   using Node = uint32_t;
   using Edge = uint64_t;
   using node_iterator = boost::counting_iterator<Node>;
@@ -41,7 +40,15 @@ public:
   using nodes_range = StandardRange<node_iterator>;
   using edges_range = StandardRange<edge_iterator>;
   using iterator = node_iterator;
+};
 
+class KATANA_EXPORT EdgeShuffleTopology;
+class KATANA_EXPORT EdgeTypeAwareTopology;
+
+/// A graph topology represents the adjacency information for a graph in CSR
+/// format.
+class KATANA_EXPORT GraphTopology : public GraphTopologyTypes {
+public:
   GraphTopology() = default;
   GraphTopology(GraphTopology&&) = default;
   GraphTopology& operator=(GraphTopology&&) = default;
@@ -66,12 +73,10 @@ public:
 
   const Node* dest_data() const noexcept { return dests_.data(); }
 
-  /**
-   * Checks equality against another instance of GraphTopology.
-   * WARNING: Expensive operation due to element-wise checks on large arrays
-   * @param that: GraphTopology instance to compare against
-   * @returns true if topology arrays are equal
-   */
+  /// Checks equality against another instance of GraphTopology.
+  /// WARNING: Expensive operation due to element-wise checks on large arrays
+  /// @param that: GraphTopology instance to compare against
+  /// @returns true if topology arrays are equal
   bool Equals(const GraphTopology& that) const noexcept {
     if (this == &that) {
       return true;
@@ -88,29 +93,16 @@ public:
 
   // Edge accessors
 
-  edge_iterator edge_begin(Node node) const noexcept {
-    return edge_iterator{node > 0 ? adj_indices_[node - 1] : 0};
-  }
-
-  edge_iterator edge_end(Node node) const noexcept {
-    return edge_iterator{adj_indices_[node]};
-  }
-
-  /// Gets the edge range of some node.
-  ///
-  /// \param node an iterator pointing to the node to get the edge range of
-  /// \returns iterable edge range for node.
-  edges_range edges(const node_iterator& node) const noexcept {
-    return edges(*node);
-  }
-  // TODO(amp): [[deprecated("use edges(Node node)")]]
-
   /// Gets the edge range of some node.
   ///
   /// \param node node to get the edge range of
   /// \returns iterable edge range for node.
   edges_range edges(Node node) const noexcept {
-    return MakeStandardRange<edge_iterator>(edge_begin(node), edge_end(node));
+    KATANA_LOG_DEBUG_ASSERT(node <= adj_indices_.size());
+    edge_iterator e_beg{node > 0 ? adj_indices_[node - 1] : 0};
+    edge_iterator e_end{adj_indices_[node]};
+
+    return MakeStandardRange(e_beg, e_end);
   }
 
   Node edge_dest(Edge edge_id) const noexcept {
@@ -118,14 +110,17 @@ public:
     return dests_[edge_id];
   }
 
-  Node edge_dest(const edge_iterator ei) const noexcept {
-    return edge_dest(*ei);
-  }
-
   nodes_range nodes(Node begin, Node end) const noexcept {
     return MakeStandardRange<node_iterator>(begin, end);
   }
 
+  nodes_range all_nodes() const noexcept {
+    return nodes(Node{0}, static_cast<Node>(num_nodes()));
+  }
+
+  edges_range all_edges() const noexcept {
+    return MakeStandardRange<edge_iterator>(Edge{0}, Edge{num_edges()});
+  }
   // Standard container concepts
 
   node_iterator begin() const noexcept { return node_iterator(0); }
@@ -135,6 +130,23 @@ public:
   size_t size() const noexcept { return num_nodes(); }
 
   bool empty() const noexcept { return num_nodes() == 0; }
+
+  ///@param node node to get degree for
+  ///@returns Degree of node N
+  size_t degree(Node node) const noexcept { return edges(node).size(); }
+
+  Edge original_edge_id(const Edge& eid) const noexcept { return eid; }
+
+  Node original_node_id(const Node& nid) const noexcept { return nid; }
+
+private:
+  // need these friend relationships to construct instances of friend classes below
+  // by moving NUMAArrays in this class.
+  friend class EdgeShuffleTopology;
+  friend class EdgeTypeAwareTopology;
+
+  NUMAArray<Edge>& GetAdjIndices() noexcept { return adj_indices_; }
+  NUMAArray<Node>& GetDests() noexcept { return dests_; }
 
 private:
   NUMAArray<Edge> adj_indices_;
@@ -776,12 +788,10 @@ public:
   /// \returns iterable edge range for node.
   edges_range edges(Node node) const { return topology().edges(node); }
 
-  /**
-   * Gets the destination for an edge.
-   *
-   * @param edge edge iterator to get the destination of
-   * @returns node iterator to the edge destination
-   */
+  /// Gets the destination for an edge.
+  ///
+  /// @param edge edge iterator to get the destination of
+  /// @returns node iterator to the edge destination
   node_iterator GetEdgeDest(const edge_iterator& edge) const {
     auto node_id = topology().edge_dest(*edge);
     return node_iterator(node_id);
@@ -807,7 +817,7 @@ KATANA_EXPORT GraphTopology::Edge FindEdgeSortedByDest(
     const PropertyGraph* graph, GraphTopology::Node node,
     GraphTopology::Node node_to_find);
 
-/// Relabel all nodes in the graph by sorting in the descending
+/// Renumber all nodes in the graph by sorting in the descending
 /// order by node degree.
 // TODO(amber): this method should return a new sorted topology
 KATANA_EXPORT Result<void> SortNodesByDegree(PropertyGraph* pg);
@@ -841,6 +851,513 @@ CreateSymmetricGraph(PropertyGraph* pg);
 // TODO(amber): this function should return a new topology
 KATANA_EXPORT Result<std::unique_ptr<PropertyGraph>>
 CreateTransposeGraphTopology(const GraphTopology& topology);
+
+class KATANA_EXPORT EdgeTypeIndex : public GraphTopologyTypes {
+  using EdgeTypeIntern = PropertyGraph::TypeSetID;
+  // map an integer id to each unique edge edge_type in the graph
+  using EdgeTypeIDToIndexMap = std::unordered_map<EdgeTypeIntern, uint32_t>;
+  // each index refers to a unique edge edge_type in the graph
+  using EdgeIndexToTypeIDMap = std::vector<EdgeTypeIntern>;
+
+public:
+  using EdgeTypeID = EdgeTypeIntern;
+  using EdgeTypeIDRange =
+      katana::StandardRange<EdgeIndexToTypeIDMap::const_iterator>;
+
+  EdgeTypeIndex() = default;
+  EdgeTypeIndex(EdgeTypeIndex&&) = default;
+  EdgeTypeIndex& operator=(EdgeTypeIndex&&) = default;
+
+  EdgeTypeIndex(const EdgeTypeIndex&) = delete;
+  EdgeTypeIndex& operator=(const EdgeTypeIndex&) = delete;
+
+  static EdgeTypeIndex Make(const PropertyGraph* pg) noexcept;
+
+  EdgeTypeID GetType(uint32_t index) const noexcept {
+    KATANA_LOG_ASSERT(index < num_unique_edge_types_);
+    KATANA_LOG_ASSERT(size_t(index) < edge_index_to_type_map_.size());
+    return edge_index_to_type_map_[index];
+  }
+
+  uint32_t GetIndex(const EdgeTypeID& edge_type) const noexcept {
+    KATANA_LOG_ASSERT(edge_type_to_index_map_.count(edge_type) > 0);
+    // return edge_type_to_index_map_[edge_type];
+    return edge_type_to_index_map_.find(edge_type)->second;
+  }
+
+  uint32_t num_unique_types() const noexcept { return num_unique_edge_types_; }
+
+  /// @param edge_type: edge_type to check
+  /// @returns true iff there exists some edge in the graph with that edge_type
+  bool has_edge_type_id(const EdgeTypeID& edge_type) const noexcept {
+    return (
+        edge_type_to_index_map_.find(edge_type) !=
+        edge_type_to_index_map_.cend());
+  }
+
+  /// Wrapper to get the distinct edge types in the graph.
+  ///
+  /// @returns Range of the distinct edge types
+  EdgeTypeIDRange distinct_edge_type_ids() const noexcept {
+    return EdgeTypeIDRange{
+        edge_index_to_type_map_.cbegin(), edge_index_to_type_map_.cend()};
+  }
+
+private:
+  EdgeTypeIndex(
+      EdgeTypeIDToIndexMap&& edge_type_to_index,
+      EdgeIndexToTypeIDMap&& edge_index_to_type,
+      uint32_t num_edge_types) noexcept
+      : edge_type_to_index_map_(std::move(edge_type_to_index)),
+        edge_index_to_type_map_(std::move(edge_index_to_type)),
+        num_unique_edge_types_(num_edge_types) {
+    KATANA_LOG_DEBUG_ASSERT(
+        num_edge_types == edge_index_to_type_map_.size() &&
+        num_edge_types == edge_type_to_index_map_.size());
+  }
+
+  EdgeTypeIDToIndexMap edge_type_to_index_map_;
+  EdgeIndexToTypeIDMap edge_index_to_type_map_;
+  uint32_t num_unique_edge_types_ = 0u;
+};
+
+// TODO(amber): make OrigEdgeIDMap optional via template argument
+class KATANA_EXPORT EdgeShuffleTopology : public GraphTopology {
+  using Base = GraphTopology;
+  using OrigEdgeIDMap = katana::NUMAArray<Edge>;
+  using EdgeTypeID = PropertyGraph::TypeSetID;
+
+public:
+  EdgeShuffleTopology() = default;
+  EdgeShuffleTopology(EdgeShuffleTopology&&) = default;
+  EdgeShuffleTopology& operator=(EdgeShuffleTopology&&) = default;
+
+  EdgeShuffleTopology(const EdgeShuffleTopology&) = delete;
+  EdgeShuffleTopology& operator=(const EdgeShuffleTopology&) = delete;
+
+  static EdgeShuffleTopology MakeTransposeCopy(const PropertyGraph* pg);
+  static EdgeShuffleTopology MakeOriginalCopy(const PropertyGraph* pg);
+
+  auto original_edge_id(Edge eid) const noexcept {
+    KATANA_LOG_DEBUG_ASSERT(eid < orig_edge_ids_.size());
+    return orig_edge_ids_[eid];
+  }
+
+  void SortEdgesByTypeThenDest() noexcept;
+
+private:
+  NUMAArray<Edge>& GetOrigEdgeIDs() noexcept { return orig_edge_ids_; }
+
+  // Needed for creating EdgeTypeAwareTopology from EdgeShuffleTopology using
+  // move semantics on member NUMAArrays below
+  friend class EdgeTypeAwareTopology;
+
+  EdgeShuffleTopology(
+      const PropertyGraph* pg, NUMAArray<Edge>&& adj_indices,
+      NUMAArray<Node>&& dests, NUMAArray<Edge>&& orig_edge_ids) noexcept
+      : GraphTopology(std::move(adj_indices), std::move(dests)),
+        prop_graph_(pg),
+        orig_edge_ids_(std::move(orig_edge_ids)) {}
+
+  const PropertyGraph* prop_graph_;
+  OrigEdgeIDMap orig_edge_ids_;
+};
+
+// TODO(amber): make private
+template <typename Topo>
+struct EdgeDestComparator {
+  const Topo* topo_;
+
+  bool operator()(const typename Topo::Edge& e, const typename Topo::Node& n)
+      const noexcept {
+    return topo_->edge_dest(e) < n;
+  }
+
+  bool operator()(const typename Topo::Node& n, const typename Topo::Edge& e)
+      const noexcept {
+    return n < topo_->edge_dest(e);
+  }
+};
+
+/// store adjacency indices per each node such that they are divided by edge edge_type type.
+/// Requires sorting the graph by edge edge_type type
+class KATANA_EXPORT EdgeTypeAwareTopology : public GraphTopologyTypes {
+  // TODO(amber): add a template flag to choose between copying edge types from
+  // PropertyGraph vs accessing the data in PropertyGraph through
+  // orig_edge_ids_
+
+protected:
+  using EdgeTypeID = PropertyGraph::TypeSetID;
+
+public:
+  EdgeTypeAwareTopology() = default;
+  EdgeTypeAwareTopology(EdgeTypeAwareTopology&&) = default;
+  EdgeTypeAwareTopology& operator=(EdgeTypeAwareTopology&&) = default;
+
+  EdgeTypeAwareTopology(const EdgeTypeAwareTopology&) = delete;
+  EdgeTypeAwareTopology& operator=(const EdgeTypeAwareTopology&) = delete;
+
+  static EdgeTypeAwareTopology MakeFromDefaultTopology(
+      const PropertyGraph* pg, const EdgeTypeIndex* edge_type_index);
+  static EdgeTypeAwareTopology MakeFromTransposeTopology(
+      const PropertyGraph* pg, const EdgeTypeIndex* edge_type_index);
+
+  // TODO(amber): logic needs fixing for the case when there are nodes but no edges
+  uint64_t num_nodes() const noexcept {
+    if (adj_indices_.size() == 0) {
+      return 0;
+    }  // corner case: graph with 0 edges
+    return adj_indices_.size() / edge_type_index_->num_unique_types();
+  }
+
+  uint64_t num_edges() const noexcept { return dests_.size(); }
+
+  // Edge accessors
+
+  /// @param N node to get edges for
+  /// @param edge_type edge_type to get edges of
+  /// @returns Range to edges of node N that have edge type == edge_type
+  edges_range edges(Node N, const EdgeTypeID& edge_type) const noexcept {
+    // adj_indices_ is expanded so that it stores P prefix sums per node, where
+    // P == edge_type_index_->num_unique_types()
+    // We pick the prefix sum based on the index of the edge_type provided
+    auto beg_idx = (N * edge_type_index_->num_unique_types()) +
+                   edge_type_index_->GetIndex(edge_type);
+    edge_iterator e_beg{(beg_idx == 0) ? 0 : adj_indices_[beg_idx - 1]};
+
+    auto end_idx = (N * edge_type_index_->num_unique_types()) +
+                   edge_type_index_->GetIndex(edge_type);
+    KATANA_LOG_DEBUG_ASSERT(end_idx < adj_indices_.size());
+    edge_iterator e_end{adj_indices_[end_idx]};
+
+    return katana::MakeStandardRange(e_beg, e_end);
+  }
+
+  /// Gets the edge range of some node.
+  ///
+  /// \param node node to get the edge range of
+  /// \returns iterable edge range for node.
+  edges_range edges(Node N) const noexcept {
+    KATANA_LOG_DEBUG_ASSERT(N < num_nodes());
+
+    auto beg_idx = N * edge_type_index_->num_unique_types();
+    KATANA_LOG_DEBUG_ASSERT(beg_idx <= adj_indices_.size());
+    edge_iterator e_beg{beg_idx > 0 ? adj_indices_[beg_idx - 1] : 0};
+
+    auto end_idx = (N + 1) * edge_type_index_->num_unique_types();
+    KATANA_LOG_DEBUG_ASSERT(end_idx <= adj_indices_.size());
+    // end_idx == 0 means num_unique_types() returns 0, which means either
+    // edge_type_index_ wasn't properly initialized or graph has no edges
+    if (end_idx == 0) {
+      KATANA_LOG_DEBUG_ASSERT(num_edges() == 0);
+    }
+    edge_iterator e_end{end_idx > 0 ? adj_indices_[end_idx - 1] : 0};
+
+    return MakeStandardRange(e_beg, e_end);
+  }
+
+  Node edge_dest(Edge edge_id) const noexcept {
+    KATANA_LOG_DEBUG_ASSERT(edge_id < dests_.size());
+    return dests_[edge_id];
+  }
+
+  /// @param node node to get degree for
+  /// @returns Degree of node N
+  size_t degree(Node node) const noexcept { return edges(node).size(); }
+
+  /// @param N node to get degree for
+  /// @param edge_type edge_type to get degree of
+  /// @returns Degree of node N
+  size_t degree(Node N, const EdgeTypeID& edge_type) const noexcept {
+    return edges(N, edge_type).size();
+  }
+
+  nodes_range nodes(Node begin, Node end) const noexcept {
+    return MakeStandardRange<node_iterator>(begin, end);
+  }
+
+  nodes_range all_nodes() const noexcept {
+    return nodes(Node{0}, static_cast<Node>(num_nodes()));
+  }
+
+  edges_range all_edges() const noexcept {
+    return MakeStandardRange<edge_iterator>(Edge{0}, Edge{num_edges()});
+  }
+  // Standard container concepts
+
+  node_iterator begin() const noexcept { return node_iterator(0); }
+
+  node_iterator end() const noexcept { return node_iterator(num_nodes()); }
+
+  size_t size() const noexcept { return num_nodes(); }
+
+  bool empty() const noexcept { return num_nodes() == 0; }
+
+  Edge original_edge_id(const Edge& e) const noexcept {
+    KATANA_LOG_DEBUG_ASSERT(e < num_edges());
+    return orig_edge_ids_[e];
+  }
+
+  Node original_node_id(const Node& nid) const noexcept { return nid; }
+
+  auto GetDistinctEdgeTypes() const noexcept {
+    return edge_type_index_->distinct_edge_type_ids();
+  }
+
+  bool DoesEdgeTypeExist(const EdgeTypeID& edge_type) const noexcept {
+    return edge_type_index_->has_edge_type_id(edge_type);
+  }
+
+  /// Returns all edges from src to dst with some edge_type.  If not found, returns
+  /// empty range.
+  edges_range FindAllEdgesWithType(
+      Node node, Node key, const EdgeTypeID& edge_type) const noexcept {
+    auto e_range = edges(node, edge_type);
+    if (e_range.empty()) {
+      return e_range;
+    }
+
+    EdgeDestComparator<EdgeTypeAwareTopology> comp{this};
+    auto [first_it, last_it] =
+        std::equal_range(e_range.begin(), e_range.end(), key, comp);
+
+    if (first_it == e_range.end() || edge_dest(*first_it) != key) {
+      // return empty range
+      return MakeStandardRange(e_range.end(), e_range.end());
+    }
+
+    auto ret_range = MakeStandardRange(first_it, last_it);
+    for ([[maybe_unused]] auto e : ret_range) {
+      KATANA_LOG_DEBUG_ASSERT(edge_dest(e) == key);
+    }
+    return ret_range;
+  }
+
+  /// Returns an edge iterator to an edge with some node and key by
+  /// searching for the key via the node's outgoing or incoming edges.
+  /// If not found, returns nothing.
+  // TODO(amber): Assess the usefulness of this method. This method cannot return
+  // edges of all types. Only the first found type. We should however support
+  // find_edges(src, dst) or find_edge(src, dst) that doesn't care about edge type
+  edges_range FindAllEdgesSingleType(Node src, Node dst) const {
+    // trivial check; can't be connected if degree is 0
+
+    auto empty_range = MakeStandardRange<edge_iterator>(Edge{0}, Edge{0});
+    if (degree(src) == 0) {
+      return empty_range;
+    }
+
+    // loop through all type_ids
+    for (const EdgeTypeID& edge_type : GetDistinctEdgeTypes()) {
+      // always use out edges (we want an id to the out edge returned)
+      edges_range r = FindAllEdgesWithType(src, dst, edge_type);
+
+      // return if something was found
+      if (r) {
+        return r;
+      }
+    }
+
+    // not found, return empty optional
+    return empty_range;
+  }
+
+  /// Check if vertex src is connected to vertex dst with the given edge edge_type
+  ///
+  /// @param src source node of the edge
+  /// @param dst destination node of the edge
+  /// @param edge_type edge_type of the edge
+  /// @returns true iff the edge exists
+  bool IsConnectedWithEdgeType(
+      Node src, Node dst, const EdgeTypeID& edge_type) const {
+    auto e_range = edges(src, edge_type);
+    if (e_range.empty()) {
+      return false;
+    }
+
+    EdgeDestComparator<EdgeTypeAwareTopology> comp{this};
+    return std::binary_search(e_range.begin(), e_range.end(), dst, comp);
+  }
+
+  /// Check if vertex src is connected to vertex dst with any edge edge_type
+  ///
+  /// @param src source node of the edge
+  /// @param dst destination node of the edge
+  /// @returns true iff the edge exists
+  bool IsConnected(Node src, Node dst) const {
+    // trivial check; can't be connected if degree is 0
+
+    if (degree(src) == 0ul) {
+      return false;
+    }
+
+    for (const auto& edge_type : GetDistinctEdgeTypes()) {
+      if (IsConnectedWithEdgeType(src, dst, edge_type)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+private:
+  using AdjIndexArray = katana::NUMAArray<Edge>;
+  using EdgeDstArray = katana::NUMAArray<Node>;
+  using OrigEdgeIDMap = katana::NUMAArray<Edge>;
+
+  // Must invoke SortAllEdgesByDataThenDst() before
+  // calling this function
+  static AdjIndexArray CreatePerEdgeTypeAdjacencyIndex(
+      const PropertyGraph* pg, const EdgeTypeIndex* edge_type_index,
+      const EdgeShuffleTopology& topo) noexcept;
+
+  EdgeTypeAwareTopology(
+      const PropertyGraph* pg, const EdgeTypeIndex* edge_type_index,
+      NUMAArray<Edge>&& adj_indices, NUMAArray<Node>&& dests,
+      NUMAArray<Edge>&& orig_edge_ids) noexcept
+      : edge_type_index_(edge_type_index),
+        adj_indices_(std::move(adj_indices)),
+        dests_(std::move(dests)),
+        orig_edge_ids_(std::move(orig_edge_ids)) {
+    KATANA_LOG_ASSERT(pg);
+    KATANA_LOG_DEBUG_ASSERT(edge_type_index);
+
+    KATANA_LOG_DEBUG_ASSERT(
+        adj_indices_.size() ==
+        pg->topology().num_nodes() * edge_type_index_->num_unique_types());
+
+    KATANA_LOG_DEBUG_ASSERT(dests_.size() == pg->topology().num_edges());
+    KATANA_LOG_DEBUG_ASSERT(dests_.size() == orig_edge_ids_.size());
+  }
+
+  const EdgeTypeIndex* edge_type_index_;
+  AdjIndexArray adj_indices_;
+  EdgeDstArray dests_;
+  OrigEdgeIDMap orig_edge_ids_;
+};
+
+/// Provides both out-going and in-coming topology API
+/// Provides Edge Type Aware topology API
+class KATANA_EXPORT EdgeTypeAwareBiDirTopology : public EdgeTypeAwareTopology {
+  // Inheriting to reuse outgoing topology API
+  //
+  using OutTopoBase = EdgeTypeAwareTopology;
+
+  using OutTopoBase::EdgeTypeID;
+
+public:
+  static EdgeTypeAwareBiDirTopology Make(const PropertyGraph* pg) noexcept {
+    // EdgeTypeIndex edge_type_index = EdgeTypeIndex::Make(pg);
+    // OutTopoBase out_topo = OutTopoBase::MakeFromDefaultTopology(pg, &edge_type_index);
+    // EdgeTypeAwareTopology in_topo = EdgeTypeAwareTopology::MakeFromTransposeTopology(pg, &edge_type_index);
+    // return EdgeTypeAwareBiDirTopology{std::move(edge_type_index), std::move(out_topo), std::move(in_topo)};
+
+    auto edge_type_index =
+        std::make_unique<EdgeTypeIndex>(EdgeTypeIndex::Make(pg));
+    return EdgeTypeAwareBiDirTopology{pg, std::move(edge_type_index)};
+  }
+
+  EdgeTypeAwareBiDirTopology() = default;
+  EdgeTypeAwareBiDirTopology(EdgeTypeAwareBiDirTopology&&) = default;
+  EdgeTypeAwareBiDirTopology& operator=(EdgeTypeAwareBiDirTopology&&) = default;
+
+  EdgeTypeAwareBiDirTopology(const EdgeTypeAwareBiDirTopology&) = delete;
+  EdgeTypeAwareBiDirTopology& operator=(const EdgeTypeAwareBiDirTopology&) =
+      delete;
+
+  bool has_edge_type_id(const EdgeTypeID& edge_type) const noexcept {
+    return edge_type_index_->has_edge_type_id(edge_type);
+  }
+
+  auto distinct_edge_type_ids() const noexcept {
+    return edge_type_index_->distinct_edge_type_ids();
+  }
+
+  edges_range in_edges(Node N) const noexcept { return in_topo_.edges(N); }
+
+  edges_range in_edges(Node N, const EdgeTypeID& edge_type) const noexcept {
+    return in_topo_.edges(N, edge_type);
+  }
+
+  Node in_edge_dest(Edge edge_id) const noexcept {
+    return in_topo_.edge_dest(edge_id);
+  }
+
+  size_t in_degree(Node N) const noexcept { return in_topo_.degree(N); }
+
+  size_t in_degree(Node N, const EdgeTypeID& edge_type) const noexcept {
+    return in_topo_.degree(N, edge_type);
+  }
+
+  Edge original_edge_id_using_in_edge(Edge in_edge) const noexcept {
+    return in_topo_.original_edge_id(in_edge);
+  }
+
+  /// Returns an edge iterator to an edge with some node and key by
+  /// searching for the key via the node's outgoing or incoming edges.
+  /// If not found, returns nothing.
+  edges_range FindAllEdgesSingleType(Node src, Node dst) const {
+    if (OutTopoBase::degree(src) == 0 || in_topo_.degree(dst) == 0) {
+      return MakeStandardRange<edge_iterator>(Edge{0}, Edge{0});
+    }
+
+    return OutTopoBase::FindAllEdgesSingleType(src, dst);
+  }
+
+  /// Check if vertex src is connected to vertex dst with the given edge edge_type
+  ///
+  /// @param src source node of the edge
+  /// @param dst destination node of the edge
+  /// @param edge_type edge_type of the edge
+  /// @returns true iff the edge exists
+  bool IsConnectedWithEdgeType(
+      Node src, Node dst, const EdgeTypeID& edge_type) const {
+    const auto d_out = OutTopoBase::degree(src, edge_type);
+    const auto d_in = in_topo_.degree(dst, edge_type);
+    if (d_out == 0 || d_in == 0) {
+      return false;
+    }
+
+    if (d_out < d_in) {
+      return OutTopoBase::IsConnectedWithEdgeType(src, dst, edge_type);
+    } else {
+      return in_topo_.IsConnectedWithEdgeType(dst, src, edge_type);
+    }
+  }
+
+  /// Check if vertex src is connected to vertex dst with any edge edge_type
+  ///
+  /// @param src source node of the edge
+  /// @param dst destination node of the edge
+  /// @returns true iff the edge exists
+  bool IsConnected(Node src, Node dst) const {
+    const auto d_out = OutTopoBase::degree(src);
+    const auto d_in = in_topo_.degree(dst);
+    if (d_out == 0 || d_in == 0) {
+      return false;
+    }
+
+    if (d_out < d_in) {
+      return OutTopoBase::IsConnected(src, dst);
+    } else {
+      return in_topo_.IsConnected(dst, src);
+    }
+  }
+
+private:
+  // A bit tricky. Can't use edge_type_index after moving it to member variable
+  // edge_type_index_. Order of initialization matters here
+  explicit EdgeTypeAwareBiDirTopology(
+      const PropertyGraph* pg,
+      std::unique_ptr<EdgeTypeIndex>&& edge_type_index) noexcept
+      : OutTopoBase{OutTopoBase::MakeFromDefaultTopology(
+            pg, edge_type_index.get())},
+        in_topo_{EdgeTypeAwareTopology::MakeFromTransposeTopology(
+            pg, edge_type_index.get())},
+        edge_type_index_(std::move(edge_type_index)) {}
+
+  EdgeTypeAwareTopology in_topo_;
+  std::unique_ptr<EdgeTypeIndex> edge_type_index_;
+};
 
 }  // namespace katana
 

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -918,7 +918,7 @@ katana::FindEdgeSortedByDest(
 
   constexpr size_t kBinarySearchThreshold = 64;
 
-  if (e_range.size() < kBinarySearchThreshold) {
+  if (e_range.size() <= kBinarySearchThreshold) {
     auto iter = std::find_if(
         e_range.begin(), e_range.end(),
         [&](const GraphTopology::Edge& e) { return topo.edge_dest(e) == dst; });
@@ -1208,8 +1208,7 @@ katana::EdgeTypeIndex::Make(const katana::PropertyGraph* pg) noexcept {
   });
 
   return EdgeTypeIndex{
-      std::move(edge_type_to_index), std::move(edge_index_to_type),
-      num_edge_types};
+      std::move(edge_type_to_index), std::move(edge_index_to_type)};
 }
 
 katana::EdgeShuffleTopology
@@ -1277,7 +1276,7 @@ katana::EdgeShuffleTopology::MakeTransposeCopy(
           orig_edge_ids[e_new] = e;
         }
       },
-      katana::no_stats());
+      katana::steal(), katana::no_stats());
 
   return EdgeShuffleTopology{
       pg, std::move(out_indices), std::move(out_dests),

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -3,6 +3,7 @@
 #include <sys/mman.h>
 
 #include "katana/ArrowInterchange.h"
+#include "katana/Iterators.h"
 #include "katana/Logging.h"
 #include "katana/Loops.h"
 #include "katana/PerThreadStorage.h"
@@ -880,19 +881,25 @@ katana::SortAllEdgesByDest(katana::PropertyGraph* pg) {
   auto* out_dests_data = const_cast<GraphTopology::Node*>(topo.dest_data());
 
   katana::do_all(
-      katana::iterate(uint64_t{0}, pg->topology().num_nodes()),
-      [&](uint64_t n) {
-        const auto e_beg = *pg->topology().edge_begin(n);
-        const auto e_end = *pg->topology().edge_end(n);
-        // IMPORTANT: Must sort permutation vector before dest array
+      katana::iterate(pg->topology().all_nodes()),
+      [&](GraphTopology::Node n) {
+        const auto e_beg = *pg->topology().edges(n).begin();
+        const auto e_end = *pg->topology().edges(n).end();
+
+        auto sort_iter_beg = katana::make_zip_iterator(
+            out_dests_data + e_beg, permutation_vec->begin() + e_beg);
+        auto sort_iter_end = katana::make_zip_iterator(
+            out_dests_data + e_end, permutation_vec->begin() + e_end);
+
         std::sort(
-            permutation_vec->begin() + e_beg, permutation_vec->begin() + e_end,
-            [&](uint64_t a, uint64_t b) {
-              return out_dests_data[a] < out_dests_data[b];
+            sort_iter_beg, sort_iter_end,
+            [&](const auto& tup1, const auto& tup2) {
+              auto d1 = std::get<0>(tup1);
+              auto d2 = std::get<0>(tup2);
+              static_assert(std::is_same_v<decltype(d1), GraphTopology::Node>);
+              static_assert(std::is_same_v<decltype(d1), GraphTopology::Node>);
+              return d1 < d2;
             });
-        std::sort(
-            out_dests_data + e_beg, out_dests_data + e_end,
-            std::less<GraphTopology::Node>{});
       },
       katana::steal());
 
@@ -906,30 +913,24 @@ katana::GraphTopology::Edge
 katana::FindEdgeSortedByDest(
     const PropertyGraph* graph, const GraphTopology::Node src,
     const GraphTopology::Node dst) {
-  using edge_iterator = GraphTopology::edge_iterator;
-
   const auto& topo = graph->topology();
-  const edge_iterator e_beg = topo.edge_begin(src);
-  const edge_iterator e_end = topo.edge_end(src);
+  auto e_range = topo.edges(src);
 
-  constexpr int BINARY_SEARCH_THRESHOLD = 100;
+  constexpr size_t kBinarySearchThreshold = 64;
 
-  if (std::distance(e_beg, e_end) < BINARY_SEARCH_THRESHOLD) {
-    auto iter = std::find_if(e_beg, e_end, [&](const GraphTopology::Edge& e) {
-      return topo.edge_dest(e) == dst;
-    });
+  if (e_range.size() < kBinarySearchThreshold) {
+    auto iter = std::find_if(
+        e_range.begin(), e_range.end(),
+        [&](const GraphTopology::Edge& e) { return topo.edge_dest(e) == dst; });
 
     return *iter;
 
   } else {
-    auto comparator = [&](const GraphTopology::Edge& e,
-                          const GraphTopology::Node& d) {
-      return topo.edge_dest(e) < d;
-    };
+    auto iter = std::lower_bound(
+        e_range.begin(), e_range.end(), dst,
+        EdgeDestComparator<GraphTopology>{&topo});
 
-    auto iter = std::lower_bound(e_beg, e_end, dst, comparator);
-
-    return topo.edge_dest(iter) == dst ? *iter : *e_end;
+    return topo.edge_dest(*iter) == dst ? *iter : *e_range.end();
   }
 }
 
@@ -945,7 +946,7 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
   katana::NUMAArray<DegreeNodePair> dn_pairs;
   dn_pairs.allocateInterleaved(num_nodes);
 
-  katana::do_all(katana::iterate(uint64_t{0}, num_nodes), [&](size_t node) {
+  katana::do_all(katana::iterate(topo.all_nodes()), [&](auto node) {
     size_t node_degree = pg->edges(node).size();
     dn_pairs[node] = DegreeNodePair(node_degree, node);
   });
@@ -978,8 +979,8 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
   auto* out_indices_data = const_cast<GraphTopology::Edge*>(topo.adj_data());
 
   katana::do_all(
-      katana::iterate(uint64_t{0}, num_nodes),
-      [&](uint32_t old_node_id) {
+      katana::iterate(topo.all_nodes()),
+      [&](auto old_node_id) {
         uint32_t new_node_id = old_to_new_mapping[old_node_id];
 
         // get the start location of this reindex'd nodes edges
@@ -1004,15 +1005,13 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
 
   //Update the underlying PropertyGraph topology
   // TODO(amber): eliminate these copies since we will be returning a new topology
-  katana::do_all(
-      katana::iterate(uint64_t{0}, num_nodes), [&](uint32_t node_id) {
-        out_indices_data[node_id] = new_prefix_sum[node_id];
-      });
+  katana::do_all(katana::iterate(uint64_t{0}, num_nodes), [&](auto node_id) {
+    out_indices_data[node_id] = new_prefix_sum[node_id];
+  });
 
-  katana::do_all(
-      katana::iterate(uint64_t{0}, num_edges), [&](uint32_t edge_id) {
-        out_dests_data[edge_id] = new_out_dest[edge_id];
-      });
+  katana::do_all(katana::iterate(uint64_t{0}, num_edges), [&](auto edge_id) {
+    out_dests_data[edge_id] = new_out_dest[edge_id];
+  });
 
   return katana::ResultSuccess();
 }
@@ -1030,19 +1029,17 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
 
   out_indices.allocateInterleaved(topology.num_nodes());
   // Store the out-degree of nodes from original graph
-  katana::do_all(
-      katana::iterate(uint64_t{0}, topology.num_nodes()), [&](uint64_t n) {
-        auto edges = topology.edges(n);
-        out_indices[n] = (*edges.end() - *edges.begin());
-      });
+  katana::do_all(katana::iterate(topology.all_nodes()), [&](auto n) {
+    auto edges = topology.edges(n);
+    out_indices[n] = (*edges.end() - *edges.begin());
+  });
 
   katana::do_all(
-      katana::iterate(uint64_t{0}, topology.num_nodes()),
-      [&](uint64_t n) {
-        auto edges = topology.edges(n);
+      katana::iterate(topology.all_nodes()),
+      [&](auto n) {
         // update the out_indices for the symmetric topology
-        for (auto e = edges.begin(); e != edges.end(); ++e) {
-          auto dest = topology.edge_dest(*e);
+        for (auto e : topology.edges(n)) {
+          auto dest = topology.edge_dest(e);
           // Do not add reverse edge for self-loops
           if (n != dest) {
             __sync_fetch_and_add(&(out_indices[dest]), 1);
@@ -1070,8 +1067,8 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
   out_dests.allocateInterleaved(num_edges_symmetric);
   // Update graph topology with the original edges + reverse edges
   katana::do_all(
-      katana::iterate(uint64_t{0}, topology.num_nodes()),
-      [&](uint64_t src) {
+      katana::iterate(topology.all_nodes()),
+      [&](auto src) {
         // get all outgoing edges (excluding self edges) of a particular
         // node and add reverse edges.
         for (GraphTopology::Edge e : topology.edges(src)) {
@@ -1120,8 +1117,8 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
   // Keep a copy of old destinaton ids and compute number of
   // in-coming edges for the new prefix sum of out_indices.
   katana::do_all(
-      katana::iterate(uint64_t{0}, topology.num_edges()),
-      [&](uint64_t e) {
+      katana::iterate(topology.all_edges()),
+      [&](auto e) {
         // Counting outgoing edges in the tranpose graph by
         // counting incoming edges in the original graph
         auto dest = topology.edge_dest(e);
@@ -1135,18 +1132,20 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
 
   katana::NUMAArray<uint64_t> out_dests_offset;
   out_dests_offset.allocateInterleaved(topology.num_nodes());
-  // Reuse out_indices_tmp for computing new destination positions
+
+  // temporary buffer for storing the starting point of each node's transpose
+  // adjacency
   out_dests_offset[0] = 0;
   katana::do_all(
       katana::iterate(uint64_t{1}, topology.num_nodes()),
       [&](uint64_t n) { out_dests_offset[n] = out_indices[n - 1]; },
       katana::no_stats());
 
-  // Update large_array_out_dests_ with the new destination ids
+  // Update out_dests with the new destination ids
   // of the transposed graphs
   katana::do_all(
-      katana::iterate(uint64_t{0}, topology.num_nodes()),
-      [&](uint64_t src) {
+      katana::iterate(topology.all_nodes()),
+      [&](auto src) {
         // get all outgoing edges of a particular
         // node and reverse the edges.
         for (GraphTopology::Edge e : topology.edges(src)) {
@@ -1157,7 +1156,6 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
           auto e_new = __sync_fetch_and_add(&(out_dests_offset[dest]), 1);
           // Save src as destination
           out_dests[e_new] = src;
-          // TODO (gill) copy edge data to the transposed graph
         }
       },
       katana::no_stats());
@@ -1167,4 +1165,246 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
       std::make_unique<katana::PropertyGraph>(std::move(transpose_topo));
 
   return std::unique_ptr<PropertyGraph>(std::move(transpose_pg));
+}
+
+katana::EdgeTypeIndex
+katana::EdgeTypeIndex::Make(const katana::PropertyGraph* pg) noexcept {
+  EdgeTypeIDToIndexMap edge_type_to_index;
+  EdgeIndexToTypeIDMap edge_index_to_type;
+
+  katana::PerThreadStorage<katana::gstl::Set<EdgeTypeID>> edgeTypes;
+
+  const auto& topo = pg->topology();
+
+  katana::do_all(
+      katana::iterate(Edge{0}, topo.num_edges()),
+      [&](const Edge& e) {
+        EdgeTypeID type = pg->GetEdgeTypeSetID(e);
+        edgeTypes.getLocal()->insert(type);
+      },
+      katana::no_stats());
+
+  // ordered map
+  std::set<EdgeTypeID> mergedSet;
+  for (uint32_t i = 0; i < katana::activeThreads; ++i) {
+    auto& edgeTypesSet = *edgeTypes.getRemote(i);
+    for (auto edgeType : edgeTypesSet) {
+      mergedSet.insert(edgeType);
+    }
+  }
+
+  // unordered map
+  uint32_t num_edge_types = 0u;
+  for (const auto& edgeType : mergedSet) {
+    edge_type_to_index[edgeType] = num_edge_types++;
+    edge_index_to_type.emplace_back(edgeType);
+  }
+
+  // TODO(amber): introduce a per-thread-container type that frees memory
+  // correctly
+  katana::on_each([&](unsigned, unsigned) {
+    // free up memory by resetting
+    *edgeTypes.getLocal() = gstl::Set<EdgeTypeID>();
+  });
+
+  return EdgeTypeIndex{
+      std::move(edge_type_to_index), std::move(edge_index_to_type),
+      num_edge_types};
+}
+
+katana::EdgeShuffleTopology
+katana::EdgeShuffleTopology::MakeTransposeCopy(
+    const katana::PropertyGraph* pg) {
+  KATANA_LOG_DEBUG_ASSERT(pg);
+
+  const auto& topology = pg->topology();
+  if (topology.empty()) {
+    return EdgeShuffleTopology{};
+  }
+
+  katana::NUMAArray<GraphTopology::Edge> out_indices;
+  katana::NUMAArray<GraphTopology::Node> out_dests;
+  katana::NUMAArray<GraphTopology::Edge> orig_edge_ids;
+  katana::NUMAArray<GraphTopology::Edge> out_dests_offset;
+
+  out_indices.allocateInterleaved(topology.num_nodes());
+  out_dests.allocateInterleaved(topology.num_edges());
+  orig_edge_ids.allocateInterleaved(topology.num_edges());
+  out_dests_offset.allocateInterleaved(topology.num_nodes());
+
+  katana::ParallelSTL::fill(out_indices.begin(), out_indices.end(), Edge{0});
+
+  // Keep a copy of old destinaton ids and compute number of
+  // in-coming edges for the new prefix sum of out_indices.
+  katana::do_all(
+      katana::iterate(topology.all_edges()),
+      [&](Edge e) {
+        // Counting outgoing edges in the tranpose graph by
+        // counting incoming edges in the original graph
+        auto dest = topology.edge_dest(e);
+        __sync_add_and_fetch(&(out_indices[dest]), 1);
+      },
+      katana::no_stats());
+
+  // Prefix sum calculation of the edge index array
+  katana::ParallelSTL::partial_sum(
+      out_indices.begin(), out_indices.end(), out_indices.begin());
+
+  // temporary buffer for storing the starting point of each node's transpose
+  // adjacency
+  out_dests_offset[0] = 0;
+  katana::do_all(
+      katana::iterate(Edge{1}, Edge{topology.num_nodes()}),
+      [&](Edge n) { out_dests_offset[n] = out_indices[n - 1]; },
+      katana::no_stats());
+
+  // Update out_dests with the new destination ids
+  // of the transposed graphs
+  katana::do_all(
+      katana::iterate(topology.all_nodes()),
+      [&](auto src) {
+        // get all outgoing edges of a particular
+        // node and reverse the edges.
+        for (GraphTopology::Edge e : topology.edges(src)) {
+          // e = start index into edge array for a particular node
+          // Destination node
+          auto dest = topology.edge_dest(e);
+          // Location to save edge
+          auto e_new = __sync_fetch_and_add(&(out_dests_offset[dest]), 1);
+          // Save src as destination
+          out_dests[e_new] = src;
+          // remember the original edge ID to look up properties
+          orig_edge_ids[e_new] = e;
+        }
+      },
+      katana::no_stats());
+
+  return EdgeShuffleTopology{
+      pg, std::move(out_indices), std::move(out_dests),
+      std::move(orig_edge_ids)};
+}
+
+katana::EdgeShuffleTopology
+katana::EdgeShuffleTopology::MakeOriginalCopy(const katana::PropertyGraph* pg) {
+  GraphTopology copy_topo = GraphTopology::Copy(pg->topology());
+
+  OrigEdgeIDMap orig_edge_ids;
+  orig_edge_ids.allocateInterleaved(copy_topo.num_edges());
+  katana::ParallelSTL::iota(
+      orig_edge_ids.begin(), orig_edge_ids.end(), Edge{0});
+
+  return EdgeShuffleTopology{
+      pg, std::move(copy_topo.GetAdjIndices()), std::move(copy_topo.GetDests()),
+      std::move(orig_edge_ids)};
+}
+
+katana::EdgeTypeAwareTopology
+katana::EdgeTypeAwareTopology::MakeFromDefaultTopology(
+    const katana::PropertyGraph* pg,
+    const katana::EdgeTypeIndex* edge_type_index) {
+  EdgeShuffleTopology copy_topo = EdgeShuffleTopology::MakeOriginalCopy(pg);
+  KATANA_LOG_DEBUG_ASSERT(copy_topo.num_edges() == pg->topology().num_edges());
+
+  copy_topo.SortEdgesByTypeThenDest();
+  AdjIndexArray adj_indices =
+      CreatePerEdgeTypeAdjacencyIndex(pg, edge_type_index, copy_topo);
+
+  return katana::EdgeTypeAwareTopology{
+      pg, edge_type_index, std::move(adj_indices),
+      std::move(copy_topo.GetDests()), std::move(copy_topo.GetOrigEdgeIDs())};
+}
+
+void
+katana::EdgeShuffleTopology::SortEdgesByTypeThenDest() noexcept {
+  katana::do_all(
+      katana::iterate(Base::all_nodes()),
+      [&](Node node) {
+        // get this node's first and last edge
+        auto e_beg = *Base::edges(node).begin();
+        auto e_end = *Base::edges(node).end();
+
+        // get iterators to locations to sort in the vector
+        auto begin_sort_iter = katana::make_zip_iterator(
+            orig_edge_ids_.begin() + e_beg, Base::GetDests().begin() + e_beg);
+
+        auto end_sort_iter = katana::make_zip_iterator(
+            orig_edge_ids_.begin() + e_end, Base::GetDests().begin() + e_end);
+
+        // rearrange vector indices based on how the destinations of this
+        // graph will eventually be sorted sort function not based on vector
+        // being passed, but rather the type and destination of the graph
+        std::sort(
+            begin_sort_iter, end_sort_iter,
+            [&](const auto& tup1, const auto& tup2) {
+              // get edge type and destinations
+              auto e1 = std::get<0>(tup1);
+              auto e2 = std::get<0>(tup2);
+              static_assert(std::is_same_v<decltype(e1), GraphTopology::Edge>);
+              static_assert(std::is_same_v<decltype(e2), GraphTopology::Edge>);
+
+              EdgeTypeID data1 = prop_graph_->GetEdgeTypeSetID(e1);
+              EdgeTypeID data2 = prop_graph_->GetEdgeTypeSetID(e2);
+              if (data1 != data2) {
+                return data1 < data2;
+              }
+
+              auto dst1 = std::get<1>(tup1);
+              auto dst2 = std::get<1>(tup2);
+              static_assert(
+                  std::is_same_v<decltype(dst1), GraphTopology::Node>);
+              static_assert(
+                  std::is_same_v<decltype(dst2), GraphTopology::Node>);
+              return dst1 < dst2;
+            });
+      },
+      katana::steal(), katana::no_stats());
+}
+
+katana::EdgeTypeAwareTopology::AdjIndexArray
+katana::EdgeTypeAwareTopology::CreatePerEdgeTypeAdjacencyIndex(
+    const PropertyGraph* pg, const EdgeTypeIndex* edge_type_index,
+    const EdgeShuffleTopology& topo) noexcept {
+  const size_t sz = topo.num_nodes() * edge_type_index->num_unique_types();
+  AdjIndexArray adj_indices;
+  adj_indices.allocateInterleaved(sz);
+
+  katana::do_all(
+      katana::iterate(topo.all_nodes()),
+      [&](Node N) {
+        auto offset = N * edge_type_index->num_unique_types();
+        uint32_t index = 0;
+        for (auto e : topo.edges(N)) {
+          // Since we sort the edges, we must use the
+          // original_edge_id because EdgeShuffleTopology rearranges the edges
+          const auto type = pg->GetEdgeTypeSetID(topo.original_edge_id(e));
+          while (type != edge_type_index->GetType(index)) {
+            adj_indices[offset + index] = e;
+            index++;
+            KATANA_LOG_DEBUG_ASSERT(
+                index < edge_type_index->num_unique_types());
+          }
+        }
+        auto e = *topo.edges(N).end();
+        while (index < edge_type_index->num_unique_types()) {
+          adj_indices[offset + index] = e;
+          index++;
+        }
+      },
+      katana::no_stats(), katana::steal());
+
+  return adj_indices;
+}
+
+katana::EdgeTypeAwareTopology
+katana::EdgeTypeAwareTopology::MakeFromTransposeTopology(
+    const katana::PropertyGraph* pg,
+    const katana::EdgeTypeIndex* edge_type_index) {
+  EdgeShuffleTopology tpose_topo = EdgeShuffleTopology::MakeTransposeCopy(pg);
+  tpose_topo.SortEdgesByTypeThenDest();
+  AdjIndexArray adj_indices =
+      CreatePerEdgeTypeAdjacencyIndex(pg, edge_type_index, tpose_topo);
+
+  return EdgeTypeAwareTopology{
+      pg, edge_type_index, std::move(adj_indices),
+      std::move(tpose_topo.GetDests()), std::move(tpose_topo.GetOrigEdgeIDs())};
 }

--- a/libsupport/include/katana/Iterators.h
+++ b/libsupport/include/katana/Iterators.h
@@ -1,0 +1,184 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_ITERATORS_H_
+#define KATANA_LIBSUPPORT_KATANA_ITERATORS_H_
+
+#include <algorithm>
+#include <tuple>
+#include <utility>
+
+#include <boost/iterator/iterator_facade.hpp>
+
+#include "katana/config.h"
+
+namespace katana {
+
+//TODO(amber): Move other iterators from libgalois to libsupport
+
+///  A Zip Iterator allows iterating over several containers simultaneously.
+///  A canonical example is sorting two containers together. A Zip iterator maintains
+///  a tuple of participating iterators and advances all of them together.
+///  Dereferencing yields a tuple of references for l-values and a tuple of values
+///  for r-values. See  code below:
+///  for example usage:
+///
+///  NOTE: It is best to define comparator functions as template functions (or
+///  lambdas that take parameters as 'auto'), e.g., for std::sort(),
+///  because either left or right parameter to the comparator can be a
+///  tuple of references or tuple of values depending on the calling context.
+///
+///int main() {
+///
+///  std::vector<int> vecA{ 5, 3, 4, 2, 1};
+///  std::vector<char> vecB{ 'e', 'c', 'd', 'b', 'a' };
+///
+///  auto beg = katana::make_zip_iterator(vecA.begin(), vecB.begin());
+///
+///  auto end = katana::make_zip_iterator(vecA.end(), vecB.end());
+///
+///  std::cout << "[";
+///  for (auto i = beg; i != end; ++i) {
+///    std::cout << "(" << std::get<0>(*i) << "," << std::get<1>(*i) << "), ";
+///  }
+///  std::cout << "]" << std::endl;
+///
+///  std::sort(beg, end,
+///      [&] (const auto& tup1, const auto& tup2) {
+///        return std::get<0>(tup1) < std::get<0>(tup2);
+///      });
+///
+///
+///  std::cout << "[";
+///  for (size_t i = 0; i < vecA.size(); ++i) {
+///    std::cout << "(" << vecA[i] << "," << vecB[i] << "), ";
+///  }
+///  std::cout << "]" << std::endl;
+///
+///  return 0;
+///}
+
+/// This is a thin wrapper around std::tuple<Args&...> . It is needed to
+/// define the swap operator (needed by things like std::sort()), without having to
+/// overload or conflict with std::swap for std::tuple<>
+template <typename... Args>
+class KATANA_EXPORT ZipRefTuple : public std::tuple<Args&...> {
+  using Base = std::tuple<Args&...>;
+
+public:
+  using ZipValTuple = std::tuple<std::remove_reference_t<Args>...>;
+
+  // ZipRefTuple(Args&... args): Base(args...) {}
+  ZipRefTuple(const Base& t) : Base(t) {}
+  ZipRefTuple(Base&& t) : Base(std::move(t)) {}
+
+  ZipRefTuple(const ZipRefTuple& that) = default;
+  ZipRefTuple(ZipRefTuple&& that) = default;
+  ZipRefTuple& operator=(const ZipRefTuple& that) = default;
+  ZipRefTuple& operator=(ZipRefTuple&& that) = default;
+
+  ZipRefTuple& operator=(const ZipValTuple& that) {
+    ApplyAssign(*this, that, std::index_sequence_for<Args...>());
+    return *this;
+  }
+
+  ZipRefTuple& operator=(ZipValTuple&& that) {
+    ApplyMoveAssign(*this, that, std::index_sequence_for<Args...>());
+    return *this;
+  }
+
+  friend void swap(ZipRefTuple a, ZipRefTuple b) noexcept { return a.swap(b); }
+
+private:
+  template <typename Tuple1, typename Tuple2, size_t... Indices>
+  static void ApplyAssign(
+      Tuple1& tup1, const Tuple2& tup2,
+      const std::index_sequence<Indices...>&) {
+    ((std::get<Indices>(tup1) = std::get<Indices>(tup2)), ...);
+  }
+
+  template <typename Tuple1, typename Tuple2, size_t... Indices>
+  static void ApplyMoveAssign(
+      Tuple1& tup1, Tuple2&& tup2, const std::index_sequence<Indices...>&) {
+    ((std::get<Indices>(tup1) = std::move(std::get<Indices>(tup2))), ...);
+  }
+};
+
+template <typename... Iterators>
+class KATANA_EXPORT ZipIterator
+    : public boost::iterator_facade<
+          ZipIterator<Iterators...>,
+          std::tuple<typename std::iterator_traits<Iterators>::value_type...>,
+          std::random_access_iterator_tag,
+          ZipRefTuple<typename std::iterator_traits<Iterators>::reference...> >
+
+{
+  friend boost::iterator_core_access;
+
+  using IterTuple = std::tuple<Iterators...>;
+  using RefTuple =
+      ZipRefTuple<typename std::iterator_traits<Iterators>::reference...>;
+
+public:
+  ZipIterator(const Iterators&... iterators)
+      : iter_tuple_(std::make_tuple(iterators...)) {}
+
+  bool equal(const ZipIterator& that) const noexcept {
+    return iter_tuple_ == that.iter_tuple_;
+  }
+
+  RefTuple dereference() const noexcept {
+    return DerefIterTuple(
+        const_cast<IterTuple&>(iter_tuple_),
+        std::index_sequence_for<Iterators...>());
+    // return DerefIterTuple(iter_tuple_, std::index_sequence_for<Iterators...>());
+  }
+
+  RefTuple dereference() noexcept {
+    return DerefIterTuple(iter_tuple_, std::index_sequence_for<Iterators...>());
+  }
+
+  void increment() noexcept {
+    ApplyToEach(iter_tuple_, [](auto& iter) { ++iter; });
+  }
+
+  void decrement() noexcept {
+    ApplyToEach(iter_tuple_, [](auto& iter) { --iter; });
+  }
+
+  void advance(std::ptrdiff_t n) noexcept {
+    ApplyToEach(iter_tuple_, [n](auto& iter) { iter += n; });
+  }
+
+  std::ptrdiff_t distance_to(const ZipIterator& that) const noexcept {
+    return std::distance(
+        std::get<0>(iter_tuple_), std::get<0>(that.iter_tuple_));
+  }
+
+private:
+  template <typename Tuple, size_t... Indices>
+  static auto DerefIterTuple(
+      Tuple& iterTuple, std::index_sequence<Indices...>) {
+    return RefTuple{std::tie(*std::get<Indices>(iterTuple)...)};
+  }
+
+  template <typename F, size_t... Indices>
+  static void ApplyToEachImpl(
+      IterTuple& tup, F func, const std::index_sequence<Indices...>&) {
+    (func(std::get<Indices>(tup)), ...);
+  }
+
+  template <typename F>
+  static void ApplyToEach(IterTuple& tup, F func) noexcept {
+    ApplyToEachImpl(tup, func, std::index_sequence_for<Iterators...>());
+  }
+
+  IterTuple iter_tuple_;
+};
+
+template <typename... Iterators>
+auto
+make_zip_iterator(const Iterators&... iterators) noexcept {
+  return ZipIterator<Iterators...>(iterators...);
+}
+
+}  // end namespace katana
+
+#endif

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_unit_test(result)
 add_unit_test(signals)
 add_unit_test(strings)
 add_unit_test(uri)
+add_unit_test(zip_iterator)
 
 add_executable(result-bench result-bench.cpp)
 target_link_libraries(result-bench katana_support benchmark::benchmark)

--- a/libsupport/test/zip_iterator.cpp
+++ b/libsupport/test/zip_iterator.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <vector>
+
+#include "katana/Iterators.h"
+#include "katana/Logging.h"
+
+int
+main() {
+  std::vector<int> vec_a{5, 3, 4, 2, 1};
+  std::vector<char> vec_b{'e', 'c', 'd', 'b', 'a'};
+
+  std::vector<std::pair<int, char>> zip_using_vec;
+  for (size_t i = 0; i < vec_a.size(); ++i) {
+    zip_using_vec.emplace_back(vec_a[i], vec_b[i]);
+  }
+  std::sort(zip_using_vec.begin(), zip_using_vec.end());
+
+  const auto beg = katana::make_zip_iterator(vec_a.begin(), vec_b.begin());
+  const auto end = katana::make_zip_iterator(vec_a.end(), vec_b.end());
+
+  std::sort(beg, end, [&](const auto& tup1, const auto& tup2) {
+    return std::get<0>(tup1) < std::get<0>(tup2);
+  });
+
+  std::cout << "[";
+  for (auto i = beg; i != end; ++i) {
+    std::cout << "(" << std::get<0>(*i) << "," << std::get<1>(*i) << "), ";
+  }
+  std::cout << "]" << std::endl;
+
+  std::vector<std::pair<int, char>> zip_using_iter;
+  for (auto i = beg; i < end; ++i) {
+    zip_using_iter.emplace_back(std::get<0>(*i), std::get<1>(*i));
+  }
+
+  KATANA_LOG_VASSERT(
+      zip_using_vec == zip_using_iter,
+      "both vectors should be sorted and equal");
+
+  return 0;
+}


### PR DESCRIPTION
This is the first implementation of multiple-topologies vision for PropertyGraph. The idea is to be able to generate multiple topologies on demand, such as sorted, or transposed. Thus exposing additional functionality.

Wait for https://github.com/KatanaGraph/katana-enterprise/pull/1537