### PR TITLE
PropertyGraph: move non-typical access functions to another class

### DIFF
--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -35,6 +35,7 @@ set(sources
         src/Profile.cpp
         src/Properties.cpp
         src/PropertyGraph.cpp
+        src/PropertyGraphRetractor.cpp
         src/PropertyIndex.cpp
         src/PropertyViews.cpp
         src/PtrLock.cpp

--- a/libgalois/include/katana/PropertyGraphRetractor.h
+++ b/libgalois/include/katana/PropertyGraphRetractor.h
@@ -1,0 +1,129 @@
+#ifndef KATANA_LIBGALOIS_KATANA_PROPERTYGRAPHRETRACTOR_H_
+#define KATANA_LIBGALOIS_KATANA_PROPERTYGRAPHRETRACTOR_H_
+
+#include "katana/PropertyGraph.h"
+
+namespace katana {
+
+/// A PropertyGraphRetractor provides a interfaces to some normally hidden
+/// parts of PropertyGraph; similar to the way a surgical retractor holds an
+/// incision open to provide access to normally hidden parts of our anatomy.
+///
+/// This is useful for cases like partitioning where extra
+/// metadata must be associated with a PropertyGraph, or where PropertyGraphs
+/// need to by dismantled piece-by-piece to save memory.
+///
+/// N.b.: some of these methods will leave the underlying PropertyGraph in an
+/// inconsistent state, always prefer using a PropertyGraph directly unless
+/// you're sure you need this.
+class KATANA_EXPORT PropertyGraphRetractor {
+public:
+  PropertyGraphRetractor(std::unique_ptr<PropertyGraph> pg)
+      : pg_(std::move(pg)) {}
+
+  const tsuba::PartitionMetadata& partition_metadata() const {
+    return pg_->rdg_.part_metadata();
+  }
+  void set_partition_metadata(const tsuba::PartitionMetadata& meta) {
+    pg_->rdg_.set_part_metadata(meta);
+  }
+
+  void update_rdg_metadata(const std::string& part_policy, uint32_t num_hosts) {
+    pg_->rdg_.set_view_name(
+        fmt::format("rdg-{}-part{}", part_policy, num_hosts));
+  }
+
+  /// Per-host vector of master nodes
+  ///
+  /// master_nodes()[this_host].empty() is true
+  /// master_nodes()[host_i][x] contains LocalNodeID of masters
+  //    for which host_i has a mirror
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
+      const {
+    return pg_->rdg_.master_nodes();
+  }
+  void set_master_nodes(std::vector<std::shared_ptr<arrow::ChunkedArray>>&& a) {
+    pg_->rdg_.set_master_nodes(std::move(a));
+  }
+
+  /// Per-host vector of mirror nodes
+  ///
+  /// mirror_nodes()[this_host].empty() is true
+  /// mirror_nodes()[host_i][x] contains LocalNodeID of mirrors
+  ///   that have a master on host_i
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes()
+      const {
+    return pg_->rdg_.mirror_nodes();
+  }
+  void set_mirror_nodes(std::vector<std::shared_ptr<arrow::ChunkedArray>>&& a) {
+    pg_->rdg_.set_mirror_nodes(std::move(a));
+  }
+
+  /// Return the node property table for local nodes
+  const std::shared_ptr<arrow::Table>& node_properties() const {
+    return pg_->rdg_.node_properties();
+  }
+
+  /// Return the edge property table for local edges
+  const std::shared_ptr<arrow::Table>& edge_properties() const {
+    return pg_->rdg_.edge_properties();
+  }
+
+  /// Tell the RDG where it's data is coming from
+  Result<void> InformPath(const std::string& input_path);
+
+  // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
+  // really a ChunkedArray of one chunk, change to arrow::Array.
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
+      const {
+    return pg_->rdg_.host_to_owned_global_node_ids();
+  }
+  void set_host_to_owned_global_node_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    pg_->rdg_.set_host_to_owned_global_node_ids(std::move(a));
+  }
+
+  // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
+  // really a ChunkedArray of one chunk, change to arrow::Array.
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
+      const {
+    return pg_->rdg_.host_to_owned_global_edge_ids();
+  }
+  void set_host_to_owned_global_edge_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    pg_->rdg_.set_host_to_owned_global_edge_ids(std::move(a));
+  }
+
+  // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
+  // really a ChunkedArray of one chunk, change to arrow::Array.
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
+    return pg_->rdg_.local_to_user_id();
+  }
+  void set_local_to_user_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
+    pg_->rdg_.set_local_to_user_id(std::move(a));
+  }
+
+  // TODO(witchel): ChunkedArray is inherited from arrow::Table interface but this is
+  // really a ChunkedArray of one chunk, change to arrow::Array.
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const {
+    return pg_->rdg_.local_to_global_id();
+  }
+  void set_local_to_global_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
+    pg_->rdg_.set_local_to_global_id(std::move(a));
+  }
+
+  /// deallocate and forget about all topology information associated with the
+  /// managed PropertyGraph
+  Result<void> DropTopologies();
+
+  /// access the managed PropertyGraph
+  PropertyGraph& property_graph() { return *pg_; }
+  const PropertyGraph& property_graph() const { return *pg_; }
+
+private:
+  std::unique_ptr<PropertyGraph> pg_;
+};
+
+}  // namespace katana
+
+#endif

--- a/libgalois/src/PropertyGraphRetractor.cpp
+++ b/libgalois/src/PropertyGraphRetractor.cpp
@@ -1,0 +1,20 @@
+#include "katana/PropertyGraphRetractor.h"
+
+template <typename T>
+using Result = katana::Result<T>;
+
+Result<void>
+katana::PropertyGraphRetractor::InformPath(const std::string& input_path) {
+  if (!pg_->rdg_.rdg_dir().empty()) {
+    KATANA_LOG_DEBUG("rdg dir from {} to {}", pg_->rdg_.rdg_dir(), input_path);
+  }
+
+  pg_->rdg_.set_rdg_dir(KATANA_CHECKED(katana::Uri::Make(input_path)));
+  return ResultSuccess();
+}
+
+Result<void>
+katana::PropertyGraphRetractor::DropTopologies() {
+  pg_->topology_ = GraphTopology{};
+  return pg_->rdg_.DropTopology();
+}

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -229,6 +229,9 @@ public:
   /// Remove all edge properties
   void DropEdgeProperties();
 
+  /// Remove topology data
+  katana::Result<void> DropTopology();
+
   std::shared_ptr<arrow::Schema> full_node_schema() const;
 
   std::shared_ptr<arrow::Schema> full_edge_schema() const;

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -923,6 +923,11 @@ tsuba::RDG::DropEdgeProperties() {
   core_->drop_edge_properties();
 }
 
+katana::Result<void>
+tsuba::RDG::DropTopology() {
+  return core_->UnbindTopologyFile();
+}
+
 std::shared_ptr<arrow::Schema>
 tsuba::RDG::full_node_schema() const {
   std::vector<std::shared_ptr<arrow::Field>> fields;

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -114,6 +114,10 @@ public:
     return topology_file_storage_.Unbind();
   }
 
+  katana::Result<void> UnbindTopologyFile() {
+    return topology_file_storage_.Unbind();
+  }
+
   katana::Result<void> RegisterNodeEntityTypeIDArrayFile(
       const std::string& new_type_id_array) {
     part_header_.set_node_entity_type_id_array_path(new_type_id_array);

--- a/python/katana/cpp/libgalois/graphs/Graph.pxd
+++ b/python/katana/cpp/libgalois/graphs/Graph.pxd
@@ -156,7 +156,6 @@ cdef extern from "katana/Graph.h" namespace "katana" nogil:
         shared_ptr[CTable] edge_properties()
 
         const string& rdg_dir()
-        Result[void]  InformPath(const string & input_path)
 
         shared_ptr[CChunkedArray] GetNodeProperty(int i)
         shared_ptr[CChunkedArray] GetNodeProperty(const string&)

--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -275,10 +275,6 @@ cdef class GraphBase:
         """
         return str(self.underlying_property_graph().rdg_dir(), encoding="UTF-8")
 
-    @path.setter
-    def path(self, path):
-        handle_result_void(self.underlying_property_graph().InformPath(bytes(str(path), encoding="UTF-8")))
-
 
 cdef class Graph(GraphBase):
     """


### PR DESCRIPTION
Sometimes we have to to do messy things to PropertyGraphs especially
when partitioning them. In an effort to keep those interfaces from
confusing direct users of PropertyGraph, this PR factors them out into
a friend class that I'm calling a "Retractor". The retractor lets
other codes that knows what it's doing have controlled access to
PropertyGraph internals.

This was motivated by the smaller change which added methods to
deallocate topology information. (Required to save memory during
repartitioning).

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>