### PR TITLE
Add pid to HostStats

### DIFF
--- a/libsupport/include/katana/JSONTracer.h
+++ b/libsupport/include/katana/JSONTracer.h
@@ -62,7 +62,7 @@ public:
 
   void SetTags(const Tags& tags) override;
 
-  void Log(const std::string& message, const Tags& tags = {}) override;
+  void Log(const std::string& message, const Tags& tags) override;
 
   const ProgressContext& GetContext() const noexcept override {
     return context_;

--- a/libsupport/include/katana/ProgressTracer.h
+++ b/libsupport/include/katana/ProgressTracer.h
@@ -85,6 +85,7 @@ struct HostStats {
   long nprocs{};
   long ram_gb{};
   std::string hostname;
+  long pid{};
 };
 
 class ProgressScope;

--- a/libsupport/include/katana/TextTracer.h
+++ b/libsupport/include/katana/TextTracer.h
@@ -42,8 +42,8 @@ private:
   friend class TextTracer;
   friend class TextSpan;
 
-  TextContext(const std::string& trace_id, const std::string& span_id)
-      : trace_id_(trace_id), span_id_(span_id) {}
+  TextContext(std::string trace_id, std::string span_id)
+      : trace_id_(std::move(trace_id)), span_id_(std::move(span_id)) {}
 
   std::string trace_id_;
   std::string span_id_;
@@ -55,7 +55,7 @@ public:
 
   void SetTags(const Tags& tags) override;
 
-  void Log(const std::string& message, const Tags& tags = {}) override;
+  void Log(const std::string& message, const Tags& tags) override;
 
   const ProgressContext& GetContext() const noexcept override {
     return context_;

--- a/libsupport/src/ProgressTracer.cpp
+++ b/libsupport/src/ProgressTracer.cpp
@@ -10,6 +10,8 @@
 
 #if __linux__
 #include <sys/sysinfo.h>
+#include <sys/types.h>
+#include <unistd.h>
 #endif
 
 std::unique_ptr<katana::ProgressTracer> katana::ProgressTracer::tracer_ =
@@ -53,12 +55,16 @@ katana::ProgressTracer::GetHostStats() {
   struct sysinfo info;
   sysinfo(&info);
 
-  char hostname[256];
-  gethostname(hostname, 256);
+  constexpr int kLen = 256;
 
-  stats.ram_gb = info.totalram / 1024 / 1024 / 1024;
+  std::array<char, kLen> hostname;
+  gethostname(hostname.begin(), kLen);
+
+  stats.ram_gb = info.totalram / (1024 * 1024 * 1024);
   stats.nprocs = get_nprocs();
-  stats.hostname = hostname;
+  stats.hostname = hostname.begin();
+
+  stats.pid = getpid();
 
   return stats;
 }


### PR DESCRIPTION
Along the way fix some clang-tidy nits:
- No default parameters in virtual functions
- Use string literals
- Move over copy
- string::find(char) over string::find(string)


Closes https://github.com/KatanaGraph/katana-enterprise/pull/1574 

The other bits of https://github.com/KatanaGraph/katana-enterprise/pull/1574 have already been implemented separately.