### PR TITLE
logging: add plaintext tracer for debugging

### DIFF
--- a/libgalois/include/katana/SharedMemSys.h
+++ b/libgalois/include/katana/SharedMemSys.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "katana/TextTracer.h"
 #include "katana/config.h"
 
 namespace katana {
@@ -21,7 +22,7 @@ class KATANA_EXPORT SharedMemSys {
   std::unique_ptr<Impl> impl_;
 
 public:
-  SharedMemSys();
+  SharedMemSys(std::unique_ptr<ProgressTracer> tracer = TextTracer::Make());
   ~SharedMemSys();
 
   SharedMemSys(const SharedMemSys&) = delete;

--- a/libgalois/src/SharedMemSys.cpp
+++ b/libgalois/src/SharedMemSys.cpp
@@ -20,11 +20,11 @@
 #include "katana/SharedMemSys.h"
 
 #include "katana/CommBackend.h"
-#include "katana/JSONTracer.h"
 #include "katana/Logging.h"
 #include "katana/Plugin.h"
 #include "katana/SharedMem.h"
 #include "katana/Statistics.h"
+#include "katana/TextTracer.h"
 #include "tsuba/FileStorage.h"
 #include "tsuba/tsuba.h"
 
@@ -39,12 +39,13 @@ struct katana::SharedMemSys::Impl {
   katana::StatManager stat_manager;
 };
 
-katana::SharedMemSys::SharedMemSys() : impl_(std::make_unique<Impl>()) {
+katana::SharedMemSys::SharedMemSys(std::unique_ptr<ProgressTracer> tracer)
+    : impl_(std::make_unique<Impl>()) {
   LoadPlugins();
   if (auto init_good = tsuba::Init(&comm_backend); !init_good) {
     KATANA_LOG_FATAL("tsuba::Init: {}", init_good.error());
   }
-  katana::ProgressTracer::SetProgressTracer(katana::JSONTracer::Make());
+  katana::ProgressTracer::Set(std::move(tracer));
 
   katana::internal::setSysStatManager(&impl_->stat_manager);
 }
@@ -56,7 +57,7 @@ katana::SharedMemSys::~SharedMemSys() {
   if (auto fini_good = tsuba::Fini(); !fini_good) {
     KATANA_LOG_ERROR("tsuba::Fini: {}", fini_good.error());
   }
-  katana::ProgressTracer::GetProgressTracer().Close();
+  katana::GetTracer().Close();
   // This will finalize plugins irreversibly, reinitialization may not work.
   FinalizePlugins();
 }

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -28,6 +28,7 @@ set(sources
         src/ProgressTracer.cpp
         src/Signals.cpp
         src/Strings.cpp
+        src/TextTracer.cpp
         src/URI.cpp
 )
 

--- a/libsupport/include/katana/ProgressTracer.h
+++ b/libsupport/include/katana/ProgressTracer.h
@@ -17,7 +17,7 @@
 /// OpenTracing Overview
 ///
 /// The following classes are based on/from the OpenTracing
-/// specifications which can be found here: https://opentracing.io/docs/overview/
+/// specifications which can be found here: https://opentracing.io/docs/overview/what-is-tracing/
 ///
 /// In short spans are units of work with a defined start and stop point which
 /// we can add timestamped logs to as well as tags for the overall span (or unit of work)
@@ -81,6 +81,12 @@ public:
 };
 using Tags = std::vector<std::pair<std::string, Value>>;
 
+struct HostStats {
+  long nprocs{};
+  long ram_gb{};
+  std::string hostname;
+};
+
 class ProgressScope;
 class ProgressSpan;
 class ProgressContext;
@@ -93,8 +99,13 @@ public:
   ProgressTracer& operator=(const ProgressTracer&) = delete;
   ProgressTracer& operator=(ProgressTracer&&) = delete;
 
-  static ProgressTracer& GetProgressTracer() { return *tracer_; }
-  static void SetProgressTracer(std::unique_ptr<ProgressTracer> tracer);
+  static ProgressTracer& Get() { return *tracer_; }
+  static void Set(std::unique_ptr<ProgressTracer> tracer);
+
+  static uint64_t ParseProcSelfRssBytes();
+  static HostStats GetHostStats();
+  static long GetMaxMem();
+  static std::string GetValue(const Value& value);
 
   // StartActiveSpan creates a new span. If there is not an active span,
   // create a new top-level span. Otherwise, this function creates a child
@@ -153,6 +164,8 @@ private:
   uint32_t num_hosts_;
   std::shared_ptr<ProgressSpan> default_active_span_ = nullptr;
 };
+
+KATANA_EXPORT ProgressTracer& GetTracer();
 
 class KATANA_EXPORT ProgressScope {
 public:

--- a/libsupport/include/katana/TextTracer.h
+++ b/libsupport/include/katana/TextTracer.h
@@ -1,7 +1,6 @@
-#ifndef KATANA_LIBSUPPORT_KATANA_JSONTRACER_H_
-#define KATANA_LIBSUPPORT_KATANA_JSONTRACER_H_
+#ifndef KATANA_LIBSUPPORT_KATANA_TEXTTRACER_H_
+#define KATANA_LIBSUPPORT_KATANA_TEXTTRACER_H_
 
-#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -11,14 +10,10 @@
 
 namespace katana {
 
-using OutputCB = std::function<void(const std::string&)>;
-
-class KATANA_EXPORT JSONTracer : public ProgressTracer {
+class KATANA_EXPORT TextTracer : public ProgressTracer {
 public:
-  static std::unique_ptr<JSONTracer> Make(
+  static std::unique_ptr<TextTracer> Make(
       uint32_t host_id = 0, uint32_t num_hosts = 1);
-  static std::unique_ptr<JSONTracer> Make(
-      uint32_t host_id, uint32_t num_hosts, OutputCB out_callback);
 
   std::shared_ptr<ProgressSpan> StartSpan(
       const std::string& span_name, const ProgressContext& child_of) override;
@@ -29,36 +24,34 @@ public:
   void Close() override {}
 
 private:
-  JSONTracer(uint32_t host_id, uint32_t num_hosts, OutputCB out_callback)
-      : ProgressTracer(host_id, num_hosts), out_callback_(out_callback) {}
+  TextTracer(uint32_t host_id, uint32_t num_hosts)
+      : ProgressTracer(host_id, num_hosts) {}
 
   std::shared_ptr<ProgressSpan> StartSpan(
       const std::string& span_name,
       std::shared_ptr<ProgressSpan> child_of) override;
-
-  OutputCB out_callback_;
 };
 
-class KATANA_EXPORT JSONContext : public ProgressContext {
+class KATANA_EXPORT TextContext : public ProgressContext {
 public:
   std::unique_ptr<ProgressContext> Clone() const noexcept override;
   std::string GetTraceID() const noexcept override { return trace_id_; }
   std::string GetSpanID() const noexcept override { return span_id_; }
 
 private:
-  friend class JSONTracer;
-  friend class JSONSpan;
+  friend class TextTracer;
+  friend class TextSpan;
 
-  JSONContext(const std::string& trace_id, const std::string& span_id)
+  TextContext(const std::string& trace_id, const std::string& span_id)
       : trace_id_(trace_id), span_id_(span_id) {}
 
   std::string trace_id_;
   std::string span_id_;
 };
 
-class KATANA_EXPORT JSONSpan : public ProgressSpan {
+class KATANA_EXPORT TextSpan : public ProgressSpan {
 public:
-  ~JSONSpan() override { Finish(); }
+  ~TextSpan() override { Finish(); }
 
   void SetTags(const Tags& tags) override;
 
@@ -69,25 +62,19 @@ public:
   }
 
 private:
-  friend JSONTracer;
+  friend TextTracer;
 
-  JSONSpan(
-      const std::string& span_name, std::shared_ptr<ProgressSpan> parent,
-      OutputCB out_callback);
-  JSONSpan(
-      const std::string& span_name, const ProgressContext& parent,
-      OutputCB out_callback);
+  TextSpan(const std::string& span_name, std::shared_ptr<ProgressSpan> parent);
+  TextSpan(const std::string& span_name, const ProgressContext& parent);
   static std::shared_ptr<ProgressSpan> Make(
-      const std::string& span_name, std::shared_ptr<ProgressSpan> parent,
-      OutputCB out_callback);
+      const std::string& span_name, std::shared_ptr<ProgressSpan> parent);
   static std::shared_ptr<ProgressSpan> Make(
-      const std::string& span_name, const ProgressContext& parent,
-      OutputCB out_callback);
+      const std::string& span_name, const ProgressContext& parent);
 
   void Close() override;
 
-  JSONContext context_;
-  OutputCB out_callback_;
+  TextContext context_;
+  std::string span_name_;
 };
 
 }  // namespace katana

--- a/libsupport/src/TextTracer.cpp
+++ b/libsupport/src/TextTracer.cpp
@@ -1,0 +1,194 @@
+#include "katana/TextTracer.h"
+
+#include <sys/time.h>
+
+#include <cstring>
+#include <iostream>
+#include <mutex>
+#include <string>
+
+#include <arrow/memory_pool.h>
+
+#include "katana/Random.h"
+#include "katana/Time.h"
+
+namespace {
+
+std::mutex output_mutex;
+
+std::string
+GetHostStatsText() {
+  katana::HostStats host_stats = katana::ProgressTracer::GetHostStats();
+  auto& tracer = katana::ProgressTracer::Get();
+  return fmt::format(
+      "hosts={} hostname={} hardware_threads={} ram_gb={}",
+      tracer.GetNumHosts(), host_stats.hostname, host_stats.nprocs,
+      host_stats.ram_gb);
+}
+
+std::string
+GetTagsText(const katana::Tags& tags) {
+  if (tags.empty()) {
+    return std::string{};
+  }
+  fmt::memory_buffer buf;
+
+  for (uint32_t i = 0; i < tags.size(); i++) {
+    const std::pair<std::string, katana::Value>& tag = tags[i];
+
+    if (i != 0) {
+      fmt::format_to(std::back_inserter(buf), " ");
+    }
+    fmt::format_to(
+        std::back_inserter(buf), "{}={}", tag.first,
+        katana::ProgressTracer::GetValue(tag.second));
+  }
+  return fmt::to_string(buf);
+}
+
+std::string
+BuildText(
+    const std::string& message, const std::string& tag_data,
+    const std::string& host_data) {
+  fmt::memory_buffer buf;
+  uint32_t host_id = katana::ProgressTracer::Get().GetHostID();
+  static auto begin = katana::Now();
+  auto msec_since_begin = katana::UsSince(begin) / 1000;
+
+  fmt::format_to(
+      std::back_inserter(buf),
+      "INFO: host={} ms={} max_mem_gb={:.3f} mem_gb={:.3f} arrow_mem_gb={:.3f}",
+      host_id, msec_since_begin,
+      katana::ProgressTracer::GetMaxMem() / 1024.0 / 1024.0,
+      katana::ProgressTracer::ParseProcSelfRssBytes() / 1024.0 / 1024.0 /
+          1024.0,
+      arrow::default_memory_pool()->bytes_allocated() / 1024.0 / 1024.0 /
+          1024.0);
+  if (!tag_data.empty()) {
+    fmt::format_to(std::back_inserter(buf), " {}", tag_data);
+  }
+  if (!host_data.empty()) {
+    fmt::format_to(std::back_inserter(buf), " {}", host_data);
+  }
+  fmt::format_to(std::back_inserter(buf), " | {}\n", message);
+  return fmt::to_string(buf);
+}
+
+void
+OutputText(const std::string& output) {
+  std::lock_guard<std::mutex> lock(output_mutex);
+  std::cerr << output;
+}
+
+}  // namespace
+
+std::unique_ptr<katana::TextTracer>
+katana::TextTracer::Make(uint32_t host_id, uint32_t num_hosts) {
+  return std::unique_ptr<TextTracer>(new TextTracer(host_id, num_hosts));
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::TextTracer::StartSpan(
+    const std::string& span_name, const katana::ProgressContext& child_of) {
+  return TextSpan::Make(span_name, child_of);
+}
+
+std::string
+katana::TextTracer::Inject(const katana::ProgressContext& ctx) {
+  return ctx.GetTraceID() + "," + ctx.GetSpanID();
+}
+
+std::unique_ptr<katana::ProgressContext>
+katana::TextTracer::Extract(const std::string& carrier) {
+  size_t split = carrier.find(",");
+  if (split == std::string::npos) {
+    return nullptr;
+  } else {
+    std::string trace_id = carrier.substr(0, split);
+    std::string span_id = carrier.substr(split + 1);
+    return std::unique_ptr<TextContext>(new TextContext(trace_id, span_id));
+  }
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::TextTracer::StartSpan(
+    const std::string& span_name,
+    std::shared_ptr<katana::ProgressSpan> child_of) {
+  return TextSpan::Make(span_name, std::move(child_of));
+}
+
+std::unique_ptr<katana::ProgressContext>
+katana::TextContext::Clone() const noexcept {
+  return std::unique_ptr<TextContext>(new TextContext(trace_id_, span_id_));
+}
+
+void
+katana::TextSpan::SetTags(const katana::Tags& tags) {
+  std::string message = "tags for " + span_name_;
+  std::string tags_data = GetTagsText(tags);
+  std::string host_data;
+
+  std::string output_Text = BuildText(message, tags_data, host_data);
+  OutputText(output_Text);
+}
+
+void
+katana::TextSpan::Log(const std::string& message, const katana::Tags& tags) {
+  std::string tags_data = GetTagsText(tags);
+  std::string host_data;
+
+  std::string output_Text = BuildText(message, tags_data, host_data);
+  OutputText(output_Text);
+}
+
+katana::TextSpan::TextSpan(
+    const std::string& span_name, std::shared_ptr<katana::ProgressSpan> parent)
+    : ProgressSpan(parent),
+      context_(TextContext{"0", "0"}),
+      span_name_(span_name) {
+  std::string message = "starting " + span_name;
+  std::string tags_data;
+  std::string host_data;
+  if (parent == nullptr) {
+    host_data = GetHostStatsText();
+  }
+
+  std::string output_Text = BuildText(message, tags_data, host_data);
+  OutputText(output_Text);
+}
+
+katana::TextSpan::TextSpan(
+    const std::string& span_name,
+    [[maybe_unused]] const katana::ProgressContext& parent)
+    : ProgressSpan(nullptr),
+      context_(TextContext{"0", "0"}),
+      span_name_(span_name) {
+  std::string message = "starting " + span_name;
+  std::string tags_data;
+  std::string host_data = GetHostStatsText();
+
+  std::string output_Text = BuildText(message, tags_data, host_data);
+  OutputText(output_Text);
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::TextSpan::Make(
+    const std::string& span_name,
+    std::shared_ptr<katana::ProgressSpan> parent) {
+  return std::shared_ptr<TextSpan>(new TextSpan(span_name, std::move(parent)));
+}
+std::shared_ptr<katana::ProgressSpan>
+katana::TextSpan::Make(
+    const std::string& span_name, const katana::ProgressContext& parent) {
+  return std::shared_ptr<TextSpan>(new TextSpan(span_name, parent));
+}
+
+void
+katana::TextSpan::Close() {
+  std::string message = "finished " + span_name_;
+  std::string tags_data;
+  std::string host_data;
+
+  std::string output_Text = BuildText(message, tags_data, host_data);
+  OutputText(output_Text);
+}

--- a/libsupport/test/tracing.cpp
+++ b/libsupport/test/tracing.cpp
@@ -1,22 +1,22 @@
-#include "katana/JSONTracer.h"
+#include "katana/TextTracer.h"
 
 katana::Result<void>
 CreateError() {
-  katana::ProgressTracer::GetProgressTracer().StartActiveSpan("getting error");
+  auto scope = katana::GetTracer().StartActiveSpan("getting error");
   return KATANA_ERROR(
       katana::ErrorCode::ArrowError, "failed to make fixed size type");
 }
 
 katana::Result<void>
 GetError() {
-  katana::ProgressTracer::GetProgressTracer().StartActiveSpan("passing error");
+  auto scope = katana::GetTracer().StartActiveSpan("passing error");
   return CreateError().error().WithContext("passed along by GetError");
 }
 
 int
 main() {
-  katana::ProgressTracer::SetProgressTracer(katana::JSONTracer::Make());
-  auto& tracer = katana::ProgressTracer::GetProgressTracer();
+  katana::ProgressTracer::Set(katana::TextTracer::Make());
+  auto& tracer = katana::GetTracer();
   auto scope = tracer.StartActiveSpan("first span");
   scope.span().SetTags(
       {{"life", static_cast<uint32_t>(42)},


### PR DESCRIPTION
TextTracer emits human-readable logs for developers trying to debug
TextTracer is not compatible with the tracing or reporting infrastructure