### PR TITLE
make conan profile update copy-pastable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ With those developer dependencies installed, you can run the following commands
 from the project root directory to build the system:
 
 ```shell
-case $(uname) in Darwin*) ;; *) conan profile update settings.compiler.libcxx=libstdc++11 default ;; esac
+conan profile update settings.compiler.libcxx=libstdc++11 default
 
 mkdir build
 cd build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,7 @@ With those developer dependencies installed, you can run the following commands
 from the project root directory to build the system:
 
 ```shell
-case $(uname) in
-  Darwin*)
-    ;;
-  *) conan profile update settings.compiler.libcxx=libstdc++11 default
-    ;;
-esac
+case $(uname) in Darwin*) ;; *) conan profile update settings.compiler.libcxx=libstdc++11 default ;; esac
 
 mkdir build
 cd build


### PR DESCRIPTION
the command 
`case $(uname) in
  Darwin*)
    ;;
  *) conan profile update settings.compiler.libcxx=libstdc++11 default
    ;;
esac`

could not be copy and pasted when it was on multiple lines. I made it one line so that it is easy to copy and paste.
