### PR TITLE
tsuba: Copy properties during write if they are not loaded

### DIFF
--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -522,7 +522,8 @@ tsuba::RDG::Store(
       handle.impl_->rdg_manifest().policy_id(), tsuba::Comm()->Num,
       core_->part_header().metadata().policy_id_, versioning_action);
   if (handle.impl_->rdg_manifest().dir() != rdg_dir_) {
-    core_->part_header().UnbindFromStorage();
+    KATANA_CHECKED(core_->part_header().ChangeStorageLocation(
+        rdg_dir_, handle.impl_->rdg_manifest().dir()));
   }
 
   auto desc_res = WriteGroup::Make();

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -110,7 +110,10 @@ public:
       RDGHandle handle, WriteGroup* writes,
       RDG::RDGVersioningPolicy retain_version) const;
 
-  void UnbindFromStorage();
+  /// Mark all in-memory properties dirty so that they can be written
+  /// out, copy out-of-memory properties
+  katana::Result<void> ChangeStorageLocation(
+      const katana::Uri& old_location, const katana::Uri& new_location);
 
   //
   // Property manipulation


### PR DESCRIPTION
This allows the `Write` operation to work properly when properties are out of memory. Properties are copied from the old location to the new one, we save some memory by not translating them to arrow.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>