### PR TITLE
Add function to get a copy of the type manager in PropertyGraph

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -431,6 +431,14 @@ public:
     return edge_entity_type_id_.data();
   }
 
+  const EntityTypeManager& GetNodeTypeManager() const {
+    return node_entity_type_manager_;
+  }
+
+  const EntityTypeManager& GetEdgeTypeManager() const {
+    return edge_entity_type_manager_;
+  }
+
   const std::string& rdg_dir() const { return rdg_.rdg_dir().string(); }
 
   uint32_t partition_id() const { return rdg_.partition_id(); }


### PR DESCRIPTION
When we construct graphs from other graphs we might want to just copy the type manager. 