### PR TITLE
Reduce the number of CI control jobs.

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -18,49 +18,13 @@ jobs:
       - name: Info
         run: echo "${{ github.event.pull_request.body }}"
 
-  do_package:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        !contains(github.event.pull_request.body, '[no package]')
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
-
-  do_cpp_package:
-    needs:
-      - do_package
-      - do_cpp
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        !contains(github.event.pull_request.body, '[no C++ package]')
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
-
-  do_test:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        !contains(github.event.pull_request.body, '[no test]')
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
-
   do_cpp_test:
     needs:
-      - do_test
       - do_cpp
     if: |
       github.event_name != 'pull_request' ||
       (
+        !contains(github.event.pull_request.body, '[no test]') &&
         !contains(github.event.pull_request.body, '[no C++ test]')
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -26,36 +26,14 @@ jobs:
       - name: Info
         run: echo "${{ github.event.pull_request.body }}"
 
-  do_package:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        !contains(github.event.pull_request.body, '[no package]')
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
-
   do_python_package:
     needs:
-      - do_package
       - do_python
     if: |
       github.event_name != 'pull_request' ||
       (
+        !contains(github.event.pull_request.body, '[no package]') &&
         !contains(github.event.pull_request.body, '[no Python package]')
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
-
-  do_test:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        !contains(github.event.pull_request.body, '[no test]')
       )
     runs-on: ubuntu-latest
     steps:
@@ -64,11 +42,11 @@ jobs:
 
   do_python_test:
     needs:
-      - do_test
       - do_python
     if: |
       github.event_name != 'pull_request' ||
       (
+        !contains(github.event.pull_request.body, '[no test]') &&
         !contains(github.event.pull_request.body, '[no Python test]')
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
There were more jobs created to check for magic words than were needed. This PR should clean things up in terms of both job runs and just the visual noise in the CI displays.