### PR TITLE
Parquet{Read,Writ}er: block files when element count would be too large

### DIFF
--- a/libgalois/include/katana/Properties.h
+++ b/libgalois/include/katana/Properties.h
@@ -267,13 +267,14 @@ public:
         sizeof(typename arrow::NumericArray<U>::value_type) == sizeof(T),
         "incompatible types");
     if (array.offset() < 0) {
-      KATANA_LOG_DEBUG("arrow error: Offset not supported");
-      return ErrorCode::ArrowError;
+      return KATANA_ERROR(
+          ErrorCode::ArrowError, "offset must be positive, given {}",
+          array.offset());
     }
     if (array.data()->buffers.size() <= 1 ||
         !array.data()->buffers[1]->is_mutable()) {
-      KATANA_LOG_DEBUG("arrow error: immutable buffers not supported");
-      return ErrorCode::ArrowError;
+      return KATANA_ERROR(
+          ErrorCode::ArrowError, "immutable buffers not supported");
     }
     return PODPropertyView(
         internal::GetMutableValuesWorkAround<T>(array.data(), 1, 0),
@@ -284,19 +285,19 @@ public:
   static Result<PODPropertyView> Make(
       const arrow::FixedSizeBinaryArray& array) {
     if (array.byte_width() != sizeof(T)) {
-      KATANA_LOG_DEBUG(
-          "arrow error: bad byte width of data: {} != {}", array.byte_width(),
-          sizeof(T));
-      return ErrorCode::ArrowError;
+      return KATANA_ERROR(
+          ErrorCode::ArrowError, "bad byte width of data: {} != {}",
+          array.byte_width(), sizeof(T));
     }
     if (array.offset() < 0) {
-      KATANA_LOG_DEBUG("arrow error: Offset not supported");
-      return ErrorCode::ArrowError;
+      return KATANA_ERROR(
+          ErrorCode::ArrowError, "offset must be positive, given {}",
+          array.offset());
     }
     if (array.data()->buffers.size() <= 1 ||
         !array.data()->buffers[1]->is_mutable()) {
-      KATANA_LOG_DEBUG("arrow error: immutable buffers not supported");
-      return ErrorCode::ArrowError;
+      return KATANA_ERROR(
+          ErrorCode::ArrowError, "immutable buffers not supported");
     }
     return PODPropertyView(
         internal::GetMutableValuesWorkAround<T>(array.data(), 1, 0),

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -82,10 +82,6 @@ private:
   katana::Result<std::shared_ptr<arrow::Table>> FixTable(
       std::shared_ptr<arrow::Table>&& _table);
 
-  katana::Result<std::shared_ptr<arrow::Table>> DoFilteredTableRead(
-      parquet::arrow::FileReader* reader, const arrow::Schema& schema,
-      const std::vector<int32_t>& filter);
-
   std::optional<Slice> slice_;
   bool make_cannonical_;
 };


### PR DESCRIPTION
This is a work around for an apparent limitation in the arrow library
when translating from parquet

String arrays have a de-facto limit in the number of elements they can
contain (it seems close to the number of string bytes). You can end up
with more elements than string bytes if there are mostly null entries.

We can account for this in memory by chunking arrays, but parquet does
not have this limitation and the chunking is lost in translation. Then
when the arrays are translated back into arrow Sting Builder complains
that there are too many elements for the array.

The workaround here chunks parquet files as well.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>