### PR TITLE
logging: fix ProgressTracer bug

### DIFF
--- a/scripts/assemble_trace.py
+++ b/scripts/assemble_trace.py
@@ -217,6 +217,8 @@ def assemble_traces(args):
 
     stream = len(args.log) == 0
     for line in fileinput.input(args.log[0] if not stream else ("-",)):
+        if line[0] == '"':
+            continue
         try:
             json_line = json.loads(line.strip())
             trace_id = json_line["trace_id"]


### PR DESCRIPTION
Fixes a small bug when spans are closed by developers via the tracer
Makes assembler script compatible with normal output as well as tracer output