### PR TITLE
Python: Enable developers to collect coverage for Python

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,7 +16,7 @@ ignore_errors=True
 
 [html]
 # Location/directory for html files
-directory=build/pythoncov
+directory=pythoncov
 
 # Title for the report page
 title="Python Code Coverage"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+# This is a configuration file for Coverage.py
+# (i.e., tool that collect code coverage for Python code)
+# https://coverage.readthedocs.io/en/coverage-5.5/config.html
+
+[run]
+# The following option is needed because we are collecting from multiple processes.
+parallel=True
+# https://cython.readthedocs.io/en/latest/src/tutorial/profiling_tutorial.html#enabling-coverage-analysis
+plugins = Cython.Coverage
+
+[report]
+# https://coverage.readthedocs.io/en/coverage-5.5/config.html#report
+show_missing=True
+skip_empty=False
+ignore_errors=True
+
+[html]
+# Location/directory for html files
+directory=build/pythoncov
+
+# Title for the report page
+title="Python Code Coverage"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ cscope.out
 .tags*
 tags
 .ycm_extra_conf.py
+.coverage
 
 # no build files
 /build*

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -40,6 +40,7 @@ dependencies:
  - pygithub
  - pytest
  - pylint=2.8.3
+ - coverage
 
 # The dependencies for pytest-notebook are incomplete, add them manually
  - pytest-notebook

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -120,13 +120,13 @@ sequence of commands to obtain (html) coverage report:
 
 .. code-block::
 
-   export COVERAGE_RCFILE="$SRC_DIR/.coveragerc
-   export COVERAGE_PROCESS_START=$COVERAGE_RCFILE
+   export COVERAGE_RCFILE="$SRC_DIR/.coveragerc"
+   export COVERAGE_PROCESS_START="$COVERAGE_RCFILE"
    $BUILD_DIR/python_env.sh coverage run -m pytest python/test -s
    coverage combine
    coverage html
 
-The output is available in ``$BUILD_DIR/pythoncov``.
+The output is available in ``$(pwd)/pythoncov``.
 
 Debugging
 =========

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -115,12 +115,19 @@ for more options.
 Coverage
 =========
 
-Collecting coverage is enabled for Python.  You can use the following
-sequence of commands to obtain (html) coverage report:
+Collecting coverage is enabled for Python.
+
+Export ``COVERAGE_RCFILE`` before running the build command:
 
 .. code-block::
 
    export COVERAGE_RCFILE="$SRC_DIR/.coveragerc"
+
+Once the build step is done, you can use the following sequence of
+commands to run tests and obtain (html) coverage report:
+
+.. code-block::
+
    export COVERAGE_PROCESS_START="$COVERAGE_RCFILE"
    $BUILD_DIR/python_env.sh coverage run -m pytest python/test -s
    coverage combine

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -112,6 +112,22 @@ See the `pytest-notebook
 documentation <https://pytest-notebook.readthedocs.io/en/latest/user_guide/tutorial_config.html>`_
 for more options.
 
+Coverage
+=========
+
+Collecting coverage is enabled for Python.  You can use the following
+sequence of commands to obtain (html) coverage report:
+
+.. code-block::
+
+   export COVERAGE_RCFILE="$SRC_DIR/.coveragerc
+   export COVERAGE_PROCESS_START=$COVERAGE_RCFILE
+   $BUILD_DIR/python_env.sh coverage run -m pytest python/test -s
+   coverage combine
+   coverage html
+
+The output is available in ``$BUILD_DIR/pythoncov``.
+
 Debugging
 =========
 

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -373,8 +373,6 @@ def cythonize(module_list, *, source_root, **kwargs):
     extension_options = load_lang_config("CXX")
     extension_options["include_dirs"].append(numpy.get_include())
     extension_options["include_dirs"].append(pyarrow.get_include())
-    if os.environ.get("COVERAGE_RCFILE"):
-        extension_options["define_macros"] = [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1")]
 
     if not extension_options["extra_compile_args"]:
         extension_options["extra_compile_args"] = ["-std=c++17", "-Werror"]
@@ -435,7 +433,7 @@ setActiveThreads(1)
         modules,
         nthreads=int(os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "0")),
         language_level="3",
-        compiler_directives={"binding": True, "linetrace": True},
+        compiler_directives={"binding": True},
         **kwargs,
     )
 

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -373,6 +373,8 @@ def cythonize(module_list, *, source_root, **kwargs):
     extension_options = load_lang_config("CXX")
     extension_options["include_dirs"].append(numpy.get_include())
     extension_options["include_dirs"].append(pyarrow.get_include())
+    if os.environ.get("COVERAGE_RCFILE"):
+        extension_options["define_macros"] = [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1")]
 
     if not extension_options["extra_compile_args"]:
         extension_options["extra_compile_args"] = ["-std=c++17", "-Werror"]
@@ -433,7 +435,7 @@ setActiveThreads(1)
         modules,
         nthreads=int(os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "0")),
         language_level="3",
-        compiler_directives={"binding": True},
+        compiler_directives={"binding": True, "linetrace": True},
         **kwargs,
     )
 

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -438,12 +438,22 @@ setActiveThreads(1)
     )
 
 
+def setup_coverage():
+    if os.environ.get("COVERAGE_RCFILE"):
+        # usercustomize.py will initialize coverage for each Python process (but only if COVERAGE_PROCESS_START is set).
+        with open(Path(os.getcwd()) / "python" / "usercustomize.py", 'w') as f:
+            f.write("import coverage\n")
+            f.write("coverage.process_startup()")
+
+
 def setup(*, source_dir, package_name, additional_requires=None, package_data=None, **kwargs):
     package_data = package_data or {}
     # TODO(amp): Dependencies are yet again repeated here. This needs to come from a central deps list.
     requires = ["pyarrow (<3.0)", "numpy", "numba (>=0.50,<1.0a0)"]
     if additional_requires:
         requires.extend(additional_requires)
+
+    setup_coverage()
 
     source_dir = Path(source_dir)
 

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -441,7 +441,7 @@ setActiveThreads(1)
 def setup_coverage():
     if os.environ.get("COVERAGE_RCFILE"):
         # usercustomize.py will initialize coverage for each Python process (but only if COVERAGE_PROCESS_START is set).
-        with open(Path(os.getcwd()) / "python" / "usercustomize.py", 'w') as f:
+        with open(Path(os.getcwd()) / "python" / "usercustomize.py", "w") as f:
             f.write("import coverage\n")
             f.write("coverage.process_startup()")
 

--- a/python/sitecustomize.py
+++ b/python/sitecustomize.py
@@ -1,4 +1,0 @@
-import coverage
-
-# This call will initialize coverage for each Python process (but only if COVERAGE_PROCESS_START is set).
-coverage.process_startup()

--- a/python/sitecustomize.py
+++ b/python/sitecustomize.py
@@ -1,0 +1,4 @@
+import coverage
+
+# This call will initialize coverage for each Python process (but only if COVERAGE_PROCESS_START is set).
+coverage.process_startup()


### PR DESCRIPTION
This includes a basic configuration for coverage.  In case there are multiple processes (or one runs several coverage for several configurations, e.g., disable/enable JIT), coverage would be combined. At the moment, although we enable Cython plugin, pyx files are not part of the report.