### PR TITLE
PropertyGraph::Make option that accepts EntityTypeManagers

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -360,11 +360,15 @@ public:
 
   PropertyGraph(
       katana::GraphTopology&& topo_to_assign,
-      NUMAArray<EntityTypeID> node_entity_type_id,
-      NUMAArray<EntityTypeID> edge_entity_type_id) noexcept
+      NUMAArray<EntityTypeID>&& node_entity_type_id,
+      NUMAArray<EntityTypeID>&& edge_entity_type_id,
+      EntityTypeManager&& node_type_manager,
+      EntityTypeManager&& edge_type_manager) noexcept
       : rdg_(),
         file_(),
         topology_(std::move(topo_to_assign)),
+        node_entity_type_manager_(std::move(node_type_manager)),
+        edge_entity_type_manager_(std::move(edge_type_manager)),
         node_entity_type_id_(std::move(node_entity_type_id)),
         edge_entity_type_id_(std::move(edge_entity_type_id)) {}
 
@@ -390,7 +394,9 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       GraphTopology&& topo_to_assign,
       NUMAArray<EntityTypeID>&& node_entity_type_id,
-      NUMAArray<EntityTypeID>&& edge_entity_type_id);
+      NUMAArray<EntityTypeID>&& edge_entity_type_id,
+      EntityTypeManager&& node_type_manager,
+      EntityTypeManager&& edge_type_manager);
 
   /// \return A copy of this with the same set of properties. The copy shares no
   ///       state with this.

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -2,6 +2,8 @@
 
 #include <sys/mman.h>
 
+#include <utility>
+
 #include "katana/ArrowInterchange.h"
 #include "katana/Iterators.h"
 #include "katana/Logging.h"
@@ -387,10 +389,13 @@ katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
     katana::GraphTopology&& topo_to_assign,
     NUMAArray<EntityTypeID>&& node_entity_type_id,
-    NUMAArray<EntityTypeID>&& edge_entity_type_id) {
+    NUMAArray<EntityTypeID>&& edge_entity_type_id,
+    EntityTypeManager&& node_type_manager,
+    EntityTypeManager&& edge_type_manager) {
   return std::make_unique<katana::PropertyGraph>(
       std::move(topo_to_assign), std::move(node_entity_type_id),
-      std::move(edge_entity_type_id));
+      std::move(edge_entity_type_id), std::move(node_type_manager),
+      std::move(edge_type_manager));
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>


### PR DESCRIPTION
If you are going to pass in arrays of type ids to a Make variant, it
makes sense for it to also accept EntityTypeManagers.