### PR TITLE
build: Bound KATANA_NUM_TEST_THREADS

### DIFF
--- a/cmake/Modules/KatanaBuildCommon.cmake
+++ b/cmake/Modules/KatanaBuildCommon.cmake
@@ -59,13 +59,16 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "" CACHE STRING "Semi-colon separated list of D
 set(KATANA_PER_ROUND_STATS OFF CACHE BOOL "Report statistics of each round of execution")
 set(KATANA_NUM_TEST_GPUS "" CACHE STRING "Number of test GPUs to use (on a single machine) for running the tests.")
 set(KATANA_USE_LCI OFF CACHE BOOL "Use LCI network runtime instead of MPI")
-set(KATANA_NUM_TEST_THREADS "" CACHE STRING "Maximum number of threads to use when running tests (default: number of physical core)")
+set(KATANA_NUM_TEST_THREADS "" CACHE STRING "Maximum number of threads to use when running tests (default: min(number of physical core, 4))")
 set(KATANA_AUTO_CONAN OFF CACHE BOOL "Automatically call conan from cmake rather than manually (experimental)")
 
 cmake_host_system_information(RESULT KATANA_NUM_PHYSICAL_CORES QUERY NUMBER_OF_PHYSICAL_CORES)
 
 if (NOT KATANA_NUM_TEST_THREADS)
   set(KATANA_NUM_TEST_THREADS ${KATANA_NUM_PHYSICAL_CORES})
+  if (KATANA_NUM_TEST_THREADS GREATER_EQUAL 4)
+    set(KATANA_NUM_TEST_THREADS 4)
+  endif ()
 endif ()
 if (KATANA_NUM_TEST_THREADS LESS_EQUAL 0)
   set(KATANA_NUM_TEST_THREADS 1)


### PR DESCRIPTION
KATANA_NUM_TEST_THREADS is used to to setup test configurations. Since
tests themselves are generally run in parallel (make -j N) and some
tests scale weakly if at all, it is more appropriate for the number of
test threads to be independent of the actual number of processors,
keeping the amount of test work constant. Thus, when we move to larger
machines, tests get faster rather than slower.

Most users of KATANA_NUM_TEST_THREADS already manually bound its value
already to avoid excessive parallelism. This change makes this
consistent for all uses of KATANA_NUM_TEST_THREADS.

The value of 4 was chosen because it permits complicated interleavings,
it is a power of 2 and it is small.