### PR TITLE
Default-constructed EdgeTypeAwareTopology num_nodes() Segfault

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -1118,6 +1118,12 @@ public:
       const PropertyGraph* pg, const EdgeTypeIndex* edge_type_index);
 
   uint64_t num_nodes() const noexcept {
+    // if default constructed, edge_type_index_ is nullptr
+    // TODO(Amber): have the default constructor put edge_type_index_
+    //              in a valid state
+    if (!edge_type_index_) {
+      return adj_indices_.size();
+    }
     // corner case: graph with 0 edges
     if (edge_type_index_->num_unique_types() == 0) {
       KATANA_LOG_DEBUG_ASSERT(num_edges() == 0);


### PR DESCRIPTION
uninitialized edge_type_index unique_ptr results in segfault on deref