### PR TITLE
ci: Avoid shell escaping issues by not printing PR body

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
+        run: echo "will build"
 
   do_cpp_test:
     needs:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
+        run: echo "will build"
 
   ###################################################################
   # lint

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
+        run: echo "will build"
 
   do_python_package:
     needs:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
+        run: echo "will build"
 
   do_python_test:
     needs:
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Info
-        run: echo "${{ github.event.pull_request.body }}"
+        run: echo "will build"
 
   build_and_test_conda_package:
     needs: do_python_package


### PR DESCRIPTION
A quotation mark in a PR description interferes with echo