### PR TITLE
exclude emacs temp files from check_cpp_format

### DIFF
--- a/scripts/check_cpp_format.sh
+++ b/scripts/check_cpp_format.sh
@@ -17,7 +17,7 @@ fi
 ROOTS="$@"
 FAILED=
 PRUNE_PATHS=${PRUNE_PATHS:-}
-PRUNE_NAMES="build*"
+PRUNE_NAMES="build* .#*"
 
 emit_prunes() {
   { for p in ${PRUNE_PATHS}; do echo "-path ${p} -prune -o"; done; \

--- a/scripts/check_sh_format.sh
+++ b/scripts/check_sh_format.sh
@@ -18,7 +18,7 @@ fi
 
 ROOTS="$*"
 PRUNE_PATHS=${PRUNE_PATHS:-}
-PRUNE_NAMES="build*"
+PRUNE_NAMES="build* .#*"
 
 emit_prunes() {
   { for p in $PRUNE_PATHS; do echo "-path $p -prune -o"; done; \


### PR DESCRIPTION
including them caused failures when using "-fix"