### PR TITLE
PropertyGraph: propagate loaded vs unloaded property info to views

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -268,15 +268,20 @@ public:
   struct ReadOnlyPropertyView {
     const PropertyGraph* const_g;
 
-    std::shared_ptr<arrow::Schema> (PropertyGraph::*schema_fn)() const;
+    std::shared_ptr<arrow::Schema> (PropertyGraph::*loaded_schema_fn)() const;
+    std::shared_ptr<arrow::Schema> (PropertyGraph::*full_schema_fn)() const;
     std::shared_ptr<arrow::ChunkedArray> (PropertyGraph::*property_fn_int)(
         int i) const;
     std::shared_ptr<arrow::ChunkedArray> (PropertyGraph::*property_fn_str)(
         const std::string& str) const;
     int32_t (PropertyGraph::*property_num_fn)() const;
 
-    std::shared_ptr<arrow::Schema> schema() const {
-      return (const_g->*schema_fn)();
+    std::shared_ptr<arrow::Schema> loaded_schema() const {
+      return (const_g->*loaded_schema_fn)();
+    }
+
+    std::shared_ptr<arrow::Schema> full_schema() const {
+      return (const_g->*full_schema_fn)();
     }
 
     std::shared_ptr<arrow::ChunkedArray> GetProperty(int i) const {
@@ -313,7 +318,12 @@ public:
     Result<void> (PropertyGraph::*remove_property_int)(int i);
     Result<void> (PropertyGraph::*remove_property_str)(const std::string& str);
 
-    std::shared_ptr<arrow::Schema> schema() const { return ropv.schema(); }
+    std::shared_ptr<arrow::Schema> loaded_schema() const {
+      return ropv.loaded_schema();
+    }
+    std::shared_ptr<arrow::Schema> full_schema() const {
+      return ropv.full_schema();
+    }
 
     std::shared_ptr<arrow::ChunkedArray> GetProperty(int i) const {
       return ropv.GetProperty(i);
@@ -818,7 +828,8 @@ public:
         .ropv =
             {
                 .const_g = this,
-                .schema_fn = &PropertyGraph::loaded_node_schema,
+                .loaded_schema_fn = &PropertyGraph::loaded_node_schema,
+                .full_schema_fn = &PropertyGraph::full_node_schema,
                 .property_fn_int = &PropertyGraph::GetNodeProperty,
                 .property_fn_str = &PropertyGraph::GetNodeProperty,
                 .property_num_fn = &PropertyGraph::GetNumNodeProperties,
@@ -833,7 +844,8 @@ public:
   ReadOnlyPropertyView NodeReadOnlyPropertyView() const {
     return ReadOnlyPropertyView{
         .const_g = this,
-        .schema_fn = &PropertyGraph::loaded_node_schema,
+        .loaded_schema_fn = &PropertyGraph::loaded_node_schema,
+        .full_schema_fn = &PropertyGraph::full_node_schema,
         .property_fn_int = &PropertyGraph::GetNodeProperty,
         .property_fn_str = &PropertyGraph::GetNodeProperty,
         .property_num_fn = &PropertyGraph::GetNumNodeProperties,
@@ -845,7 +857,8 @@ public:
         .ropv =
             {
                 .const_g = this,
-                .schema_fn = &PropertyGraph::loaded_edge_schema,
+                .loaded_schema_fn = &PropertyGraph::loaded_edge_schema,
+                .full_schema_fn = &PropertyGraph::full_edge_schema,
                 .property_fn_int = &PropertyGraph::GetEdgeProperty,
                 .property_fn_str = &PropertyGraph::GetEdgeProperty,
                 .property_num_fn = &PropertyGraph::GetNumEdgeProperties,
@@ -860,7 +873,8 @@ public:
   ReadOnlyPropertyView EdgeReadOnlyPropertyView() const {
     return ReadOnlyPropertyView{
         .const_g = this,
-        .schema_fn = &PropertyGraph::loaded_edge_schema,
+        .loaded_schema_fn = &PropertyGraph::loaded_edge_schema,
+        .full_schema_fn = &PropertyGraph::full_edge_schema,
         .property_fn_int = &PropertyGraph::GetEdgeProperty,
         .property_fn_str = &PropertyGraph::GetEdgeProperty,
         .property_num_fn = &PropertyGraph::GetNumEdgeProperties,

--- a/tools/graph-convert/Transforms.cpp
+++ b/tools/graph-convert/Transforms.cpp
@@ -11,12 +11,12 @@ ApplyTransform(
     katana::PropertyGraph::MutablePropertyView view,
     katana::ColumnTransformer* transform) {
   int cur_field = 0;
-  int num_fields = view.schema()->num_fields();
+  int num_fields = view.loaded_schema()->num_fields();
   std::vector<std::shared_ptr<arrow::Field>> new_fields;
   std::vector<std::shared_ptr<arrow::ChunkedArray>> new_columns;
 
   while (cur_field < num_fields) {
-    auto field = view.schema()->field(cur_field);
+    auto field = view.loaded_schema()->field(cur_field);
     if (!transform->Matches(field.get())) {
       ++cur_field;
       continue;
@@ -33,7 +33,7 @@ ApplyTransform(
 
     // Reread num_fields from view.schema rather than caching schema() value
     // because RemoveProperty may have updated view itself.
-    num_fields = view.schema()->num_fields();
+    num_fields = view.loaded_schema()->num_fields();
 
     auto [new_field, new_column] = (*transform)(field.get(), property.get());
 


### PR DESCRIPTION
In my earlier change I missed these changes, and it turns out cases
where reasoning about what's loaded and what's not is important though
these classes.

Enterprise fix is in https://github.com/KatanaGraph/katana-enterprise/pull/1701

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>