### PR TITLE
[KAT-1033, KAT-146] python: Implement more input formats and types.

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -41,6 +41,7 @@ dependencies:
  - pytest
  - pylint=2.8.3
  - coverage
+ - pandas
 
 # The dependencies for pytest-notebook are incomplete, add them manually
  - pytest-notebook

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -129,6 +129,7 @@ outputs:
       requires:
         - jupyter
         - pytest
+        - pandas
 
         # The dependencies for pytest-notebook are incomplete, add them manually
         - pytest-notebook

--- a/python/katana/local/_graph.pxd
+++ b/python/katana/local/_graph.pxd
@@ -2,7 +2,7 @@ from cython import final
 
 from libc.stdint cimport uint64_t
 from libcpp.memory cimport shared_ptr
-from pyarrow.lib cimport Schema
+from pyarrow.lib cimport CTable, Schema
 
 from katana.cpp.libgalois.graphs.Graph cimport GraphTopology, RDGLoadOptions, _PropertyGraph
 
@@ -17,6 +17,9 @@ cdef class GraphBase:
 
     @staticmethod
     cdef uint64_t _property_name_to_id(object prop, Schema schema) except -1
+
+    @staticmethod
+    cdef shared_ptr[CTable] _convert_table(object table, dict kwargs) except *
 
     @final
     cdef const GraphTopology* topology(PropertyGraphInterface)

--- a/python/katana/local/convert_graph.py
+++ b/python/katana/local/convert_graph.py
@@ -1,0 +1,114 @@
+from typing import Collection, Dict, Optional, Union
+
+import numba
+import numpy as np
+
+import katana.local
+from katana.native_interfacing.buffer_access import to_numpy
+
+
+def from_adjacency_matrix(adjacency: np.ndarray, property_name: str = "weight") -> katana.local.Graph:
+    """
+    Convert an adjacency matrix with shape (n_edges, n_edges) into a :py:class:`~katana.local.Graph` with the
+    non-zero values as an edge weight property.
+
+    This preserves node IDs, but not edge IDs.
+    """
+    sources, destinations = adjacency.nonzero()
+    weights = adjacency[sources, destinations]
+
+    return from_edge_list_arrays(sources, destinations, {property_name: weights})
+
+
+def from_edge_list_matrix(edges: np.ndarray) -> katana.local.Graph:
+    """
+    Convert an edge list with shape (n_edges, 2) into a :py:class:`~katana.local.Graph`.
+
+    This preserves node IDs, but not edge IDs.
+    """
+    if len(edges.shape) != 2 or edges.shape[1] != 2:
+        raise TypeError("edges must have shape (n_edges, 2).")
+
+    return from_edge_list_arrays(edges[:, 0], edges[:, 1])
+
+
+@numba.njit()
+def _fill_indices(sort_order: np.ndarray, sources: np.ndarray, indices: np.ndarray):
+    last_source = 0
+    for source_index, edge_index in enumerate(sort_order):
+        source = sources[source_index]
+        if source != last_source:
+            for j in range(last_source, source):
+                indices[j] = edge_index
+            last_source = source
+    for j in range(last_source, len(indices)):
+        indices[j] = len(sources)
+
+
+def from_edge_list_arrays(
+    sources: np.ndarray, destinations: np.ndarray, property_dict: Dict[str, np.ndarray] = None, **properties: np.ndarray
+) -> katana.local.Graph:
+    """
+    Convert an edge list represented as two parallel arrays into a :py:class:`~katana.local.Graph`.
+
+    This preserves node IDs, but not edge IDs.
+    """
+    sources = to_numpy(sources)
+    destinations = to_numpy(destinations)
+
+    if len(sources.shape) != 1:
+        raise TypeError("sources must be a 1-d array")
+    if len(destinations.shape) != 1:
+        raise TypeError("destinations must be a 1-d array")
+
+    n_edges = len(sources)
+
+    if not n_edges:
+        raise ValueError("Must have at least one edge")
+
+    if len(destinations) != n_edges:
+        raise ValueError("Sources and destinations must have the same length")
+
+    if property_dict is not None:
+        properties.update(property_dict)
+
+    for name, prop in properties.items():
+        if len(prop) != n_edges:
+            raise ValueError(f"{name} does not have length equal to sources.")
+
+    n_nodes = max(np.max(sources), np.max(destinations)) + 1
+
+    sort_order = sources.argsort()
+
+    csr_destinations = destinations[sort_order]
+    csr_indices = np.empty(n_nodes, dtype=np.uint64)
+    _fill_indices(sort_order, sources, csr_indices)
+
+    graph = katana.local.Graph.from_csr(csr_indices, csr_destinations)
+    if properties:
+        graph.add_edge_property(properties)
+    return graph
+
+
+def from_edge_list_dataframe(
+    df,
+    source_column: Union[str, int] = "source",
+    destination_column: Union[str, int] = "destination",
+    property_columns: Optional[Collection[Union[str, int]]] = None,
+):
+    """
+    Convert an edge list in the form of a dataframe-like object into a :py:class:`~katana.local.Graph` with edge
+    properties.
+
+    :param df: The edge list and edge properties.
+    :type df: A data frame like type, such as a `pandas.DataFrame` or even a dict of numpy arrays.
+    :param source_column: The name or ID of the column which holds edge sources.
+    :param destination_column: The name or ID of the column which holds edge destinations.
+    :param property_columns: The names or IDs of columns which should be used as edge properties. If this is ``None``,
+        use all columns other than sources and destinations specified above.
+    """
+    if property_columns is None:
+        property_columns = set(df) - {source_column, destination_column}
+
+    edge_properties = {col_name: df[col_name] for col_name in property_columns}
+    return from_edge_list_arrays(df[source_column], df[destination_column], **edge_properties)

--- a/python/katana/local/convert_graph.py
+++ b/python/katana/local/convert_graph.py
@@ -9,7 +9,7 @@ from katana.native_interfacing.buffer_access import to_numpy
 
 def from_adjacency_matrix(adjacency: np.ndarray, property_name: str = "weight") -> katana.local.Graph:
     """
-    Convert an adjacency matrix with shape (n_edges, n_edges) into a :py:class:`~katana.local.Graph` with the
+    Convert an adjacency matrix with shape (n_nodes, n_nodes) into a :py:class:`~katana.local.Graph` with the
     non-zero values as an edge weight property.
 
     This preserves node IDs, but not edge IDs.

--- a/python/katana/native_interfacing/buffer_access.pxd
+++ b/python/katana/native_interfacing/buffer_access.pxd
@@ -16,3 +16,7 @@ cdef class UntypedBufferAccess:
 
     cdef inline object dtype(self):
         return self._numpy_dtype
+
+
+cpdef to_numpy(v)
+cpdef to_pyarrow(v)

--- a/python/katana/native_interfacing/buffer_access.pyx
+++ b/python/katana/native_interfacing/buffer_access.pyx
@@ -1,4 +1,5 @@
 import numpy
+import pyarrow
 
 from cpython.buffer cimport PyBUF_CONTIG, PyBuffer_Release, PyObject_CheckBuffer, PyObject_GetBuffer
 
@@ -24,3 +25,40 @@ cdef class UntypedBufferAccess:
 
     def empty_like(self, *args, **kwds):
         return numpy.empty(*args, dtype=self._numpy_dtype, **kwds)
+
+
+cpdef to_numpy(v):
+    """
+    Convert a value to numpy using it's own conversion methods if possible.
+
+    This tries four different ways to convert:
+
+    1. If ``v`` is a numpy array already, return it.
+    2. If ``v`` has a method ``to_numpy``, call it and return the result. (supports pyarrow, pandas, etc.)
+    3. If ``v`` has a method ``as_numpy``, call it and return the result. (supports tensorflow, etc.)
+    3. Call `numpy.array` and return the result.
+
+    In all cases, this function attempts to avoid a copy, but does not guarantee it. The result should be treated as
+    immutable in most cases.
+    """
+    if isinstance(v, numpy.ndarray):
+        return v
+    if hasattr(v, "to_numpy"):
+        return v.to_numpy()
+    if hasattr(v, "as_numpy"):
+        return v.as_numpy()
+    return numpy.array(v, copy=False)
+
+
+cpdef to_pyarrow(v):
+    """
+    Convert an array to pyarrow.
+
+    This tries two different ways to convert:
+
+    1. If ``v`` is a pyarrow array already, return it.
+    3. Call `pyarrow.array` and return the result.
+    """
+    if isinstance(v, pyarrow.Array):
+        return v
+    return pyarrow.array(v)

--- a/python/test/test_convert_graph.py
+++ b/python/test/test_convert_graph.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pandas
+import pytest
+
+from katana.local.convert_graph import (
+    from_adjacency_matrix,
+    from_edge_list_arrays,
+    from_edge_list_dataframe,
+    from_edge_list_matrix,
+)
+
+
+def test_adjacency_matrix():
+    g = from_adjacency_matrix(np.array([[0, 1, 0], [0, 0, 2], [3, 0, 0]]))
+    assert [g.edges(n) for n in g] == [range(0, 1), range(1, 2), range(2, 3)]
+    assert [g.get_edge_dest(i) for i in range(g.num_edges())] == [1, 2, 0]
+    assert list(g.get_edge_property("weight").to_numpy()) == [1, 2, 3]
+
+
+def test_trivial_arrays():
+    g = from_edge_list_arrays(np.array([0, 1, 10]), np.array([1, 2, 0]))
+    assert [g.edges(n) for n in g] == [
+        range(0, 1),
+        range(1, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 3),
+    ]
+    assert [g.get_edge_dest(i) for i in range(g.num_edges())] == [1, 2, 0]
+
+
+def test_properties_arrays():
+    g = from_edge_list_arrays(np.array([0, 1, 10]), np.array([1, 2, 0]), prop=np.array([1, 2, 3]))
+    assert [g.edges(n) for n in g] == [
+        range(0, 1),
+        range(1, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 3),
+    ]
+    assert [g.get_edge_dest(i) for i in range(g.num_edges())] == [1, 2, 0]
+    assert list(g.get_edge_property("prop").to_numpy()) == [1, 2, 3]
+
+
+def test_trivial_matrix():
+    g = from_edge_list_matrix(np.array([[0, 1], [1, 2], [10, 0]]))
+    assert [g.edges(n) for n in g] == [
+        range(0, 1),
+        range(1, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 3),
+    ]
+    assert [g.get_edge_dest(i) for i in range(g.num_edges())] == [1, 2, 0]
+
+
+def test_arrays_bad_arguments():
+    with pytest.raises(TypeError):
+        from_edge_list_arrays(np.array([[0, 0], [1, 0]]), np.array([1, 2, 0]))
+    with pytest.raises(TypeError):
+        from_edge_list_arrays(np.array([1, 2, 0]), np.array([[0, 0], [1, 0]]))
+    with pytest.raises(ValueError):
+        from_edge_list_arrays(np.array([1, 2, 0]), np.array([0, 0, 1, 0]))
+    with pytest.raises(ValueError):
+        from_edge_list_arrays(np.array([]), np.array([]))
+
+
+def test_matrix_bad_arguments():
+    with pytest.raises(TypeError):
+        from_edge_list_matrix(np.array([1, 2, 0]))
+    with pytest.raises(TypeError):
+        from_edge_list_matrix(np.array([[0, 0, 1], [1, 0, 3]]))
+
+
+def test_dataframe():
+    g = from_edge_list_dataframe(pandas.DataFrame(dict(source=[0, 1, 10], destination=[1, 2, 0], prop=[1, 2, 3])))
+    assert [g.edges(n) for n in g] == [
+        range(0, 1),
+        range(1, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 2),
+        range(2, 3),
+    ]
+    assert [g.get_edge_dest(i) for i in range(g.num_edges())] == [1, 2, 0]
+    assert list(g.get_edge_property("prop").to_numpy()) == [1, 2, 3]


### PR DESCRIPTION
After: https://github.com/KatanaGraph/katana-enterprise/pull/1718

This PR allows converting external formats to Katana local graphs. It does not provide a super clean API for it. I will do that in a separate PR. This just implements the features. Currently they are accessible as `katana.local.convert_graph.from_*`, exactly how to expose them to the user is open for discussion. This is not a final placement.

This PR also enables passing many more types to `add_*_property` (and `upsert_*`) making it easier to add properties from many sources such as data frames or even keyword parameters. The user no longer needs to manually create a `pyarrow.Table`.
