### PR TITLE
Implement type support in RDGSlice

### DIFF
--- a/libtsuba/include/tsuba/RDGSlice.h
+++ b/libtsuba/include/tsuba/RDGSlice.h
@@ -47,6 +47,8 @@ public:
   const std::shared_ptr<arrow::Table>& node_properties() const;
   const std::shared_ptr<arrow::Table>& edge_properties() const;
   const FileView& topology_file_storage() const;
+  const FileView& node_entity_type_id_array_file_storage() const;
+  const FileView& edge_entity_type_id_array_file_storage() const;
 
 private:
   static katana::Result<RDGSlice> Make(


### PR DESCRIPTION
Mirror the type support in RDG, but load only a slice of the type id arrays, just like with the topology array in RDGSlice.

Follows #403 