### PR TITLE
[KAT-1316] Enforce safe use of Get*Property(string) on PropertyGraph.

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -623,7 +623,7 @@ public:
       const std::string& name) const {
     auto ret = node_properties()->GetColumnByName(name);
     if (ret) {
-      return ret;
+      return MakeResult(std::move(ret));
     }
     return KATANA_ERROR(
         ErrorCode::PropertyNotFound, "node property does not exist: {}", name);
@@ -637,7 +637,7 @@ public:
       const std::string& name) const {
     auto ret = edge_properties()->GetColumnByName(name);
     if (ret) {
-      return ret;
+      return MakeResult(std::move(ret));
     }
     return KATANA_ERROR(
         ErrorCode::PropertyNotFound, "edge property does not exist: {}", name);
@@ -664,7 +664,7 @@ public:
     if (!array) {
       return ErrorCode::TypeError;
     }
-    return array;
+    return MakeResult(std::move(array));
   }
 
   /// Get an edge property by name and cast it to a type.
@@ -684,7 +684,7 @@ public:
     if (!array) {
       return ErrorCode::TypeError;
     }
-    return array;
+    return MakeResult(std::move(array));
   }
 
   const GraphTopology& topology() const noexcept { return topology_; }

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -11,6 +11,7 @@
 #include "katana/Details.h"
 #include "katana/EntityTypeManager.h"
 #include "katana/ErrorCode.h"
+#include "katana/Result.h"
 #include "katana/GraphTopology.h"
 #include "katana/Iterators.h"
 #include "katana/NUMAArray.h"

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -11,11 +11,11 @@
 #include "katana/Details.h"
 #include "katana/EntityTypeManager.h"
 #include "katana/ErrorCode.h"
-#include "katana/Result.h"
 #include "katana/GraphTopology.h"
 #include "katana/Iterators.h"
 #include "katana/NUMAArray.h"
 #include "katana/PropertyIndex.h"
+#include "katana/Result.h"
 #include "katana/config.h"
 #include "tsuba/RDG.h"
 

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -827,6 +827,26 @@ katana::PropertyGraph::ReportDiff(const PropertyGraph* other) const {
   return std::string(buf.begin(), buf.end());
 }
 
+katana::Result<std::shared_ptr<arrow::ChunkedArray>>
+katana::PropertyGraph::GetNodeProperty(const std::string& name) const {
+  auto ret = node_properties()->GetColumnByName(name);
+  if (ret) {
+    return MakeResult(std::move(ret));
+  }
+  return KATANA_ERROR(
+      ErrorCode::PropertyNotFound, "node property does not exist: {}", name);
+}
+
+katana::Result<std::shared_ptr<arrow::ChunkedArray>>
+katana::PropertyGraph::GetEdgeProperty(const std::string& name) const {
+  auto ret = edge_properties()->GetColumnByName(name);
+  if (ret) {
+    return MakeResult(std::move(ret));
+  }
+  return KATANA_ERROR(
+      ErrorCode::PropertyNotFound, "edge property does not exist: {}", name);
+}
+
 katana::Result<void>
 katana::PropertyGraph::Write(
     const std::string& rdg_name, const std::string& command_line) {

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -1022,11 +1022,7 @@ katana::PropertyGraph::MakeNodeIndex(const std::string& column_name) {
 
   // Get a view of the property.
   std::shared_ptr<arrow::ChunkedArray> chunked_property =
-      GetNodeProperty(column_name);
-  if (!chunked_property) {
-    return KATANA_ERROR(
-        katana::ErrorCode::NotFound, "No such property: {}", column_name);
-  }
+      KATANA_CHECKED(GetNodeProperty(column_name));
   KATANA_LOG_ASSERT(chunked_property->num_chunks() == 1);
   std::shared_ptr<arrow::Array> property = chunked_property->chunk(0);
 
@@ -1055,11 +1051,7 @@ katana::PropertyGraph::MakeEdgeIndex(const std::string& column_name) {
 
   // Get a view of the property.
   std::shared_ptr<arrow::ChunkedArray> chunked_property =
-      GetEdgeProperty(column_name);
-  if (!chunked_property) {
-    return KATANA_ERROR(
-        katana::ErrorCode::NotFound, "No such property: {}", column_name);
-  }
+      KATANA_CHECKED(GetEdgeProperty(column_name));
   KATANA_LOG_ASSERT(chunked_property->num_chunks() == 1);
   std::shared_ptr<arrow::Array> property = chunked_property->chunk(0);
 

--- a/libgalois/src/PropertyViews.cpp
+++ b/libgalois/src/PropertyViews.cpp
@@ -28,12 +28,7 @@ katana::internal::ExtractArrays(
     const std::vector<std::string>& properties) {
   std::vector<arrow::Array*> ret;
   for (auto& property : properties) {
-    auto column = pview.GetProperty(property);
-    if (!column) {
-      return KATANA_ERROR(
-          ErrorCode::PropertyNotFound, "property named {}",
-          std::quoted(property));
-    }
+    auto column = KATANA_CHECKED(pview.GetProperty(property));
     if (column->num_chunks() != 1) {
       // Katana form graphs only contain single chunk property columns.
       return KATANA_ERROR(

--- a/libgalois/src/analytics/louvain_clustering/louvain_clustering.cpp
+++ b/libgalois/src/analytics/louvain_clustering/louvain_clustering.cpp
@@ -582,7 +582,9 @@ katana::Result<void>
 katana::analytics::LouvainClustering(
     katana::PropertyGraph* pg, const std::string& edge_weight_property_name,
     const std::string& output_property_name, LouvainClusteringPlan plan) {
-  switch (pg->GetEdgeProperty(edge_weight_property_name)->type()->id()) {
+  switch (KATANA_CHECKED(pg->GetEdgeProperty(edge_weight_property_name))
+              ->type()
+              ->id()) {
   case arrow::UInt32Type::type_id:
     return LouvainClusteringWithWrap<uint32_t>(
         pg, edge_weight_property_name, output_property_name, plan);
@@ -726,7 +728,9 @@ katana::analytics::LouvainClusteringStatistics::Compute(
 
   double modularity = 0.0;
 
-  switch (pg->GetEdgeProperty(edge_weight_property_name)->type()->id()) {
+  switch (KATANA_CHECKED(pg->GetEdgeProperty(edge_weight_property_name))
+              ->type()
+              ->id()) {
   case arrow::UInt32Type::type_id: {
     auto modularity_result = CalModularityWrap<uint32_t>(
         pg, edge_weight_property_name, property_name);

--- a/libgalois/src/analytics/random_walks/random_walks.cpp
+++ b/libgalois/src/analytics/random_walks/random_walks.cpp
@@ -524,8 +524,8 @@ katana::analytics::RandomWalks(PropertyGraph* pg, RandomWalksPlan plan) {
 
 /// \cond DO_NOT_DOCUMENT
 katana::Result<void>
-katana::analytics::RandomWalksAssertValid([
-    [maybe_unused]] katana::PropertyGraph* pg) {
+katana::analytics::RandomWalksAssertValid(
+    [[maybe_unused]] katana::PropertyGraph* pg) {
   // TODO(gill): This should have real checks.
   return katana::ResultSuccess();
 }

--- a/libgalois/src/analytics/random_walks/random_walks.cpp
+++ b/libgalois/src/analytics/random_walks/random_walks.cpp
@@ -524,8 +524,8 @@ katana::analytics::RandomWalks(PropertyGraph* pg, RandomWalksPlan plan) {
 
 /// \cond DO_NOT_DOCUMENT
 katana::Result<void>
-katana::analytics::RandomWalksAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg) {
+katana::analytics::RandomWalksAssertValid([
+    [maybe_unused]] katana::PropertyGraph* pg) {
   // TODO(gill): This should have real checks.
   return katana::ResultSuccess();
 }

--- a/libgalois/src/analytics/sssp/sssp.cpp
+++ b/libgalois/src/analytics/sssp/sssp.cpp
@@ -529,7 +529,9 @@ SSSPWithWrap(
   if (!graph && graph.error() == katana::ErrorCode::TypeError) {
     KATANA_LOG_DEBUG(
         "Incorrect edge property type: {}",
-        pg->GetEdgeProperty(edge_weight_property_name)->type()->ToString());
+        KATANA_CHECKED(pg->GetEdgeProperty(edge_weight_property_name))
+            ->type()
+            ->ToString());
   }
   if (!graph) {
     return graph.error();
@@ -545,7 +547,9 @@ katana::analytics::Sssp(
     PropertyGraph* pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, SsspPlan plan) {
-  switch (pg->GetEdgeProperty(edge_weight_property_name)->type()->id()) {
+  switch (KATANA_CHECKED(pg->GetEdgeProperty(edge_weight_property_name))
+              ->type()
+              ->id()) {
   case arrow::UInt32Type::type_id:
     return SSSPWithWrap<uint32_t>(
         pg, start_node, edge_weight_property_name, output_property_name, plan);
@@ -610,7 +614,8 @@ katana::analytics::SsspAssertValid(
     katana::PropertyGraph* pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name) {
-  switch (pg->GetNodeProperty(output_property_name)->type()->id()) {
+  switch (
+      KATANA_CHECKED(pg->GetNodeProperty(output_property_name))->type()->id()) {
   case arrow::UInt32Type::type_id:
     return SsspValidateImpl<uint32_t>(
         pg, start_node, edge_weight_property_name, output_property_name);
@@ -678,7 +683,8 @@ ComputeStatistics(
 katana::Result<SsspStatistics>
 SsspStatistics::Compute(
     PropertyGraph* pg, const std::string& output_property_name) {
-  switch (pg->GetNodeProperty(output_property_name)->type()->id()) {
+  switch (
+      KATANA_CHECKED(pg->GetNodeProperty(output_property_name))->type()->id()) {
   case arrow::UInt32Type::type_id:
     return ComputeStatistics<uint32_t>(pg, output_property_name);
   case arrow::Int32Type::type_id:

--- a/lonestar/analytics/cpu/sssp/sssp_cli.cpp
+++ b/lonestar/analytics/cpu/sssp/sssp_cli.cpp
@@ -275,7 +275,7 @@ main(int argc, char** argv) {
 
     if (output) {
       std::string output_filename = "output-" + std::to_string(startNode);
-      switch (pg->GetNodeProperty(node_distance_prop)->type()->id()) {
+      switch (pg->GetNodeProperty(node_distance_prop).value()->type()->id()) {
       case arrow::UInt32Type::type_id:
         OutputResults<uint32_t>(pg.get(), node_distance_prop, output_filename);
         break;
@@ -296,7 +296,8 @@ main(int argc, char** argv) {
         break;
       default:
         KATANA_LOG_FATAL(
-            "Unsupported type: {}", pg->GetNodeProperty("distance")->type());
+            "Unsupported type: {}",
+            pg->GetNodeProperty(node_distance_prop).value()->type());
         break;
       }
     }


### PR DESCRIPTION
With: https://github.com/KatanaGraph/katana-enterprise/pull/1777

They now return Result types.

This fixes bugs in some algorithms that failed to check the return value properly.