### PR TITLE
Fix notebook testing

### DIFF
--- a/libgalois/include/katana/Statistics.h
+++ b/libgalois/include/katana/Statistics.h
@@ -373,7 +373,14 @@ template <typename T>
 void
 ReportParam(
     const std::string& region, const std::string& category, const T& value) {
-  internal::sysStatManager()->AddParam(region, category, gstl::makeStr(value));
+  if (internal::sysStatManager()) {
+    internal::sysStatManager()->AddParam(
+        region, category, gstl::makeStr(value));
+  } else {
+    KATANA_LOG_WARN(
+        "StatManager already shutdown: {}, {}, {}, {}", region, category,
+        StatTotal::str(StatTotal::SINGLE), gstl::makeStr(value));
+  }
 }
 
 template <typename T>
@@ -382,7 +389,13 @@ ReportStat(
     const std::string& region, const std::string& category, const T& value,
     const StatTotal::Type& type,
     std::enable_if_t<std::is_integral_v<T>>* = nullptr) {
-  internal::sysStatManager()->AddInt(region, category, int64_t(value), type);
+  if (internal::sysStatManager()) {
+    internal::sysStatManager()->AddInt(region, category, int64_t(value), type);
+  } else {
+    KATANA_LOG_WARN(
+        "StatManager already shutdown: {}, {}, {}, {}", region, category,
+        StatTotal::str(type), uint64_t(value));
+  }
 }
 
 template <typename T>
@@ -391,7 +404,13 @@ ReportStat(
     const std::string& region, const std::string& category, const T& value,
     const StatTotal::Type& type,
     std::enable_if_t<std::is_floating_point_v<T>>* = nullptr) {
-  internal::sysStatManager()->AddFP(region, category, double(value), type);
+  if (internal::sysStatManager()) {
+    internal::sysStatManager()->AddFP(region, category, double(value), type);
+  } else {
+    KATANA_LOG_WARN(
+        "StatManager already shutdown: {}, {}, {}, {}", region, category,
+        StatTotal::str(type), double(value));
+  }
 }
 
 template <typename T>

--- a/python/examples/notebooks/Katana Tutorial.ipynb
+++ b/python/examples/notebooks/Katana Tutorial.ipynb
@@ -64,9 +64,11 @@
    "execution_count": 2,
    "id": "e53dc295",
    "metadata": {
-     "nbreg": {
-       "diff_ignore": ["/outputs/0/data/text/plain"]
-     }
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/0/data/text/plain"
+     ]
+    }
    },
    "outputs": [
     {
@@ -334,9 +336,11 @@
    "execution_count": 10,
    "id": "9862731b",
    "metadata": {
-     "nbreg": {
-       "diff_ignore": ["/outputs/0/text"]
-     }
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/0/text"
+     ]
+    }
    },
    "outputs": [
     {
@@ -458,7 +462,9 @@
    "metadata": {
     "scrolled": true,
     "nbreg": {
-      "diff_ignore": ["/outputs/0/text"]
+     "diff_ignore": [
+      "/outputs/0/text"
+     ]
     }
    },
    "outputs": [
@@ -520,7 +526,7 @@
     "This supports much larger graphs, and much more computing power.\n",
     "Katana Enterprise will provide an interface similar to the one shown here for distributed graphs, including custom algorithms written in Python.\n",
     "\n",
-    "(Python support for distributed graphs will be available in enterprise Katana by the end of Q2 2021.)"
+    "(Python support for distributed graphs will be available in enterprise Katana by the end of Q3 2021.)"
    ]
   },
   {
@@ -553,9 +559,9 @@
  ],
  "metadata": {
   "nbreg": {
-    "diff_ignore": [
-      "/metadata/language_info/version"
-    ]
+   "diff_ignore": [
+    "/metadata/language_info/version"
+   ]
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/python/examples/notebooks/jaccard_numba.ipynb
+++ b/python/examples/notebooks/jaccard_numba.ipynb
@@ -60,9 +60,9 @@
    "execution_count": 3,
    "metadata": {
     "nbreg": {
-      "diff_ignore": [
-        "/outputs/0/text"
-      ]
+     "diff_ignore": [
+      "/outputs/0/text"
+     ]
     }
    },
    "outputs": [
@@ -83,9 +83,9 @@
    "execution_count": 4,
    "metadata": {
     "nbreg": {
-      "diff_ignore": [
-        "/outputs/0/text"
-      ]
+     "diff_ignore": [
+      "/outputs/0/text"
+     ]
     }
    },
    "outputs": [
@@ -106,7 +106,7 @@
     "jaccard(g, 1, \"JM\")\n",
     "timer.stop()\n",
     "print(timer.get())\n",
-    "# del timer\n",
+    "del timer\n",
     "\n",
     "print(\"Node {}: {}\".format(2, g.get_node_property(\"JM\")[2]))"
    ]
@@ -114,9 +114,9 @@
  ],
  "metadata": {
   "nbreg": {
-    "diff_ignore": [
-      "/metadata/language_info/version"
-    ]
+   "diff_ignore": [
+    "/metadata/language_info/version"
+   ]
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/python/katana/lonestar/analytics/jaccard.py
+++ b/python/katana/lonestar/analytics/jaccard.py
@@ -61,7 +61,7 @@ def main():
     timer.start()
     jaccard(g, args.baseNode, args.propertyName)
     timer.stop()
-    # del timer
+    del timer
 
     print("Node {}: {}".format(args.reportNode, g.get_node_property(args.propertyName)[args.reportNode]))
 

--- a/python/test/test_notebooks.py
+++ b/python/test/test_notebooks.py
@@ -1,22 +1,27 @@
 import os
 import pathlib
 
-NOTEBOOK_DIR = pathlib.Path(__file__).parent.parent / "examples"
+import nbformat
+import pytest
+from nbconvert.preprocessors import ExecutePreprocessor
+
+NOTEBOOK_DIR = pathlib.Path(__file__).parent.parent / "examples" / "notebooks"
+
+NOTEBOOKS = [
+    "jaccard_numba.ipynb",
+    "Katana Tutorial.ipynb",
+]
 
 
-def pytest_generate_tests(metafunc):
-    notebooks = []
-    ids = []
-    for root, _, files in os.walk(NOTEBOOK_DIR):
-        ext = ".ipynb"
-        for filename in files:
-            if not filename.endswith(ext):
-                continue
-            notebooks.append(pathlib.Path(root, filename))
-            ids.append(filename[: -len(ext)])
-
-    metafunc.parametrize("notebook", notebooks, ids=ids)
+def execute_notebook(notebook_filename):
+    with open(notebook_filename) as f:
+        nb = nbformat.read(f, as_version=4)
+        ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
+        # the following line will throw CellExecutionError if
+        # there is any exception during the execution
+        ep.preprocess(nb, {"metadata": {"path": "."}})
 
 
-def test_notebooks(nb_regression, notebook):
-    nb_regression.check(str(notebook))
+@pytest.mark.parametrize("notebook", NOTEBOOKS)
+def test_execute_notebook(notebook):
+    execute_notebook(NOTEBOOK_DIR / notebook)


### PR DESCRIPTION
* Eliminate crash if a stat is reported after the *MemSys is destructed (this can happen easily in python)
* Reenable more notebook testing and update it to match how @gliga did it in enterprise.

Fixes  #252