### PR TITLE
tsuba: keep all type information around

### DIFF
--- a/libgalois/include/katana/PropertyViews.h
+++ b/libgalois/include/katana/PropertyViews.h
@@ -71,7 +71,8 @@ MakeNodePropertyViews(
 template <typename PropTuple>
 static Result<katana::PropertyViewTuple<PropTuple>>
 MakeNodePropertyViews(const PropertyGraph* pg) {
-  return MakeNodePropertyViews<PropTuple>(pg, pg->node_schema()->field_names());
+  return MakeNodePropertyViews<PropTuple>(
+      pg, pg->loaded_node_schema()->field_names());
 }
 
 /// MakeEdgePropertyViews asserts a typed view on top of runtime properties.
@@ -93,7 +94,8 @@ MakeEdgePropertyViews(
 template <typename PropTuple>
 static Result<katana::PropertyViewTuple<PropTuple>>
 MakeEdgePropertyViews(const PropertyGraph* pg) {
-  return MakeEdgePropertyViews<PropTuple>(pg, pg->edge_schema()->field_names());
+  return MakeEdgePropertyViews<PropTuple>(
+      pg, pg->loaded_edge_schema()->field_names());
 }
 
 }  // namespace katana::internal

--- a/libgalois/include/katana/TypedPropertyGraph.h
+++ b/libgalois/include/katana/TypedPropertyGraph.h
@@ -234,7 +234,8 @@ template <typename NodeProps, typename EdgeProps>
 Result<TypedPropertyGraph<NodeProps, EdgeProps>>
 TypedPropertyGraph<NodeProps, EdgeProps>::Make(PropertyGraph* pg) {
   return TypedPropertyGraph<NodeProps, EdgeProps>::Make(
-      pg, pg->node_schema()->field_names(), pg->edge_schema()->field_names());
+      pg, pg->loaded_node_schema()->field_names(),
+      pg->loaded_edge_schema()->field_names());
 }
 
 }  // namespace katana

--- a/libgalois/src/BuildGraph.cpp
+++ b/libgalois/src/BuildGraph.cpp
@@ -1883,11 +1883,11 @@ katana::WritePropertyGraph(
 katana::Result<void>
 katana::WritePropertyGraph(
     katana::PropertyGraph& prop_graph, const std::string& dir) {
-  for (const auto& field : prop_graph.node_schema()->fields()) {
+  for (const auto& field : prop_graph.loaded_node_schema()->fields()) {
     KATANA_LOG_VERBOSE(
         "node prop: ({}) {}", field->type()->ToString(), field->name());
   }
-  for (const auto& field : prop_graph.edge_schema()->fields()) {
+  for (const auto& field : prop_graph.loaded_edge_schema()->fields()) {
     KATANA_LOG_VERBOSE(
         "edge prop: ({}) {}", field->type()->ToString(), field->name());
   }

--- a/libgalois/src/GraphMLSchema.cpp
+++ b/libgalois/src/GraphMLSchema.cpp
@@ -386,8 +386,8 @@ katana::graphml::ExportGraph(
   xmlTextWriterPtr writer = CreateGraphmlFile(outfile);
 
   // export schema
-  std::shared_ptr<arrow::Schema> node_schema = graph->node_schema();
-  std::shared_ptr<arrow::Schema> edge_schema = graph->edge_schema();
+  std::shared_ptr<arrow::Schema> node_schema = graph->loaded_node_schema();
+  std::shared_ptr<arrow::Schema> edge_schema = graph->loaded_edge_schema();
 
   std::vector<uint64_t> node_property_indexes;
   std::vector<uint64_t> node_label_indexes;

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -415,7 +415,8 @@ katana::PropertyGraph::Make(katana::GraphTopology&& topo_to_assign) {
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Copy() const {
-  return Copy(node_schema()->field_names(), edge_schema()->field_names());
+  return Copy(
+      loaded_node_schema()->field_names(), loaded_edge_schema()->field_names());
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>

--- a/libgalois/src/PropertyViews.cpp
+++ b/libgalois/src/PropertyViews.cpp
@@ -7,7 +7,9 @@ katana::internal::ExtractArrays(
   for (auto& property : properties) {
     auto column = table->GetColumnByName(property);
     if (!column) {
-      return ErrorCode::PropertyNotFound;
+      return KATANA_ERROR(
+          ErrorCode::PropertyNotFound, "property named {}",
+          std::quoted(property));
     }
     if (column->num_chunks() != 1) {
       // Katana form graphs only contain single chunk property columns.
@@ -28,7 +30,9 @@ katana::internal::ExtractArrays(
   for (auto& property : properties) {
     auto column = pview.GetProperty(property);
     if (!column) {
-      return ErrorCode::PropertyNotFound;
+      return KATANA_ERROR(
+          ErrorCode::PropertyNotFound, "property named {}",
+          std::quoted(property));
     }
     if (column->num_chunks() != 1) {
       // Katana form graphs only contain single chunk property columns.

--- a/libgalois/test/property-file-graph.cpp
+++ b/libgalois/test/property-file-graph.cpp
@@ -86,17 +86,19 @@ TestRoundTrip() {
 
   std::unique_ptr<katana::PropertyGraph> g2 = std::move(make_result.value());
 
-  KATANA_LOG_ASSERT(g2->GetNumNodeProperties() == 1);
+  KATANA_LOG_VASSERT(
+      g2->GetNumNodeProperties() == 1, "found {} properties",
+      g2->GetNumNodeProperties());
   KATANA_LOG_ASSERT(g2->GetNumEdgeProperties() == 1);
 
-  KATANA_LOG_ASSERT(g2->edge_schema()->field(0)->name() == "edge-name");
-  KATANA_LOG_ASSERT(g2->node_schema()->field(0)->name() == "node-name");
+  KATANA_LOG_ASSERT(g2->loaded_edge_schema()->field(0)->name() == "edge-name");
+  KATANA_LOG_ASSERT(g2->loaded_node_schema()->field(0)->name() == "node-name");
 
   // the throwaway type was int64; make sure we didn't alias
   KATANA_LOG_ASSERT(
-      g2->edge_schema()->field(0)->type()->Equals(arrow::int32()));
+      g2->loaded_edge_schema()->field(0)->type()->Equals(arrow::int32()));
   KATANA_LOG_ASSERT(
-      g2->node_schema()->field(0)->type()->Equals(arrow::int32()));
+      g2->loaded_node_schema()->field(0)->type()->Equals(arrow::int32()));
 
   std::shared_ptr<arrow::ChunkedArray> node_property = g2->GetNodeProperty(0);
   std::shared_ptr<arrow::ChunkedArray> edge_property = g2->GetEdgeProperty(0);

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -56,6 +56,10 @@ public:
   katana::Result<std::shared_ptr<arrow::Table>> ReadTable(
       const katana::Uri& uri, const std::vector<int32_t>& column_bitmap);
 
+  /// read only the schema from a parquet file in storage
+  katana::Result<std::shared_ptr<arrow::Schema>> GetSchema(
+      const katana::Uri& uri);
+
   /// read a column part of a table from storage
   /// n.b. support for the `slice` read option is missing here
   ///   \param uri an identifier for a parquet file
@@ -81,6 +85,9 @@ private:
 
   katana::Result<std::shared_ptr<arrow::Table>> FixTable(
       std::shared_ptr<arrow::Table>&& _table);
+
+  katana::Result<std::shared_ptr<arrow::Schema>> FixSchema(
+      const std::shared_ptr<arrow::Schema>& schema);
 
   std::optional<Slice> slice_;
   bool make_cannonical_;

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -180,6 +180,10 @@ public:
   /// Remove all edge properties
   void DropEdgeProperties();
 
+  std::shared_ptr<arrow::Schema> full_node_schema() const;
+
+  std::shared_ptr<arrow::Schema> full_edge_schema() const;
+
   const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
       const {
     return master_nodes_;

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -1,58 +1,70 @@
 #include "RDGCore.h"
 
 #include "RDGPartHeader.h"
+#include "katana/Result.h"
 #include "tsuba/Errors.h"
+#include "tsuba/ParquetReader.h"
 
 namespace {
 
 katana::Result<void>
 UpsertProperties(
     const std::shared_ptr<arrow::Table>& props,
-    std::shared_ptr<arrow::Table>* to_update) {
-  std::shared_ptr<arrow::Table> current = *to_update;
-
-  if (current->num_columns() > 0 && current->num_rows() != props->num_rows()) {
+    std::shared_ptr<arrow::Table>* to_update,
+    std::vector<tsuba::PropStorageInfo>* prop_state) {
+  if (!props->schema()->HasDistinctFieldNames()) {
     return KATANA_ERROR(
-        tsuba::ErrorCode::InvalidArgument, "expected {} rows found {} instead",
-        current->num_rows(), props->num_rows());
+        tsuba::ErrorCode::Exists, "column names must be distinct: {}",
+        fmt::join(props->schema()->field_names(), ", "));
   }
 
-  std::shared_ptr<arrow::Table> next = current;
-
-  if (current->num_columns() == 0 && current->num_rows() == 0) {
-    next = props;
-  } else {
-    const auto& schema = props->schema();
-    int last = current->num_columns();
-
-    for (int i = 0, n = schema->num_fields(); i < n; i++) {
-      auto name = schema->field(i)->name();
-      auto current_col = next->GetColumnByName(name);
-      arrow::Result<std::shared_ptr<arrow::Table>> result;
-      std::string error_context = "insert";
-      if (current_col == nullptr) {
-        // Insert the column, error_context == "insert"
-        result = next->AddColumn(last++, schema->field(i), props->column(i));
-      } else {
-        // Update the column
-        error_context = "update";
-        auto col_names = next->ColumnNames();
-        // Column names are not sorted, but assumed to be less than 100s
-        auto col_it = std::find(col_names.begin(), col_names.end(), name);
-        KATANA_LOG_ASSERT(
-            col_it != col_names.end());  // GetColumnByName != null
-        result = next->SetColumn(
-            std::distance(col_names.begin(), col_it), schema->field(i),
-            props->column(i));
-      }
-      if (!result.ok()) {
-        return KATANA_ERROR(
-            tsuba::ErrorCode::ArrowError, "arrow error {}: {}", error_context,
-            result.status());
-      }
-
-      next = result.ValueOrDie();
+  if (prop_state->empty()) {
+    KATANA_LOG_ASSERT((*to_update)->num_columns() == 0);
+    for (const auto& field : props->fields()) {
+      prop_state->emplace_back(field->name(), field->type());
     }
+    *to_update = props;
+    return katana::ResultSuccess();
+  }
+
+  std::shared_ptr<arrow::Table> next = *to_update;
+
+  if (next->num_columns() > 0 && next->num_rows() != props->num_rows()) {
+    return KATANA_ERROR(
+        tsuba::ErrorCode::InvalidArgument, "expected {} rows found {} instead",
+        next->num_rows(), props->num_rows());
+  }
+
+  int last = next->num_columns();
+
+  for (int i = 0, n = props->num_columns(); i < n; i++) {
+    std::shared_ptr<arrow::Field> field = props->field(i);
+    int current_col = -1;
+
+    auto prop_info_it = std::find_if(
+        prop_state->begin(), prop_state->end(),
+        [&](const tsuba::PropStorageInfo& psi) {
+          return field->name() == psi.name();
+        });
+    if (prop_info_it == prop_state->end()) {
+      prop_info_it = prop_state->insert(
+          prop_info_it, tsuba::PropStorageInfo(field->name(), field->type()));
+    } else if (!prop_info_it->IsAbsent()) {
+      current_col = next->schema()->GetFieldIndex(field->name());
+    }
+
+    if (current_col < 0) {
+      if (next->num_columns() == 0) {
+        next = arrow::Table::Make(arrow::schema({field}), {props->column(i)});
+      } else {
+        next = KATANA_CHECKED_CONTEXT(
+            next->AddColumn(last++, field, props->column(i)), "insert");
+      }
+    } else {
+      next = KATANA_CHECKED_CONTEXT(
+          next->SetColumn(current_col, field, props->column(i)), "update");
+    }
+    prop_info_it->WasModified(field->type());
   }
 
   if (!next->schema()->HasDistinctFieldNames()) {
@@ -69,20 +81,34 @@ UpsertProperties(
 katana::Result<void>
 AddProperties(
     const std::shared_ptr<arrow::Table>& props,
-    std::shared_ptr<arrow::Table>* to_update) {
-  auto col_names = (*to_update)->ColumnNames();
-
-  const auto& schema = props->schema();
-  for (int i = 0, n = schema->num_fields(); i < n; i++) {
-    auto name = schema->field(i)->name();
+    std::shared_ptr<arrow::Table>* to_update,
+    std::vector<tsuba::PropStorageInfo>* prop_state) {
+  for (const auto& field : props->fields()) {
     // Column names are not sorted, but assumed to be less than 100s
-    auto col_it = std::find(col_names.begin(), col_names.end(), name);
-    if (col_it != col_names.end()) {
+    auto prop_info_it = std::find_if(
+        prop_state->begin(), prop_state->end(),
+        [&](const tsuba::PropStorageInfo& psi) {
+          return field->name() == psi.name();
+        });
+
+    if (prop_info_it != prop_state->end()) {
       return KATANA_ERROR(
           tsuba::ErrorCode::Exists, "column names are not distinct");
     }
   }
-  return UpsertProperties(props, to_update);
+  return UpsertProperties(props, to_update, prop_state);
+}
+
+katana::Result<void>
+EnsureTypeLoaded(const katana::Uri& rdg_dir, tsuba::PropStorageInfo* psi) {
+  if (!psi->type()) {
+    auto reader = KATANA_CHECKED(tsuba::ParquetReader::Make());
+    KATANA_LOG_ASSERT(psi->IsAbsent());
+    std::shared_ptr<arrow::Schema> schema =
+        KATANA_CHECKED(reader->GetSchema(rdg_dir.Join(psi->path())));
+    psi->set_type(schema->field(0)->type());
+  }
+  return katana::ResultSuccess();
 }
 
 }  // namespace
@@ -91,22 +117,46 @@ namespace tsuba {
 
 katana::Result<void>
 RDGCore::AddNodeProperties(const std::shared_ptr<arrow::Table>& props) {
-  return AddProperties(props, &node_properties_);
+  return AddProperties(
+      props, &node_properties_, &part_header_.node_prop_info_list());
 }
 
 katana::Result<void>
 RDGCore::AddEdgeProperties(const std::shared_ptr<arrow::Table>& props) {
-  return AddProperties(props, &edge_properties_);
+  return AddProperties(
+      props, &edge_properties_, &part_header_.edge_prop_info_list());
 }
 
 katana::Result<void>
 RDGCore::UpsertNodeProperties(const std::shared_ptr<arrow::Table>& props) {
-  return UpsertProperties(props, &node_properties_);
+  return UpsertProperties(
+      props, &node_properties_, &part_header_.node_prop_info_list());
 }
 
 katana::Result<void>
 RDGCore::UpsertEdgeProperties(const std::shared_ptr<arrow::Table>& props) {
-  return UpsertProperties(props, &edge_properties_);
+  return UpsertProperties(
+      props, &edge_properties_, &part_header_.edge_prop_info_list());
+}
+
+katana::Result<void>
+RDGCore::EnsureNodeTypesLoaded(const katana::Uri& rdg_dir) {
+  for (auto& prop : part_header_.node_prop_info_list()) {
+    KATANA_CHECKED_CONTEXT(
+        EnsureTypeLoaded(rdg_dir, &prop), "property {}",
+        std::quoted(prop.name()));
+  }
+  return katana::ResultSuccess();
+}
+
+katana::Result<void>
+RDGCore::EnsureEdgeTypesLoaded(const katana::Uri& rdg_dir) {
+  for (auto& prop : part_header_.edge_prop_info_list()) {
+    KATANA_CHECKED_CONTEXT(
+        EnsureTypeLoaded(rdg_dir, &prop), "property {}",
+        std::quoted(prop.name()));
+  }
+  return katana::ResultSuccess();
 }
 
 void
@@ -130,32 +180,18 @@ RDGCore::Equals(const RDGCore& other) const {
 
 katana::Result<void>
 RDGCore::RemoveNodeProperty(int i) {
-  auto result = node_properties_->RemoveColumn(i);
-  if (!result.ok()) {
-    return KATANA_ERROR(
-        ErrorCode::ArrowError, "arrow error: {}", result.status());
-  }
+  auto field = node_properties_->field(i);
+  node_properties_ = KATANA_CHECKED(node_properties_->RemoveColumn(i));
 
-  node_properties_ = std::move(result.ValueOrDie());
-
-  part_header_.RemoveNodeProperty(i);
-
-  return katana::ResultSuccess();
+  return part_header_.RemoveNodeProperty(field->name());
 }
 
 katana::Result<void>
 RDGCore::RemoveEdgeProperty(int i) {
-  auto result = edge_properties_->RemoveColumn(i);
-  if (!result.ok()) {
-    return KATANA_ERROR(
-        ErrorCode::ArrowError, "arrow error: {}", result.status());
-  }
+  auto field = edge_properties_->field(i);
+  edge_properties_ = KATANA_CHECKED(edge_properties_->RemoveColumn(i));
 
-  edge_properties_ = std::move(result.ValueOrDie());
-
-  part_header_.RemoveEdgeProperty(i);
-
-  return katana::ResultSuccess();
+  return part_header_.RemoveEdgeProperty(field->name());
 }
 
 }  // namespace tsuba

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -37,6 +37,11 @@ public:
 
   katana::Result<void> RemoveEdgeProperty(int i);
 
+  // type info will be missing for properties that weren't loaded
+  // make sure it's not missing
+  katana::Result<void> EnsureNodeTypesLoaded(const katana::Uri& rdg_dir);
+  katana::Result<void> EnsureEdgeTypesLoaded(const katana::Uri& rdg_dir);
+
   //
   // Accessors and Mutators
   //
@@ -58,10 +63,12 @@ public:
   void drop_node_properties() {
     std::vector<std::shared_ptr<arrow::Array>> empty;
     node_properties_ = arrow::Table::Make(arrow::schema({}), empty, 0);
+    part_header_.set_node_prop_info_list({});
   }
   void drop_edge_properties() {
     std::vector<std::shared_ptr<arrow::Array>> empty;
     edge_properties_ = arrow::Table::Make(arrow::schema({}), empty, 0);
+    part_header_.set_edge_prop_info_list({});
   }
 
   const FileView& topology_file_storage() const {

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -141,21 +141,21 @@ RDGPartHeader::ChangeStorageLocation(
     if (prop.IsAbsent()) {
       KATANA_CHECKED(CopyProperty(&prop, old_location, new_location));
     } else {
-      prop.WasModified();
+      prop.WasModified(prop.type());
     }
   }
   for (PropStorageInfo& prop : edge_prop_info_list_) {
     if (prop.IsAbsent()) {
       KATANA_CHECKED(CopyProperty(&prop, old_location, new_location));
     } else {
-      prop.WasModified();
+      prop.WasModified(prop.type());
     }
   }
   for (PropStorageInfo& prop : part_prop_info_list_) {
     if (prop.IsAbsent()) {
       KATANA_CHECKED(CopyProperty(&prop, old_location, new_location));
     } else {
-      prop.WasModified();
+      prop.WasModified(prop.type());
     }
   }
   topology_path_ = "";

--- a/python/katana/_property_graph.pyx
+++ b/python/katana/_property_graph.pyx
@@ -91,17 +91,17 @@ cdef class PropertyGraphBase:
         """
         return self.topology().num_edges()
 
-    def node_schema(self):
+    def loaded_node_schema(self):
         """
-        Return the `pyarrow` schema for the node properties stored with this graph.
+        Return the `pyarrow` schema for the node properties loaded for this graph.
         """
-        return pyarrow_wrap_schema(self.underlying_property_graph().node_schema())
+        return pyarrow_wrap_schema(self.underlying_property_graph().loaded_node_schema())
 
-    def edge_schema(self):
+    def loaded_edge_schema(self):
         """
-        Return the `pyarrow` schema for the edge properties stored with this graph.
+        Return the `pyarrow` schema for the edge properties loaded for this graph.
         """
-        return pyarrow_wrap_schema(self.underlying_property_graph().edge_schema())
+        return pyarrow_wrap_schema(self.underlying_property_graph().loaded_edge_schema())
 
     @staticmethod
     cdef uint64_t _property_name_to_id(object prop, Schema schema) except -1:
@@ -123,13 +123,13 @@ cdef class PropertyGraphBase:
         """
         Return the index (ID) of a node property specified by name. If an index is provided, it is returned.
         """
-        return PropertyGraph._property_name_to_id(prop, self.node_schema())
+        return PropertyGraph._property_name_to_id(prop, self.loaded_node_schema())
 
     def edge_property_name_to_id(self, prop):
         """
         Return the index (ID) of a edge property specified by name. If an index is provided, it is returned.
         """
-        return PropertyGraph._property_name_to_id(prop, self.edge_schema())
+        return PropertyGraph._property_name_to_id(prop, self.loaded_edge_schema())
 
     def __iter__(self):
         """
@@ -178,7 +178,7 @@ cdef class PropertyGraphBase:
         `get_node_property` should be used unless a chunked array is explicitly needed as non-chunked arrays are much more efficient.
         """
         return pyarrow_wrap_chunked_array(
-            self.underlying_property_graph().GetNodeProperty(PropertyGraph._property_name_to_id(prop, self.node_schema()))
+            self.underlying_property_graph().GetNodeProperty(PropertyGraph._property_name_to_id(prop, self.loaded_node_schema()))
         )
 
     def get_edge_property(self, prop):
@@ -196,7 +196,7 @@ cdef class PropertyGraphBase:
         `get_edge_property` should be used unless a chunked array is explicitly needed as non-chunked arrays are much more efficient.
         """
         return pyarrow_wrap_chunked_array(
-            self.underlying_property_graph().GetEdgeProperty(PropertyGraph._property_name_to_id(prop, self.edge_schema()))
+            self.underlying_property_graph().GetEdgeProperty(PropertyGraph._property_name_to_id(prop, self.loaded_edge_schema()))
         )
 
     def add_node_property(self, table):
@@ -235,13 +235,13 @@ cdef class PropertyGraphBase:
         """
         Remove a node property from the graph by name or index.
         """
-        handle_result_void(self.underlying_property_graph().RemoveNodeProperty(PropertyGraph._property_name_to_id(prop, self.node_schema())))
+        handle_result_void(self.underlying_property_graph().RemoveNodeProperty(PropertyGraph._property_name_to_id(prop, self.loaded_node_schema())))
 
     def remove_edge_property(self, prop):
         """
         Remove an edge property from the graph by name or index.
         """
-        handle_result_void(self.underlying_property_graph().RemoveEdgeProperty(PropertyGraph._property_name_to_id(prop, self.edge_schema())))
+        handle_result_void(self.underlying_property_graph().RemoveEdgeProperty(PropertyGraph._property_name_to_id(prop, self.loaded_edge_schema())))
 
     @property
     def path(self):

--- a/python/katana/cpp/libgalois/graphs/Graph.pxd
+++ b/python/katana/cpp/libgalois/graphs/Graph.pxd
@@ -144,8 +144,8 @@ cdef extern from "katana/Graph.h" namespace "katana" nogil:
 
         GraphTopology& topology()
 
-        shared_ptr[CSchema] node_schema()
-        shared_ptr[CSchema] edge_schema()
+        shared_ptr[CSchema] loaded_node_schema()
+        shared_ptr[CSchema] loaded_edge_schema()
 
         shared_ptr[CTable] node_properties()
         shared_ptr[CTable] edge_properties()

--- a/python/katana/lonestar/analytics/bfs.py
+++ b/python/katana/lonestar/analytics/bfs.py
@@ -121,7 +121,7 @@ def main():
     print("Node {}: {}".format(args.reportNode, graph.get_node_property(args.propertyName)[args.reportNode]))
 
     if not args.noverify:
-        numNodeProperties = len(graph.node_schema())
+        numNodeProperties = len(graph.loaded_node_schema())
         newPropertyId = numNodeProperties - 1
         verify_bfs(graph, args.startNode, newPropertyId)
 

--- a/python/katana/lonestar/analytics/connected_components.py
+++ b/python/katana/lonestar/analytics/connected_components.py
@@ -166,7 +166,7 @@ def main():
     print("Node {}: {}".format(args.reportNode, graph.get_node_property(args.propertyName)[args.reportNode]))
 
     if not args.noverify:
-        numNodeProperties = len(graph.node_schema())
+        numNodeProperties = len(graph.loaded_node_schema())
         newPropertyId = numNodeProperties - 1
         verify_cc(graph, newPropertyId)
 

--- a/python/katana/lonestar/analytics/sssp.py
+++ b/python/katana/lonestar/analytics/sssp.py
@@ -149,7 +149,7 @@ def main():
     print("Node {}: {}".format(args.reportNode, graph.get_node_property(args.propertyName)[args.reportNode]))
 
     if not args.noverify:
-        numNodeProperties = len(graph.node_schema())
+        numNodeProperties = len(graph.loaded_node_schema())
         newPropertyId = numNodeProperties - 1
         verify_sssp(graph, args.startNode, newPropertyId)
 

--- a/python/test/test_cpp_algos.py
+++ b/python/test/test_cpp_algos.py
@@ -109,7 +109,7 @@ def test_bfs(property_graph: PropertyGraph):
 
     bfs(property_graph, start_node, property_name)
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name
@@ -133,7 +133,7 @@ def test_sssp(property_graph: PropertyGraph):
 
     sssp(property_graph, start_node, weight_name, property_name)
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name
@@ -157,7 +157,7 @@ def test_jaccard(property_graph: PropertyGraph):
 
     jaccard(property_graph, compare_node, property_name)
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name
@@ -197,7 +197,7 @@ def test_pagerank(property_graph: PropertyGraph):
 
     pagerank(property_graph, property_name)
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name
@@ -216,7 +216,7 @@ def test_betweenness_centrality_outer(property_graph: PropertyGraph):
 
     betweenness_centrality(property_graph, property_name, 16, BetweennessCentralityPlan.outer())
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name
@@ -233,7 +233,7 @@ def test_betweenness_centrality_level(property_graph: PropertyGraph):
 
     betweenness_centrality(property_graph, property_name, 16, BetweennessCentralityPlan.level())
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name
@@ -395,7 +395,7 @@ def test_busy_wait(property_graph: PropertyGraph):
 
     bfs(property_graph, start_node, property_name)
 
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name

--- a/python/test/test_numba_algos.py
+++ b/python/test/test_numba_algos.py
@@ -11,7 +11,7 @@ def test_bfs(property_graph: PropertyGraph):
 
     bfs_sync_pg(property_graph, start_node, property_name)
 
-    num_node_properties = len(property_graph.node_schema())
+    num_node_properties = len(property_graph.loaded_node_schema())
     new_property_id = num_node_properties - 1
     verify_bfs(property_graph, start_node, new_property_id)
 
@@ -26,7 +26,7 @@ def test_sssp(property_graph):
 
     sssp(property_graph, start_node, weight_name, 6, property_name)
 
-    num_node_properties = len(property_graph.node_schema())
+    num_node_properties = len(property_graph.loaded_node_schema())
     new_property_id = num_node_properties - 1
     verify_sssp(property_graph, start_node, new_property_id)
 

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -13,8 +13,8 @@ from katana.property_graph import PropertyGraph
 def test_load(property_graph):
     assert property_graph.num_nodes() == 29946
     assert property_graph.num_edges() == 43072
-    assert len(property_graph.node_schema()) == 31
-    assert len(property_graph.edge_schema()) == 18
+    assert len(property_graph.loaded_node_schema()) == 31
+    assert len(property_graph.loaded_edge_schema()) == 18
 
 
 def test_write(property_graph):
@@ -25,8 +25,8 @@ def test_write(property_graph):
         property_graph = PropertyGraph(tmpdir)
     assert property_graph.num_nodes() == 29946
     assert property_graph.num_edges() == 43072
-    assert len(property_graph.node_schema()) == 31
-    assert len(property_graph.edge_schema()) == 18
+    assert len(property_graph.loaded_node_schema()) == 31
+    assert len(property_graph.loaded_edge_schema()) == 18
 
     assert property_graph == old_property_graph
 
@@ -41,8 +41,8 @@ def test_commit(property_graph):
         property_graph = PropertyGraph(tmpdir)
     assert property_graph.num_nodes() == 29092
     assert property_graph.num_edges() == 39283
-    assert len(property_graph.node_schema()) == 31
-    assert len(property_graph.edge_schema()) == 19
+    assert len(property_graph.loaded_node_schema()) == 31
+    assert len(property_graph.loaded_edge_schema()) == 19
 
 
 def test_get_edge_dest(property_graph):
@@ -92,10 +92,10 @@ def test_get_node_property_chunked(property_graph):
 
 def test_remove_node_property(property_graph):
     property_graph.remove_node_property(10)
-    assert len(property_graph.node_schema()) == 30
+    assert len(property_graph.loaded_node_schema()) == 30
     property_graph.remove_node_property("length")
-    assert len(property_graph.node_schema()) == 29
-    assert property_graph.node_schema()[4].name == "email"
+    assert len(property_graph.loaded_node_schema()) == 29
+    assert property_graph.loaded_node_schema()[4].name == "email"
 
 
 def test_add_node_property_exception(property_graph):
@@ -108,7 +108,7 @@ def test_add_node_property_exception(property_graph):
 def test_add_node_property(property_graph):
     t = pyarrow.table(dict(new_prop=range(property_graph.num_nodes())))
     property_graph.add_node_property(t)
-    assert len(property_graph.node_schema()) == 32
+    assert len(property_graph.loaded_node_schema()) == 32
     assert property_graph.get_node_property_chunked("new_prop") == pyarrow.chunked_array(
         [range(property_graph.num_nodes())]
     )
@@ -116,10 +116,10 @@ def test_add_node_property(property_graph):
 
 
 def test_upsert_node_property(property_graph):
-    prop = property_graph.node_schema().names[0]
+    prop = property_graph.loaded_node_schema().names[0]
     t = pyarrow.table({prop: range(property_graph.num_nodes())})
     property_graph.upsert_node_property(t)
-    assert len(property_graph.node_schema()) == 31
+    assert len(property_graph.loaded_node_schema()) == 31
     assert property_graph.get_node_property_chunked(prop) == pyarrow.chunked_array([range(property_graph.num_nodes())])
     assert property_graph.get_node_property(prop) == pyarrow.array(range(property_graph.num_nodes()))
 
@@ -142,10 +142,10 @@ def test_get_edge_property_chunked(property_graph):
 
 def test_remove_edge_property(property_graph):
     property_graph.remove_edge_property(7)
-    assert len(property_graph.edge_schema()) == 17
+    assert len(property_graph.loaded_edge_schema()) == 17
     property_graph.remove_edge_property("classYear")
-    assert len(property_graph.edge_schema()) == 16
-    assert property_graph.edge_schema()[3].name == "HAS_CREATOR"
+    assert len(property_graph.loaded_edge_schema()) == 16
+    assert property_graph.loaded_edge_schema()[3].name == "HAS_CREATOR"
 
 
 def test_add_edge_property_exception(property_graph):
@@ -158,7 +158,7 @@ def test_add_edge_property_exception(property_graph):
 def test_add_edge_property(property_graph):
     t = pyarrow.table(dict(new_prop=range(property_graph.num_edges())))
     property_graph.add_edge_property(t)
-    assert len(property_graph.edge_schema()) == 19
+    assert len(property_graph.loaded_edge_schema()) == 19
     assert property_graph.get_edge_property_chunked("new_prop") == pyarrow.chunked_array(
         [range(property_graph.num_edges())]
     )
@@ -166,10 +166,10 @@ def test_add_edge_property(property_graph):
 
 
 def test_upsert_edge_property(property_graph):
-    prop = property_graph.edge_schema().names[0]
+    prop = property_graph.loaded_edge_schema().names[0]
     t = pyarrow.table({prop: range(property_graph.num_edges())})
     property_graph.upsert_edge_property(t)
-    assert len(property_graph.edge_schema()) == 18
+    assert len(property_graph.loaded_edge_schema()) == 18
     assert property_graph.get_edge_property_chunked(prop) == pyarrow.chunked_array([range(property_graph.num_edges())])
     assert property_graph.get_edge_property(prop) == pyarrow.array(range(property_graph.num_edges()))
 

--- a/scripts/bench_python_cpp_algos.py
+++ b/scripts/bench_python_cpp_algos.py
@@ -24,7 +24,7 @@ def time_block(run_name):
 
 
 def check_schema(property_graph: PropertyGraph, property_name):
-    node_schema: Schema = property_graph.node_schema()
+    node_schema: Schema = property_graph.loaded_node_schema()
     num_node_properties = len(node_schema)
     new_property_id = num_node_properties - 1
     assert node_schema.names[new_property_id] == property_name

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -2990,8 +2990,10 @@ struct Gr2Kg : public Conversion {
       }
     }
 
-    katana::gPrint("Edge Schema : ", pg->edge_schema()->ToString(), "\n");
-    katana::gPrint("Node Schema : ", pg->node_schema()->ToString(), "\n");
+    katana::gPrint(
+        "Edge Schema : ", pg->loaded_edge_schema()->ToString(), "\n");
+    katana::gPrint(
+        "Node Schema : ", pg->loaded_node_schema()->ToString(), "\n");
 
     if (auto r = pg->Write(out_file_name, "cmd"); !r) {
       KATANA_LOG_FATAL("Failed to write property file graph: {}", r.error());


### PR DESCRIPTION
As others have noted (@witchel) it is desirable to have type information
for properties that are not loaded. This PR adds that facility along
with some mechanism for the sane management of same.

I elected not to modify our metadata format. Although the metadata
files are surely a logical place for this, I'm loath to change the
format so often. Instead, this code reads the type of columns out of
the parquet files for unloaded properties. This is slower but requires
no metadata changes.

We could always add it to the metadata later as an optimization if this
way of doing things is deemed too slow.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>