### PR TITLE
add hirsute dev setup support, clean up ubuntu version identification, other small fixes

### DIFF
--- a/scripts/setup_dev_ubuntu.sh
+++ b/scripts/setup_dev_ubuntu.sh
@@ -6,7 +6,7 @@
 set -xeuo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.."; pwd)"
 
-EXPECTED_RELEASES=("20.04" "18.04" "16.04")
+EXPECTED_RELEASES=("21.04" "20.04" "18.04" "16.04")
 RELEASE=$(lsb_release --release --short)
 
 SUPPORTED_RELEASE=false


### PR DESCRIPTION
- use focal packages for hirsute where required for clang-10 and
apache-arrow
- RELEASE and RELEASE_CODENAME were the same thing, only use
RELEASE_CODENAME
- pip would throw an error about testresources not being in the user
install directory, add it
- clangd-10 is required for lsp servers, add it to the dev tools