### PR TITLE
Fix bug in PropertyGraph::ConstructEntityTypeIDs()

### DIFF
--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -396,14 +396,14 @@ katana::PropertyGraph::ConstructEntityTypeIDs() {
   // when EntityTypeIDs are not expected in properties then we have nothing to do here
   KATANA_LOG_WARN("Loading types from properties.");
   node_entity_type_manager_ = EntityTypeManager{};
-  EntityTypeIDArray node_entity_type_ids_;
+  node_entity_type_ids_ = EntityTypeIDArray{};
   node_entity_type_ids_.allocateInterleaved(num_nodes());
   KATANA_CHECKED(EntityTypeManager::AssignEntityTypeIDsFromProperties(
       num_nodes(), node_properties(), &node_entity_type_manager_,
       &node_entity_type_ids_));
 
   edge_entity_type_manager_ = EntityTypeManager{};
-  EntityTypeIDArray edge_entity_type_ids_;
+  edge_entity_type_ids_ = EntityTypeIDArray{};
   edge_entity_type_ids_.allocateInterleaved(num_edges());
   KATANA_CHECKED(EntityTypeManager::AssignEntityTypeIDsFromProperties(
       num_edges(), edge_properties(), &edge_entity_type_manager_,


### PR DESCRIPTION
This function was declaring two local variables, node_entity_type_ids_
and edge_entity_type_ids_. These two variables had the exact same names
as two PropertyGraph class members. So the function was operating on the
local objects, not the class members. As a result, all of the work of
the function was discarded after it returned.

Question for someone with more `PropertyGraph` experience (@amberhassaan maybe?): Here I set the two type arrays to be empty and then allocate the right amount of space for them. But in my experiments they were always the right size before I set them to empty. Is that something we can rely on? Or just a quirk of the test I was running?