### PR TITLE
build: Pin jupyter client version

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -46,6 +46,7 @@ dependencies:
 
 # The dependencies for pytest-notebook are incomplete, add them manually
  - pytest-notebook
+ - jupyter_client<7
  - attrs<21,>=19
  - nbconvert<6
  - pexpect

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -133,6 +133,7 @@ outputs:
 
         # The dependencies for pytest-notebook are incomplete, add them manually
         - pytest-notebook
+        - jupyter_client<7
         - attrs<21,>=19
         - nbconvert<6
         - pexpect


### PR DESCRIPTION
The pytest-notebook package depends on a older version of nbconvert
which in turn uses a nbclient package that seems incompatible with the
recent jupyter-client 7.

This leads to errors like:

  TypeError: 'coroutine' object is not subscriptable