### PR TITLE
Cancel CI jobs if a new version of the PR is pushed.

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -6,6 +6,13 @@ on:
     - master
   pull_request:
 
+# Cancel any previous runs with the same key.
+concurrency:
+  # Example key: Repository Structure CI-refs/pull/1381/merge
+  #   or Repository Structure CI-<owner>-<sha> for pushes
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.repository_owner, github.sha) }}
+  cancel-in-progress: true
+
 jobs:
   do_cpp:
     if: |

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -6,15 +6,14 @@ on:
     - master
   pull_request:
 
+# Cancel any previous runs with the same key.
+concurrency:
+  # Example key: Repository Structure CI-refs/pull/1381/merge
+  #   or Repository Structure CI-<owner>-<sha> for pushes
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.repository_owner, github.sha) }}
+  cancel-in-progress: true
+
 jobs:
-# Canceling other workflows doesn't work on the open repo because it requires write permissions.
-#  cancel_previous:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: styfle/cancel-workflow-action@0.6.0
-#      if: ${{ github.event_name == 'pull_request' }}
-#      with:
-#        access_token: ${{ github.token }}
   do_python:
     if: |
       github.event_name != 'pull_request' ||


### PR DESCRIPTION
This is applying the same changes as used in enterprise (https://github.com/KatanaGraph/katana-enterprise/commit/29fe27c6502da65157639fb72cbe2f514a69f553) in open.