### PR TITLE
libsupport Cache provides an LRU cache 

### DIFF
--- a/libsupport/include/katana/Cache.h
+++ b/libsupport/include/katana/Cache.h
@@ -1,0 +1,166 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_CACHE_H_
+#define KATANA_LIBSUPPORT_KATANA_CACHE_H_
+
+// This is single threaded only, it is not intended to store large objects,
+// but rather metadata (e.g., a shared_ptr to a property column).
+
+// The problem witchel had implementing a multi-threaded version using
+// parallel-hashmap is a lock ordering problem.  parallel-hashmap 1.33 allows
+// execution of code with the write lock held, only when modifying, not when adding an
+// element.  We have to modify the LRU list when eviciting an element, so the natural
+// lock ordering is parallel-hashmap write lock, then list lock.  But without a way to
+// execute insert code with the parallel-hashmap write lock held, it seemed like there
+// would be some form of race condition.
+
+#include <list>
+#include <optional>
+#include <string>
+
+#include <boost/container_hash/hash.hpp>
+
+#include "katana/Logging.h"
+
+namespace tsuba {
+
+template <typename Key, typename Value>
+class KATANA_EXPORT Cache {
+  using ListType = std::list<Key>;
+  struct MapValue {
+    Value value;
+    // This allows us to delete the old position in the LRU list without a scan
+    typename ListType::iterator lru_it;
+  };
+  using MapType = std::unordered_map<Key, MapValue>;
+  enum class ReplacementPolicy { kLRUSize, kLRUBytes };
+
+public:
+  /// Construct an LRU cache that has a fixed number of entries.
+  Cache(
+      size_t capacity,  // number of entries
+      std::function<void(const Key& key)> evict_cb = nullptr)
+      : policy_(ReplacementPolicy::kLRUSize),
+        capacity_(capacity),
+        value_to_bytes_(nullptr),
+        evict_cb_(std::move(evict_cb)) {
+    KATANA_LOG_VASSERT(capacity_ > 0, "cache requires positive capacity");
+  }
+  /// Construct an LRU cache that holds fixed number of bytes.
+  Cache(
+      size_t capacity,  // bytes of entries
+      std::function<size_t(const Value& value)> value_to_bytes,
+      std::function<void(const Key& key)> evict_cb = nullptr)
+      : policy_(ReplacementPolicy::kLRUBytes),
+        capacity_(capacity),
+        value_to_bytes_(std::move(value_to_bytes)),
+        evict_cb_(std::move(evict_cb)) {
+    KATANA_LOG_VASSERT(capacity_ > 0, "cache requires positive capacity");
+    KATANA_LOG_VASSERT(
+        value_to_bytes_ != nullptr,
+        "kLRUBytes policy requires value to bytes function");
+  }
+
+  size_t size() const {
+    if (policy_ == ReplacementPolicy::kLRUSize) {
+      return key_to_value_.size();
+    } else {
+      return total_bytes_;
+    }
+  }
+
+  size_t capacity() const { return capacity_; }
+
+  bool Empty() const { return key_to_value_.empty(); }
+
+  bool Contains(const Key& key) const {
+    return key_to_value_.find(key) != key_to_value_.end();
+  }
+
+  void Insert(const Key& key, const Value& value) {
+    auto mapit = key_to_value_.find(key);
+    if (mapit == key_to_value_.end()) {
+      lru_list_.push_front(key);
+      key_to_value_[key] = {value, lru_list_.begin()};
+      if (value_to_bytes_ != nullptr) {
+        total_bytes_ += value_to_bytes_(value);
+      }
+    } else {
+      mapit->second.value = value;
+      UpdateLRU(mapit);
+    }
+    EvictIfNecessary();
+  }
+
+  std::optional<Value> Get(const Key& key) {
+    // lookup value in the cache
+    std::optional<Value> ret;
+    auto it = key_to_value_.find(key);
+    if (it != key_to_value_.end()) {
+      ret = UpdateLRU(it);
+    }
+    return ret;
+  }
+
+private:
+  Value UpdateLRU(typename MapType::iterator mapit) {
+    auto lru_it = mapit->second.lru_it;
+    auto lru_head = lru_list_.begin();
+    if (lru_it != lru_head) {
+      // move item to the front of the most recently used list
+      lru_list_.splice(lru_head, lru_list_, lru_it);
+      mapit->second.lru_it = lru_head;
+    }
+    return mapit->second.value;
+  }
+
+  void EvictOne() {
+    // evict item from the end of most recently used list
+    auto tail = --lru_list_.end();
+    KATANA_LOG_ASSERT(tail != lru_list_.end());
+    Key evicted_key = std::move(*tail);
+    lru_list_.erase(tail);
+    auto evicted_value = std::move(key_to_value_.at(evicted_key).value);
+    key_to_value_.erase(evicted_key);
+    if (value_to_bytes_ != nullptr) {
+      total_bytes_ -= value_to_bytes_(evicted_value);
+    }
+    if (evict_cb_) {
+      evict_cb_(evicted_key);
+    }
+  }
+
+  void EvictIfNecessary() {
+    switch (policy_) {
+    case ReplacementPolicy::kLRUSize: {
+      while (size() > capacity_) {
+        EvictOne();
+      }
+    } break;
+    case ReplacementPolicy::kLRUBytes: {
+      KATANA_LOG_DEBUG_ASSERT(value_to_bytes_ != nullptr);
+      // Allow a single entry to exceed our byte capacity
+      while (size() > capacity_ && key_to_value_.size() > 1) {
+        EvictOne();
+      }
+    } break;
+    default:
+      KATANA_LOG_FATAL("bad cache replacement policy: {}", policy_);
+    }
+  }
+
+  // Map from key to value
+  MapType key_to_value_;
+  // LRU list
+  ListType lru_list_;
+
+  ReplacementPolicy policy_;
+  // for kLRUSize number of entries kLRUBytes it is byte total
+  size_t capacity_{0};
+  size_t total_bytes_{0};
+
+  std::function<size_t(const Value& value)> value_to_bytes_;
+  std::function<void(const Key& key)> evict_cb_;
+};
+
+}  // namespace tsuba
+
+#endif

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 
 add_unit_test(tracing)
 add_unit_test(bitmath)
+add_unit_test(cache)
 add_unit_test(env)
 add_unit_test(logging)
 add_unit_test(opaque-id)

--- a/libsupport/test/cache.cpp
+++ b/libsupport/test/cache.cpp
@@ -1,0 +1,210 @@
+#include "katana/Cache.h"
+
+#include <map>
+#include <random>
+
+#include "katana/Logging.h"
+#include "katana/Random.h"
+
+enum class NodeEdge { kNode, kEdge };
+
+// Basic Cache Key implementation
+struct CacheKey {
+  CacheKey(const NodeEdge& node_edge, const std::string& name)
+      : node_edge_(node_edge), name_(name) {}
+
+  bool operator==(const CacheKey& o) const {
+    return node_edge_ == o.node_edge_ && name_ == o.name_;
+  }
+
+  std::size_t hash() const noexcept {
+    using boost::hash_combine;
+    using boost::hash_value;
+
+    std::size_t seed = 0;
+    hash_combine(seed, hash_value(node_edge_));
+    hash_combine(seed, hash_value(name_));
+
+    // Return the result.
+    return seed;
+  }
+
+  NodeEdge node_edge_;
+  std::string name_;
+};
+
+// inject custom specialization of std::hash to namespace std
+namespace std {
+template <>
+struct hash<CacheKey> {
+  std::size_t operator()(CacheKey const& key) const noexcept {
+    return key.hash();
+  }
+};
+}  // namespace std
+
+struct CacheValue {
+  int64_t a;
+  int32_t b;
+  uint32_t c;
+};
+static uint64_t count_evictions{0};
+
+CacheValue
+RandomValue() {
+  std::uniform_int_distribution<int64_t> dist(
+      0, std::numeric_limits<int64_t>::max());
+  CacheValue elt;
+  elt.a = dist(katana::GetGenerator());
+  elt.b = static_cast<int32_t>(elt.a);
+  elt.c = static_cast<uint32_t>(elt.a);
+  return elt;
+}
+
+size_t
+BytesInValue(const CacheValue& value) {
+  if (value.a & 1) {
+    return 5;
+  } else {
+    return 1;
+  }
+}
+
+CacheValue
+SizeOneValue() {
+  auto v = RandomValue();
+  v.a = 0;
+  return v;
+}
+
+CacheValue
+SizeFiveValue() {
+  auto v = RandomValue();
+  v.a = 1;
+  return v;
+}
+
+void
+InsertRandom(
+    const std::vector<CacheKey>& keys,
+    tsuba::Cache<CacheKey, CacheValue>& cache) {
+  for (const auto& key : keys) {
+    cache.Insert(key, RandomValue());
+  }
+}
+
+void
+AssertLRUElements(
+    std::vector<CacheKey>::const_iterator endit, size_t num,
+    tsuba::Cache<CacheKey, CacheValue>& cache) {
+  for (auto it = endit - num; it < endit; ++it) {
+    KATANA_LOG_ASSERT(cache.Get(*it).has_value());
+  }
+  KATANA_LOG_ASSERT(!cache.Get(*(endit - num - 1)).has_value());
+}
+
+void
+TestLRUBytes(
+    const std::vector<CacheKey>& node_keys,
+    const std::vector<CacheKey>& edge_keys) {
+  count_evictions = 0;
+  size_t byte_size = 4;
+  tsuba::Cache<CacheKey, CacheValue> cache(
+      byte_size, [](const CacheValue& value) { return BytesInValue(value); },
+      [&](const CacheKey&) { count_evictions++; });
+
+  auto nodeit = --node_keys.end();
+  KATANA_LOG_ASSERT(nodeit != node_keys.begin());
+  cache.Insert(*nodeit--, SizeOneValue());
+  KATANA_LOG_ASSERT(nodeit != node_keys.begin());
+  cache.Insert(*nodeit--, SizeOneValue());
+  KATANA_LOG_ASSERT(nodeit != node_keys.begin());
+  cache.Insert(*nodeit--, SizeOneValue());
+  KATANA_LOG_ASSERT(nodeit != node_keys.begin());
+  cache.Insert(*nodeit--, SizeOneValue());
+
+  KATANA_LOG_ASSERT((byte_size + 1) < node_keys.size());
+  AssertLRUElements(node_keys.end(), byte_size, cache);
+  // Check eviction count
+  KATANA_LOG_ASSERT(count_evictions == 0);
+
+  KATANA_LOG_ASSERT(nodeit != node_keys.begin());
+  cache.Insert(*nodeit--, SizeOneValue());
+  KATANA_LOG_ASSERT(count_evictions == 1);
+
+  // EDGE keys
+  nodeit = --edge_keys.end();
+  KATANA_LOG_ASSERT(nodeit != edge_keys.begin());
+  cache.Insert(*nodeit--, SizeFiveValue());
+  KATANA_LOG_ASSERT(count_evictions == 5);
+  KATANA_LOG_ASSERT(cache.size() == 5);
+
+  cache.Insert(*nodeit--, SizeOneValue());
+  KATANA_LOG_ASSERT(count_evictions == 6);
+  KATANA_LOG_ASSERT(cache.size() == 1);
+}
+
+void
+TestLRUSize(
+    size_t lru_size, const std::vector<CacheKey>& node_keys,
+    const std::vector<CacheKey>& edge_keys) {
+  count_evictions = 0;
+  tsuba::Cache<CacheKey, CacheValue> cache(
+      lru_size, [&](const CacheKey&) { count_evictions++; });
+
+  InsertRandom(node_keys, cache);
+
+  fmt::print(
+      "Inserted {} node keys, size {}\n", node_keys.size(), cache.size());
+  KATANA_LOG_VASSERT(
+      cache.size() == lru_size, "size {} allocated {}", cache.size(), lru_size);
+
+  InsertRandom(edge_keys, cache);
+
+  fmt::print(
+      "Inserted {} edge keys, size {}\n", edge_keys.size(), cache.size());
+  KATANA_LOG_VASSERT(
+      cache.size() == lru_size, "size {} allocated {}", cache.size(), lru_size);
+
+  // Make sure we have the LRU elements and only them.
+  KATANA_LOG_ASSERT((lru_size + 1) < edge_keys.size());
+
+  AssertLRUElements(edge_keys.end(), lru_size, cache);
+}
+
+int
+main(int argc, char** argv) {
+  constexpr size_t lru_size = 10;
+
+  uint64_t size = 11 * lru_size;
+  if (argc > 1) {
+    size = strtol(argv[1], nullptr, 10);
+  }
+  if (size <= 0) {
+    size = 1000000;
+  }
+
+  std::vector<CacheKey> node_keys;
+  std::vector<CacheKey> edge_keys;
+  // Generate maximum overlap of names
+  std::vector<std::string> names;
+  size_t mid = size / 2;
+  if (mid * mid < size) {
+    mid++;
+  }
+  KATANA_LOG_ASSERT(mid * mid >= size);
+  for (size_t i = 0; i < mid; ++i) {
+    names.emplace_back(katana::RandomAlphanumericString(16));
+    node_keys.emplace_back(CacheKey(NodeEdge::kNode, names.back()));
+  }
+
+  for (size_t i = 0, end = size - node_keys.size(); i < end; ++i) {
+    edge_keys.emplace_back(CacheKey(NodeEdge::kEdge, names[i]));
+  }
+
+  TestLRUSize(lru_size, node_keys, edge_keys);
+
+  TestLRUBytes(node_keys, edge_keys);
+
+  return 0;
+}


### PR DESCRIPTION

Support for caching properties is split into a different PR because it is messy.