### PR TITLE
[KAT-956] Changed the difference_type to ptrdiff_t

### DIFF
--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -197,7 +197,9 @@ struct OpaqueIDLinear : public OpaqueIDOrderedWithValue<_IDType, _Value> {
 public:
   using OpaqueIDOrderedWithValue<_IDType, _Value>::OpaqueIDOrderedWithValue;
 
-  static_assert(sizeof(_Value) <= sizeof(std::ptrdiff_t), "OpaqueIDLinear only supports values up to the size of ptrdiff_t.");
+  static_assert(
+      sizeof(_Value) <= sizeof(std::ptrdiff_t),
+      "OpaqueIDLinear only supports values up to the size of ptrdiff_t.");
 
   using DifferenceType = std::ptrdiff_t;
 

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -197,7 +197,11 @@ struct OpaqueIDLinear : public OpaqueIDOrderedWithValue<_IDType, _Value> {
 public:
   using OpaqueIDOrderedWithValue<_IDType, _Value>::OpaqueIDOrderedWithValue;
 
-  using DifferenceType = std::make_signed_t<_Value>;
+  static_assert(
+      sizeof(_Value) <= sizeof(std::ptrdiff_t),
+      "OpaqueIDLinear only supports values up to the size of ptrdiff_t.");
+
+  using DifferenceType = std::ptrdiff_t;
 
   // iterator traits
   using difference_type = DifferenceType;

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <type_traits>
 
 #include <boost/math/tools/precision.hpp>
 
@@ -196,6 +197,8 @@ template <typename _IDType, typename _Value>
 struct OpaqueIDLinear : public OpaqueIDOrderedWithValue<_IDType, _Value> {
 public:
   using OpaqueIDOrderedWithValue<_IDType, _Value>::OpaqueIDOrderedWithValue;
+
+  static_assert(sizeof(_Value) <= sizeof(std::ptrdiff_t), "The ID is too large to safely use ptrdiff_t");
 
   using DifferenceType = std::ptrdiff_t;
 

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <iostream>
-#include <type_traits>
 
 #include <boost/math/tools/precision.hpp>
 
@@ -198,7 +197,7 @@ struct OpaqueIDLinear : public OpaqueIDOrderedWithValue<_IDType, _Value> {
 public:
   using OpaqueIDOrderedWithValue<_IDType, _Value>::OpaqueIDOrderedWithValue;
 
-  static_assert(sizeof(_Value) <= sizeof(std::ptrdiff_t), "The ID is too large to safely use ptrdiff_t");
+  static_assert(sizeof(_Value) <= sizeof(std::ptrdiff_t), "OpaqueIDLinear only supports values up to the size of ptrdiff_t.");
 
   using DifferenceType = std::ptrdiff_t;
 

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -197,7 +197,7 @@ struct OpaqueIDLinear : public OpaqueIDOrderedWithValue<_IDType, _Value> {
 public:
   using OpaqueIDOrderedWithValue<_IDType, _Value>::OpaqueIDOrderedWithValue;
 
-  using DifferenceType = std::make_signed_t<_Value>;
+  using DifferenceType = std::ptrdiff_t;
 
   // iterator traits
   using difference_type = DifferenceType;


### PR DESCRIPTION
I changed the difference type to int64_t for the purposes of resolving comparison issues. I also added some comments to prevent some potential issues that could arise from this change. This fix was thought of to affect as little things as possible.