### PR TITLE
Update google's benchmark library version

### DIFF
--- a/config/conanfile.py
+++ b/config/conanfile.py
@@ -12,7 +12,7 @@ class KatanaConan(ConanFile):
     #  - llvm
     requires = (
         "backward-cpp/1.5",
-        "benchmark/1.5.0",
+        "benchmark/1.5.3",
         "boost/1.74.0",
         "eigen/3.3.7",
         "fmt/6.2.1",


### PR DESCRIPTION
Version 1.5.0 of Benchmark has a missing include in one file the leads
to compile errors on modern compilers (gcc-11, clang-12). Upgrading to
version 1.5.3 resolves the issue.