### PR TITLE
Python analytics code blocks

### DIFF
--- a/python/katana/local/analytics/_betweenness_centrality.pyx
+++ b/python/katana/local/analytics/_betweenness_centrality.pyx
@@ -131,13 +131,8 @@ cdef class BetweennessCentralityPlan(Plan):
 def betweenness_centrality(PropertyGraph pg, str output_property_name, sources = None,
              BetweennessCentralityPlan plan = BetweennessCentralityPlan()):
     """
-
-    Description
-    -----------
     Betweenness centrality measures the extent to which a vertex lies on paths between other vertices. Vertices with high betweenness may have considerable influence within a network by virtue of their control over information passing between others.
     
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
@@ -147,9 +142,8 @@ def betweenness_centrality(PropertyGraph pg, str output_property_name, sources =
     :type plan: BetweennessCentralityPlan
     :param plan: The execution plan to use.
 
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_betweenness_centrality.pyx
+++ b/python/katana/local/analytics/_betweenness_centrality.pyx
@@ -25,7 +25,7 @@ from libcpp.vector cimport vector
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -55,7 +55,7 @@ cdef extern from "katana/analytics/betweenness_centrality/betweenness_centrality
 
     Result[void] BetweennessCentrality(_PropertyGraph* pg, string output_property_name, const BetweennessCentralitySources& sources, _BetweennessCentralityPlan plan)
 
-    # std_result[void] BetweennessCentralityAssertValid(Graph* pg, string output_property_name)
+    # std_result[void] BetweennessCentralityAssertValid(PropertyGraph* pg, string output_property_name)
 
     cppclass _BetweennessCentralityStatistics "katana::analytics::BetweennessCentralityStatistics":
         float max_centrality
@@ -128,10 +128,17 @@ cdef class BetweennessCentralityPlan(Plan):
         return BetweennessCentralityPlan.make(_BetweennessCentralityPlan.Level())
 
 
-def betweenness_centrality(Graph pg, str output_property_name, sources = None,
+def betweenness_centrality(PropertyGraph pg, str output_property_name, sources = None,
              BetweennessCentralityPlan plan = BetweennessCentralityPlan()):
     """
-    :type pg: katana.local.Graph
+
+    Description
+    -----------
+    Betweenness centrality measures the extent to which a vertex lies on paths between other vertices. Vertices with high betweenness may have considerable influence within a network by virtue of their control over information passing between others.
+    
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
     :param output_property_name: The output property to write path lengths into. This property must not already exist.
@@ -139,6 +146,25 @@ def betweenness_centrality(Graph pg, str output_property_name, sources = None,
     :param sources: Only process some sources, producing an approximate betweenness centrality. If this is a list of node IDs process those source nodes; if this is an int process that number of source nodes.
     :type plan: BetweennessCentralityPlan
     :param plan: The execution plan to use.
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        g = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import betweenness_centrality, BetweennessCentralityPlan, BetweennessCentralityStatistics
+        property_name="betweenness_centrality"
+        betweenness_centrality(g, property_name, 16, BetweennessCentralityPlan.outer())
+        stats = BetweennessCentralityStatistics(g, property_name)
+
+        print("Min Centrality:", stats.min_centrality)
+        print("Max Centrality:", stats.max_centrality)
+        print("Average Centrality:", stats.average_centrality)
+    
     """
     output_property_name_bytes = bytes(output_property_name, "utf-8")
     output_property_name_cstr = <string>output_property_name_bytes
@@ -169,7 +195,7 @@ cdef class BetweennessCentralityStatistics:
     """
     cdef _BetweennessCentralityStatistics underlying
 
-    def __init__(self, Graph pg, str output_property_name):
+    def __init__(self, PropertyGraph pg, str output_property_name):
         output_property_name_bytes = bytes(output_property_name, "utf-8")
         output_property_name_cstr = <string> output_property_name_bytes
         with nogil:

--- a/python/katana/local/analytics/_bfs.pyx
+++ b/python/katana/local/analytics/_bfs.pyx
@@ -161,7 +161,6 @@ cdef class BfsPlan(Plan):
 
 def bfs(PropertyGraph pg, uint32_t start_node, str output_property_name, BfsPlan plan = BfsPlan()):
     """
-    
     Compute the Breadth-First Search parents on `pg` using `start_node` as the source. The computed parents are
     written to the property `output_property_name`.
 

--- a/python/katana/local/analytics/_bfs.pyx
+++ b/python/katana/local/analytics/_bfs.pyx
@@ -161,6 +161,7 @@ cdef class BfsPlan(Plan):
 
 def bfs(PropertyGraph pg, uint32_t start_node, str output_property_name, BfsPlan plan = BfsPlan()):
     """
+    
     Compute the Breadth-First Search parents on `pg` using `start_node` as the source. The computed parents are
     written to the property `output_property_name`.
 

--- a/python/katana/local/analytics/_bfs.pyx
+++ b/python/katana/local/analytics/_bfs.pyx
@@ -27,7 +27,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -159,12 +159,17 @@ cdef class BfsPlan(Plan):
         return BfsPlan.make(_BfsPlan.SynchronousDirectOpt(alpha, beta))
 
 
-def bfs(Graph pg, uint32_t start_node, str output_property_name, BfsPlan plan = BfsPlan()):
+def bfs(PropertyGraph pg, uint32_t start_node, str output_property_name, BfsPlan plan = BfsPlan()):
     """
+    
+    Description
+    -----------
     Compute the Breadth-First Search parents on `pg` using `start_node` as the source. The computed parents are
     written to the property `output_property_name`.
 
-    :type pg: katana.local.Graph
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type start_node: Node ID
     :param start_node: The source node.
@@ -172,13 +177,30 @@ def bfs(Graph pg, uint32_t start_node, str output_property_name, BfsPlan plan = 
     :param output_property_name: The output property to write path lengths into. This property must not already exist.
     :type plan: BfsPlan
     :param plan: The execution plan to use.
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import bfs, BfsStatistics
+        property_name="bfs"
+        start_node = 0
+        bfs(property_graph, start_node, property_name)
+        stats = BfsStatistics(property_graph, property_name)
+        print("Number of reached nodes:", stats.n_reached_nodes)
+
     """
     output_property_name_bytes = bytes(output_property_name, "utf-8")
     output_property_name_cstr = <string>output_property_name_bytes
     with nogil:
         handle_result_void(Bfs(pg.underlying_property_graph(), start_node, output_property_name_cstr, plan.underlying_))
 
-def bfs_assert_valid(Graph pg, uint32_t start_node, str property_name):
+def bfs_assert_valid(PropertyGraph pg, uint32_t start_node, str property_name):
     """
     Raise an exception if the BFS results in `pg` appear to be incorrect. This is not an
     exhaustive check, just a sanity check.
@@ -202,7 +224,7 @@ cdef class BfsStatistics:
     """
     cdef _BfsStatistics underlying
 
-    def __init__(self, Graph pg, str property_name):
+    def __init__(self, PropertyGraph pg, str property_name):
         output_property_name_bytes = bytes(property_name, "utf-8")
         output_property_name_cstr = <string> output_property_name_bytes
         with nogil:

--- a/python/katana/local/analytics/_bfs.pyx
+++ b/python/katana/local/analytics/_bfs.pyx
@@ -161,14 +161,9 @@ cdef class BfsPlan(Plan):
 
 def bfs(PropertyGraph pg, uint32_t start_node, str output_property_name, BfsPlan plan = BfsPlan()):
     """
-    
-    Description
-    -----------
     Compute the Breadth-First Search parents on `pg` using `start_node` as the source. The computed parents are
     written to the property `output_property_name`.
 
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type start_node: Node ID
@@ -178,9 +173,8 @@ def bfs(PropertyGraph pg, uint32_t start_node, str output_property_name, BfsPlan
     :type plan: BfsPlan
     :param plan: The execution plan to use.
 
-    Examples
-    --------
     .. code-block:: python
+
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_connected_components.pyx
+++ b/python/katana/local/analytics/_connected_components.pyx
@@ -247,12 +247,8 @@ cdef class ConnectedComponentsPlan(Plan):
 def connected_components(PropertyGraph pg, str output_property_name,
                          ConnectedComponentsPlan plan = ConnectedComponentsPlan()) -> int:
     """
-    Description
-    -----------
     Compute the Connected-components for `pg`. `pg` must be symmetric.
 
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
@@ -260,9 +256,8 @@ def connected_components(PropertyGraph pg, str output_property_name,
     :type plan: ConnectedComponentsPlan
     :param plan: The execution plan to use. Defaults to heuristically selecting the plan.
     
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_independent_set.pyx
+++ b/python/katana/local/analytics/_independent_set.pyx
@@ -124,14 +124,10 @@ cdef class IndependentSetPlan(Plan):
 def independent_set(PropertyGraph pg, str output_property_name,
              IndependentSetPlan plan = IndependentSetPlan()):
     """
-    Description
-    -----------
     Find a maximal (not the maximum) independent set in the graph and create an indicator property that is true for
     elements of the independent set. The graph must be symmetric. The property named output_property_name is created by
     this function and may not exist before the call. The created property has type uint8_t.
 
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
@@ -139,9 +135,8 @@ def independent_set(PropertyGraph pg, str output_property_name,
     :type plan: IndependentSetPlan
     :param plan: The execution plan to use.
     
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_independent_set.pyx
+++ b/python/katana/local/analytics/_independent_set.pyx
@@ -25,7 +25,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -121,20 +121,37 @@ cdef class IndependentSetPlan(Plan):
         return IndependentSetPlan.make(_IndependentSetPlan.EdgeTiledPriority())
 
 
-def independent_set(Graph pg, str output_property_name,
+def independent_set(PropertyGraph pg, str output_property_name,
              IndependentSetPlan plan = IndependentSetPlan()):
     """
+    Description
+    -----------
     Find a maximal (not the maximum) independent set in the graph and create an indicator property that is true for
     elements of the independent set. The graph must be symmetric. The property named output_property_name is created by
     this function and may not exist before the call. The created property has type uint8_t.
 
-
-    :type pg: katana.local.Graph
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
     :param output_property_name: The output property to write path lengths into. This property must not already exist.
     :type plan: IndependentSetPlan
     :param plan: The execution plan to use.
+    
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import independent_set, IndependentSetStatistics
+        independent_set(property_graph, "output")
+        IndependentSetStatistics(property_graph, "output")
+
     """
     output_property_name_bytes = bytes(output_property_name, "utf-8")
     output_property_name_cstr = <string>output_property_name_bytes
@@ -142,7 +159,7 @@ def independent_set(Graph pg, str output_property_name,
         handle_result_void(IndependentSet(pg.underlying_property_graph(), output_property_name_cstr, plan.underlying_))
 
 
-def independent_set_assert_valid(Graph pg, str output_property_name):
+def independent_set_assert_valid(PropertyGraph pg, str output_property_name):
     """
     Raise an exception if the Independent Set results in `pg` are invalid. This is not an exhaustive check, just a
     sanity check.
@@ -168,7 +185,7 @@ cdef class IndependentSetStatistics:
     """
     cdef _IndependentSetStatistics underlying
 
-    def __init__(self, Graph pg, str output_property_name):
+    def __init__(self, PropertyGraph pg, str output_property_name):
         output_property_name_bytes = bytes(output_property_name, "utf-8")
         output_property_name_cstr = <string> output_property_name_bytes
         with nogil:

--- a/python/katana/local/analytics/_jaccard.pyx
+++ b/python/katana/local/analytics/_jaccard.pyx
@@ -135,12 +135,8 @@ cdef class JaccardPlan(Plan):
 def jaccard(PropertyGraph pg, size_t compare_node, str output_property_name,
             JaccardPlan plan = JaccardPlan()):
     """
-    Description
-    -----------
     Compute the Jaccard Similarity between `compare_node` and all nodes in the graph.
     
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type compare_node: node ID
@@ -150,9 +146,8 @@ def jaccard(PropertyGraph pg, size_t compare_node, str output_property_name,
     :type plan: JaccardPlan
     :param plan: The execution plan to use.
     
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_jaccard.pyx
+++ b/python/katana/local/analytics/_jaccard.pyx
@@ -25,7 +25,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -132,12 +132,16 @@ cdef class JaccardPlan(Plan):
         return JaccardPlan.make(_JaccardPlan.Unsorted())
 
 
-def jaccard(Graph pg, size_t compare_node, str output_property_name,
+def jaccard(PropertyGraph pg, size_t compare_node, str output_property_name,
             JaccardPlan plan = JaccardPlan()):
     """
+    Description
+    -----------
     Compute the Jaccard Similarity between `compare_node` and all nodes in the graph.
-
-    :type pg: katana.local.Graph
+    
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type compare_node: node ID
     :param compare_node: The node to compare to all nodes.
@@ -145,6 +149,26 @@ def jaccard(Graph pg, size_t compare_node, str output_property_name,
     :param output_property_name: The output property for similarities. This property must not already exist.
     :type plan: JaccardPlan
     :param plan: The execution plan to use.
+    
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import jaccard, JaccardStatistics
+        property_name = "NewProp"
+        compare_node = 0
+
+        jaccard(property_graph, compare_node, property_name)
+        stats = JaccardStatistics(property_graph, compare_node, property_name)
+
+        print("Max Similarity:", stats.max_similarity)
+        print("Min Similarity:", stats.min_similarity)
+        print("Average Similarity:", stats.average_similarity)    
     """
     output_property_name_bytes = bytes(output_property_name, "utf-8")
     output_property_name_cstr = <string>output_property_name_bytes
@@ -152,7 +176,7 @@ def jaccard(Graph pg, size_t compare_node, str output_property_name,
         handle_result_void(Jaccard(pg.underlying_property_graph(), compare_node, output_property_name_cstr, plan.underlying_))
 
 
-def jaccard_assert_valid(Graph pg, size_t compare_node, str output_property_name):
+def jaccard_assert_valid(PropertyGraph pg, size_t compare_node, str output_property_name):
     """
     Raise an exception if the Jaccard Similarity results in `pg` are invalid. This is not an exhaustive check, just a
     sanity check.
@@ -180,7 +204,7 @@ cdef class JaccardStatistics:
     """
     cdef _JaccardStatistics underlying
 
-    def __init__(self, Graph pg, size_t compare_node, str output_property_name):
+    def __init__(self, PropertyGraph pg, size_t compare_node, str output_property_name):
         output_property_name_bytes = bytes(output_property_name, "utf-8")
         output_property_name_cstr = <string> output_property_name_bytes
         with nogil:

--- a/python/katana/local/analytics/_k_core.pyx
+++ b/python/katana/local/analytics/_k_core.pyx
@@ -25,7 +25,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -106,11 +106,15 @@ cdef class KCorePlan(Plan):
         return KCorePlan.make(_KCorePlan.Asynchronous())
 
 
-def k_core(Graph pg, uint32_t k_core_number, str output_property_name, KCorePlan plan = KCorePlan()) -> int:
+def k_core(PropertyGraph pg, uint32_t k_core_number, str output_property_name, KCorePlan plan = KCorePlan()) -> int:
     """
+    Description
+    -----------
     Compute nodes which are in the k-core of pg. The pg must be symmetric.
-
-    :type pg: katana.local.Graph
+    
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :param k_core_number: k. The minimum degree of nodes in the resulting core.
     :type output_property_name: str
@@ -118,6 +122,21 @@ def k_core(Graph pg, uint32_t k_core_number, str output_property_name, KCorePlan
         This property must not already exist.
     :type plan: KCorePlan
     :param plan: The execution plan to use.
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import k_core, KCoreStatistics
+        k_core(property_graph, 10, "output")
+
+        stats = KCoreStatistics(property_graph, 10, "output")
+        print("Number of Nodes in K-core:", stats.number_of_nodes_in_kcore)
     """
     cdef string output_property_name_str = output_property_name.encode("utf-8")
     with nogil:
@@ -125,7 +144,7 @@ def k_core(Graph pg, uint32_t k_core_number, str output_property_name, KCorePlan
     return v
 
 
-def k_core_assert_valid(Graph pg, uint32_t k_core_number, str output_property_name):
+def k_core_assert_valid(PropertyGraph pg, uint32_t k_core_number, str output_property_name):
     """
     Raise an exception if the k-core results in `pg` are invalid. This is not an exhaustive check, just a sanity check.
 
@@ -149,7 +168,7 @@ cdef class KCoreStatistics:
     """
     cdef _KCoreStatistics underlying
 
-    def __init__(self, Graph pg, uint32_t k_core_number, str output_property_name):
+    def __init__(self, PropertyGraph pg, uint32_t k_core_number, str output_property_name):
         cdef string output_property_name_str = output_property_name.encode("utf-8")
         with nogil:
             self.underlying = handle_result_KCoreStatistics(_KCoreStatistics.Compute(

--- a/python/katana/local/analytics/_k_core.pyx
+++ b/python/katana/local/analytics/_k_core.pyx
@@ -108,12 +108,8 @@ cdef class KCorePlan(Plan):
 
 def k_core(PropertyGraph pg, uint32_t k_core_number, str output_property_name, KCorePlan plan = KCorePlan()) -> int:
     """
-    Description
-    -----------
     Compute nodes which are in the k-core of pg. The pg must be symmetric.
     
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :param k_core_number: k. The minimum degree of nodes in the resulting core.
@@ -123,9 +119,8 @@ def k_core(PropertyGraph pg, uint32_t k_core_number, str output_property_name, K
     :type plan: KCorePlan
     :param plan: The execution plan to use.
 
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_k_truss.pyx
+++ b/python/katana/local/analytics/_k_truss.pyx
@@ -123,12 +123,8 @@ cdef class KTrussPlan(Plan):
 
 def k_truss(PropertyGraph pg, uint32_t k_truss_number, str output_property_name, KTrussPlan plan = KTrussPlan()) -> int:
     """
-    Description
-    -----------
     Compute the k-truss for pg. `pg` must be symmetric.
     
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :param k_truss_number: k. The number of triangles that each edge must be part of.
@@ -138,9 +134,8 @@ def k_truss(PropertyGraph pg, uint32_t k_truss_number, str output_property_name,
     :type plan: KTrussPlan
     :param plan: The execution plan to use.
 
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_k_truss.pyx
+++ b/python/katana/local/analytics/_k_truss.pyx
@@ -27,7 +27,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -121,11 +121,15 @@ cdef class KTrussPlan(Plan):
         return KTrussPlan.make(_KTrussPlan.BspCoreThenTruss())
 
 
-def k_truss(Graph pg, uint32_t k_truss_number, str output_property_name, KTrussPlan plan = KTrussPlan()) -> int:
+def k_truss(PropertyGraph pg, uint32_t k_truss_number, str output_property_name, KTrussPlan plan = KTrussPlan()) -> int:
     """
+    Description
+    -----------
     Compute the k-truss for pg. `pg` must be symmetric.
-
-    :type pg: katana.local.Graph
+    
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :param k_truss_number: k. The number of triangles that each edge must be part of.
     :type output_property_name: str
@@ -133,6 +137,21 @@ def k_truss(Graph pg, uint32_t k_truss_number, str output_property_name, KTrussP
         This property must not already exist.
     :type plan: KTrussPlan
     :param plan: The execution plan to use.
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import k_truss, KTrussStatistics
+        k_truss(property_graph, 10, "output")
+
+        stats = KTrussStatistics(property_graph, 10, "output")
+        print("Number of Edges Left:", stats.number_of_edges_left)
     """
     cdef string output_property_name_str = output_property_name.encode("utf-8")
     with nogil:
@@ -140,7 +159,7 @@ def k_truss(Graph pg, uint32_t k_truss_number, str output_property_name, KTrussP
     return v
 
 
-def k_truss_assert_valid(Graph pg, uint32_t k_truss_number, str output_property_name):
+def k_truss_assert_valid(PropertyGraph pg, uint32_t k_truss_number, str output_property_name):
     """
     Raise an exception if the k-truss results in `pg` are invalid. This is not an exhaustive check, just a sanity check.
 
@@ -164,7 +183,7 @@ cdef class KTrussStatistics:
     """
     cdef _KTrussStatistics underlying
 
-    def __init__(self, Graph pg, uint32_t k_truss_number, str output_property_name):
+    def __init__(self, PropertyGraph pg, uint32_t k_truss_number, str output_property_name):
         cdef string output_property_name_str = output_property_name.encode("utf-8")
         with nogil:
             self.underlying = handle_result_KTrussStatistics(_KTrussStatistics.Compute(

--- a/python/katana/local/analytics/_local_clustering_coefficient.pyx
+++ b/python/katana/local/analytics/_local_clustering_coefficient.pyx
@@ -119,8 +119,6 @@ cdef class LocalClusteringCoefficientPlan(Plan):
                 bool edges_sorted = kDefaultEdgesSorted
             ):
         """
-        Description
-        -----------
         An ordered count algorithm that sorts the nodes by degree before
         execution. This has been found to give good performance. We implement the
         ordered count algorithm from the following:
@@ -128,8 +126,6 @@ cdef class LocalClusteringCoefficientPlan(Plan):
 
         This algorithm uses atomic instructions to update counts.
         
-        Parameters
-        ----------
         :param relabeling: Should the algorithm relabel the nodes.
         :param edges_sorted: Are the edges of the graph already sorted.
 

--- a/python/katana/local/analytics/_local_clustering_coefficient.pyx
+++ b/python/katana/local/analytics/_local_clustering_coefficient.pyx
@@ -18,7 +18,7 @@ from libcpp.string cimport string
 
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, handle_result_void
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -119,15 +119,20 @@ cdef class LocalClusteringCoefficientPlan(Plan):
                 bool edges_sorted = kDefaultEdgesSorted
             ):
         """
+        Description
+        -----------
         An ordered count algorithm that sorts the nodes by degree before
         execution. This has been found to give good performance. We implement the
         ordered count algorithm from the following:
         http://gap.cs.berkeley.edu/benchmark.html
 
         This algorithm uses atomic instructions to update counts.
-
+        
+        Parameters
+        ----------
         :param relabeling: Should the algorithm relabel the nodes.
         :param edges_sorted: Are the edges of the graph already sorted.
+
         """
         return LocalClusteringCoefficientPlan.make(_LocalClusteringCoefficientPlan.OrderedCountAtomics(
              edges_sorted, _relabeling_from_python(relabeling)))
@@ -152,7 +157,7 @@ cdef class LocalClusteringCoefficientPlan(Plan):
              edges_sorted, _relabeling_from_python(relabeling)))
 
 
-def local_clustering_coefficient(Graph pg, str output_property_name, LocalClusteringCoefficientPlan plan = LocalClusteringCoefficientPlan()):
+def local_clustering_coefficient(PropertyGraph pg, str output_property_name, LocalClusteringCoefficientPlan plan = LocalClusteringCoefficientPlan()):
     cdef string output_property_name_str = bytes(output_property_name, "utf-8")
     with nogil:
         handle_result_void(LocalClusteringCoefficient(pg.underlying_property_graph(), output_property_name_str, plan.underlying_))

--- a/python/katana/local/analytics/_louvain_clustering.pyx
+++ b/python/katana/local/analytics/_louvain_clustering.pyx
@@ -26,7 +26,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -171,8 +171,10 @@ cdef class LouvainClusteringPlan(Plan):
         return LouvainClusteringPlan.make(_LouvainClusteringPlan.Deterministic(
             enable_vf, modularity_threshold_per_round, modularity_threshold_total, max_iterations, min_graph_size))
 
-def louvain_clustering(Graph pg, str edge_weight_property_name, str output_property_name, LouvainClusteringPlan plan = LouvainClusteringPlan()):
+def louvain_clustering(PropertyGraph pg, str edge_weight_property_name, str output_property_name, LouvainClusteringPlan plan = LouvainClusteringPlan()):
     """
+    Description
+    -----------
     Compute the Louvain Clustering for pg.
     The edge weights are taken from the property named
     edge_weight_property_name (which may be a 32- or 64-bit sign or unsigned
@@ -180,6 +182,31 @@ def louvain_clustering(Graph pg, str edge_weight_property_name, str output_prope
     output_property_name (as uint32_t).
     The property named output_property_name is created by this function and may
     not exist before the call.
+        
+    Parameters
+    ----------
+    :type pg: PropertyGraph
+    :param pg: The graph to analyze.
+    :type edge_weight_property_name: str
+    :param edge_weight_property_name: may be a 32- or 64-bit sign or unsigned int
+    :type output_property_name: str
+    :param output_property_name: The output edge property
+    :type LouvainClusteringPlan: LouvainClusteringPlan
+    :param LouvainClusteringPlan: The Louvain Clustering Plan
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import louvain_clustering, LouvainClusteringStatistics
+        louvain_clustering(property_graph, "value", "output")
+        LouvainClusteringStatistics(property_graph, "value", "output")
+
     """
     cdef string edge_weight_property_name_str = bytes(edge_weight_property_name, "utf-8")
     cdef string output_property_name_str = bytes(output_property_name, "utf-8")
@@ -187,7 +214,7 @@ def louvain_clustering(Graph pg, str edge_weight_property_name, str output_prope
         handle_result_void(LouvainClustering(pg.underlying_property_graph(), edge_weight_property_name_str, output_property_name_str, plan.underlying_))
 
 
-def louvain_clustering_assert_valid(Graph pg, str edge_weight_property_name, str output_property_name ):
+def louvain_clustering_assert_valid(PropertyGraph pg, str edge_weight_property_name, str output_property_name ):
     cdef string edge_weight_property_name_str = bytes(edge_weight_property_name, "utf-8")
     cdef string output_property_name_str = bytes(output_property_name, "utf-8")
     with nogil:
@@ -207,7 +234,7 @@ cdef _LouvainClusteringStatistics handle_result_LouvainClusteringStatistics(Resu
 cdef class LouvainClusteringStatistics:
     cdef _LouvainClusteringStatistics underlying
 
-    def __init__(self, Graph pg,
+    def __init__(self, PropertyGraph pg,
             str edge_weight_property_name,
             str output_property_name
             ):

--- a/python/katana/local/analytics/_louvain_clustering.pyx
+++ b/python/katana/local/analytics/_louvain_clustering.pyx
@@ -173,8 +173,6 @@ cdef class LouvainClusteringPlan(Plan):
 
 def louvain_clustering(PropertyGraph pg, str edge_weight_property_name, str output_property_name, LouvainClusteringPlan plan = LouvainClusteringPlan()):
     """
-    Description
-    -----------
     Compute the Louvain Clustering for pg.
     The edge weights are taken from the property named
     edge_weight_property_name (which may be a 32- or 64-bit sign or unsigned
@@ -183,8 +181,6 @@ def louvain_clustering(PropertyGraph pg, str edge_weight_property_name, str outp
     The property named output_property_name is created by this function and may
     not exist before the call.
         
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type edge_weight_property_name: str
@@ -194,9 +190,8 @@ def louvain_clustering(PropertyGraph pg, str edge_weight_property_name, str outp
     :type LouvainClusteringPlan: LouvainClusteringPlan
     :param LouvainClusteringPlan: The Louvain Clustering Plan
 
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_pagerank.pyx
+++ b/python/katana/local/analytics/_pagerank.pyx
@@ -169,12 +169,8 @@ cdef class PagerankPlan(Plan):
 
 def pagerank(PropertyGraph pg, str output_property_name, PagerankPlan plan = PagerankPlan()):
     """
-    Description
-    -----------
     Compute the Page Rank of each node in the graph.
     
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
@@ -182,9 +178,8 @@ def pagerank(PropertyGraph pg, str output_property_name, PagerankPlan plan = Pag
     :type plan: PagerankPlan
     :param plan: The execution plan to use.
 
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_pagerank.pyx
+++ b/python/katana/local/analytics/_pagerank.pyx
@@ -195,6 +195,7 @@ def pagerank(PropertyGraph pg, str output_property_name, PagerankPlan plan = Pag
         print("Min Rank:", stats.min_rank)
         print("Max Rank:", stats.max_rank)
         print("Average Rank:", stats.average_rank)
+        
     """
     output_property_name_bytes = bytes(output_property_name, "utf-8")
     output_property_name_cstr = <string>output_property_name_bytes

--- a/python/katana/local/analytics/_pagerank.pyx
+++ b/python/katana/local/analytics/_pagerank.pyx
@@ -28,7 +28,7 @@ from libcpp.string cimport string
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libstd.iostream cimport ostream, ostringstream
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -167,16 +167,39 @@ cdef class PagerankPlan(Plan):
         return PagerankPlan.make(_PagerankPlan.PushSynchronous(tolerance, max_iterations, alpha))
 
 
-def pagerank(Graph pg, str output_property_name, PagerankPlan plan = PagerankPlan()):
+def pagerank(PropertyGraph pg, str output_property_name, PagerankPlan plan = PagerankPlan()):
     """
+    Description
+    -----------
     Compute the Page Rank of each node in the graph.
-
-    :type pg: katana.local.Graph
+    
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type output_property_name: str
     :param output_property_name: The output property to store the rank. This property must not already exist.
     :type plan: PagerankPlan
     :param plan: The execution plan to use.
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import pagerank, PagerankStatistics
+        property_name = "NewProp"
+
+        pagerank(property_graph, property_name)
+
+        stats = PagerankStatistics(property_graph, property_name)
+        print("Min Rank:", stats.min_rank)
+        print("Max Rank:", stats.max_rank)
+        print("Average Rank:", stats.average_rank)
     """
     output_property_name_bytes = bytes(output_property_name, "utf-8")
     output_property_name_cstr = <string>output_property_name_bytes
@@ -184,7 +207,7 @@ def pagerank(Graph pg, str output_property_name, PagerankPlan plan = PagerankPla
         handle_result_void(Pagerank(pg.underlying_property_graph(), output_property_name_cstr, plan.underlying_))
 
 
-def pagerank_assert_valid(Graph pg, str output_property_name):
+def pagerank_assert_valid(PropertyGraph pg, str output_property_name):
     """
     Raise an exception if the pagerank results in `pg` are invalid. This is not an exhaustive check, just a sanity check.
 
@@ -211,7 +234,7 @@ cdef class PagerankStatistics:
     """
     cdef _PagerankStatistics underlying
 
-    def __init__(self, Graph pg, str output_property_name):
+    def __init__(self, PropertyGraph pg, str output_property_name):
         output_property_name_bytes = bytes(output_property_name, "utf-8")
         output_property_name_cstr = <string> output_property_name_bytes
         with nogil:

--- a/python/katana/local/analytics/_sssp.pyx
+++ b/python/katana/local/analytics/_sssp.pyx
@@ -246,13 +246,9 @@ cdef class SsspPlan(Plan):
 def sssp(PropertyGraph pg, size_t start_node, str edge_weight_property_name, str output_property_name,
          SsspPlan plan = SsspPlan()):
     """
-    Description
-    -----------
     Compute the Single-Source Shortest Path on `pg` using `start_node` as the source. The computed path lengths are
     written to the property `output_property_name`.
     
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type start_node: Node ID
@@ -264,9 +260,8 @@ def sssp(PropertyGraph pg, size_t start_node, str edge_weight_property_name, str
     :type plan: SsspPlan
     :param plan: The execution plan to use. Defaults to heuristically selecting the plan.
 
-    Examples
-    --------
     .. code-block:: python
+    
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph

--- a/python/katana/local/analytics/_subgraph_extraction.pyx
+++ b/python/katana/local/analytics/_subgraph_extraction.pyx
@@ -16,7 +16,7 @@ from pyarrow.lib cimport to_shared
 
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -81,7 +81,7 @@ cdef shared_ptr[_PropertyGraph] handle_result_property_graph(Result[unique_ptr[_
     return to_shared(res.value())
 
 
-def subgraph_extraction(Graph pg, node_vec, SubGraphExtractionPlan plan = SubGraphExtractionPlan()) -> Graph:
+def subgraph_extraction(PropertyGraph pg, node_vec, SubGraphExtractionPlan plan = SubGraphExtractionPlan()) -> PropertyGraph:
     """
     Given a set of node ids, this algorithm constructs a new sub-graph which contains all nodes in the set and edges
     between them.
@@ -89,4 +89,4 @@ def subgraph_extraction(Graph pg, node_vec, SubGraphExtractionPlan plan = SubGra
     cdef vector[uint32_t] vec = [<uint32_t>n for n in node_vec]
     with nogil:
         v = handle_result_property_graph(SubGraphExtraction(pg.underlying_property_graph(), vec, plan.underlying_))
-    return Graph.make(v)
+    return PropertyGraph.make(v)

--- a/python/katana/local/analytics/_triangle_count.pyx
+++ b/python/katana/local/analytics/_triangle_count.pyx
@@ -182,21 +182,16 @@ cdef uint64_t handle_result_int(Result[uint64_t] res) nogil except *:
 
 def triangle_count(PropertyGraph pg,  TriangleCountPlan plan = TriangleCountPlan()) -> int:
     """
-    Description
-    -----------
     Count the triangles in `pg`.
 
-    Parameters
-    ----------
     :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type plan: TriangleCountPlan
     :param plan: The execution plan to use.
     :return: The number of triangles found.
 
-    Examples
-    --------
     .. code-block:: python
+
         import katana.local
         from katana.example_utils import get_input
         from katana.property_graph import PropertyGraph
@@ -206,6 +201,7 @@ def triangle_count(PropertyGraph pg,  TriangleCountPlan plan = TriangleCountPlan
         from katana.analytics import triangle_count
         n = triangle_count(property_graph)
         print("Triangle Count:", n)
+        
     """
     with nogil:
         v = handle_result_int(TriangleCount(pg.underlying_property_graph(), plan.underlying_))

--- a/python/katana/local/analytics/_triangle_count.pyx
+++ b/python/katana/local/analytics/_triangle_count.pyx
@@ -21,7 +21,7 @@ from libcpp cimport bool
 
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -180,15 +180,32 @@ cdef uint64_t handle_result_int(Result[uint64_t] res) nogil except *:
     return res.value()
 
 
-def triangle_count(Graph pg,  TriangleCountPlan plan = TriangleCountPlan()) -> int:
+def triangle_count(PropertyGraph pg,  TriangleCountPlan plan = TriangleCountPlan()) -> int:
     """
+    Description
+    -----------
     Count the triangles in `pg`.
 
-    :type pg: katana.local.Graph
+    Parameters
+    ----------
+    :type pg: PropertyGraph
     :param pg: The graph to analyze.
     :type plan: TriangleCountPlan
     :param plan: The execution plan to use.
     :return: The number of triangles found.
+
+    Examples
+    --------
+    .. code-block:: python
+        import katana.local
+        from katana.example_utils import get_input
+        from katana.property_graph import PropertyGraph
+        katana.local.initialize()
+
+        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
+        from katana.analytics import triangle_count
+        n = triangle_count(property_graph)
+        print("Triangle Count:", n)
     """
     with nogil:
         v = handle_result_int(TriangleCount(pg.underlying_property_graph(), plan.underlying_))

--- a/python/katana/local/analytics/_wrappers.pyx
+++ b/python/katana/local/analytics/_wrappers.pyx
@@ -13,7 +13,7 @@ from pyarrow.lib cimport CUInt64Array
 from katana.cpp.libgalois.datastructures cimport NUMAArray
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, handle_result_void, raise_error_code
-from katana.local._graph cimport Graph
+from katana.local._property_graph cimport PropertyGraph
 from katana.local.datastructures cimport NUMAArray_uint64_t
 
 
@@ -37,7 +37,7 @@ cdef unique_ptr[NUMAArray[uint64_t]] handle_result_unique_numaarray_uint64(Resul
     return move(res.value())
 
 
-# "Algorithms" from Graph
+# "Algorithms" from PropertyGraph
 
 cdef extern from "katana/PropertyGraph.h" namespace "katana" nogil:
     Result[unique_ptr[NUMAArray[uint64_t]]] SortAllEdgesByDest(_PropertyGraph* pg);
@@ -63,7 +63,7 @@ def sort_all_edges_by_dest(Graph pg):
     return NUMAArray_uint64_t.make_move(move(deref(res.get())))
 
 
-def find_edge_sorted_by_dest(Graph pg, uint32_t node, uint32_t node_to_find):
+def find_edge_sorted_by_dest(PropertyGraph pg, uint32_t node, uint32_t node_to_find):
     """
     Find an edge based on its incident nodes. The graph must have sorted edges.
 
@@ -81,7 +81,7 @@ def find_edge_sorted_by_dest(Graph pg, uint32_t node, uint32_t node_to_find):
     return res
 
 
-def sort_nodes_by_degree(Graph pg):
+def sort_nodes_by_degree(PropertyGraph pg):
     """
     Relabel all nodes in the graph by sorting in the descending order by node degree.
     """

--- a/python/katana/local/analytics/plan.pyx
+++ b/python/katana/local/analytics/plan.pyx
@@ -61,7 +61,7 @@ cdef class Statistics:
         """
         Compute the appropriate statistics for the algorithm the subclass is associated with.
 
-        :type pg: katana.local.Graph
+        :type pg: katana.property_graph.PropertyGraph
         :param pg: The property graph containing the algorithm outputs.
         :param args...: Additional parameters needed to compute statistics, including output property names.
         """


### PR DESCRIPTION
Update python docstrings to include code blocks with the ldbc_003 examples pulled from the pytests. I confirmed these code blocks work. Below is an example of the code blocks added for each of the analytics routines: 

   .. code-block:: python
    
        import katana.local
        from katana.example_utils import get_input
        from katana.property_graph import PropertyGraph
        katana.local.initialize()

        property_graph = PropertyGraph(get_input("propertygraphs/ldbc_003"))
        from katana.analytics import louvain_clustering, LouvainClusteringStatistics
        louvain_clustering(property_graph, "value", "output")
        LouvainClusteringStatistics(property_graph, "value", "output")
