### PR TITLE
Add edge_source() and original_edge_id() APIs to GraphTopology (and PropertyGraph by extension)

### DIFF
--- a/libgalois/test/CMakeLists.txt
+++ b/libgalois/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_test_unit(property-file-graph-rdg-conversion "${BASEINPUT}/propertygraphs/ld
 add_test_unit(property-graph)
 add_test_unit(property-graph-diff)
 add_test_unit(property-graph-bench NOT_QUICK)
+add_test_unit(property-graph-topology)
 add_test_unit(property-index)
 add_test_unit(reduction)
 add_test_unit(sort)

--- a/libgalois/test/property-graph-topology.cpp
+++ b/libgalois/test/property-graph-topology.cpp
@@ -1,0 +1,28 @@
+#include "katana/Logging.h"
+#include "katana/PropertyGraph.h"
+#include "katana/SharedMemSys.h"
+
+void
+TestEdgeSource(const katana::GraphTopology& topo) noexcept {
+  for (auto node : topo.all_nodes()) {
+    for (auto e : topo.edges(node)) {
+      auto s = topo.edge_source(e);
+      KATANA_LOG_ASSERT(s == node);
+    }
+  }
+}
+
+int
+main() {
+  katana::SharedMemSys S;
+
+  constexpr size_t kNumNodes = 1000;
+  constexpr size_t kEdgesPerNode = 5;
+
+  katana::GraphTopology topo =
+      katana::CreateUniformRandomTopology(kNumNodes, kEdgesPerNode);
+
+  TestEdgeSource(topo);
+
+  return 0;
+}


### PR DESCRIPTION
Query code needs to obtain source of an edge. Hence `edge_source()` API. Sometimes, query code needs to obtain the `LocalEdgeID` from a sorted topology, hence `original_edge_id()` API

Wait on: https://github.com/KatanaGraph/katana-enterprise/pull/1819

KAT-1325