### PR TITLE
Enable vectorized versions for RDG, RDGManifest

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -78,12 +78,12 @@ private:
   std::unique_ptr<tsuba::RDGFile> file_;
   GraphTopology topology_;
 
-  // branch_: the branch to write run-time PropertyGraph
-  // by default it is the trunk inside graph_dir.
+  /// the branch to write run-time PropertyGraph
+  /// by default it is the trunk inside graph_dir.
   katana::RDGVersion branch_{katana::RDGVersion(0)};
 
-  // loaded_version_: version loaded for current PropertyGraph
-  // since file_ is reserved for writing
+  /// version loaded for current PropertyGraph
+  /// since file_ is reserved for writing
   katana::RDGVersion loaded_version_{katana::RDGVersion(0)};
 
   /// Manages the relations between the node entity types
@@ -278,11 +278,6 @@ public:
   /// and its underlying resources.
   static Result<std::unique_ptr<PropertyGraph>> Make(
       std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg);
-
-  /// Make a property graph from an RDG name with Version.
-  static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name, katana::RDGVersion version,
-      const tsuba::RDGLoadOptions& opts);
 
   /// Make a property graph from an RDG name.
   static Result<std::unique_ptr<PropertyGraph>> Make(
@@ -715,7 +710,7 @@ public:
     return edge_entity_type_manager_;
   }
 
-  // Get the RDGFile version
+  /// Get the version from the RDGFile
   katana::RDGVersion RDGFileVersion() {
     if (file_ == nullptr) {
       return katana::RDGVersion(0);
@@ -724,19 +719,22 @@ public:
     }
   }
 
-  // Set or Get the targeted branch in graph_dir for writing PropertyGraph
-  // If a positive num is provided, new graph should retain the version number
+  /// Set the targeted branch in graph_dir for writing PropertyGraph
+  /// If a positive num is provided, new graph should retain the version number
   void SetBranch(const katana::RDGVersion& val, uint64_t num = 0) {
     branch_ = val;
     branch_.SetLeafNumber(num);
   }
+  /// Get the targeted branch in graph_dir for writing PropertyGraph
   katana::RDGVersion& GetBranch() { return branch_; }
 
-  // Set or Get the version of loaded PropertyGraph
+  /// Record the version of loaded PropertyGraph
   void SetLoadedVersion(const katana::RDGVersion& val) {
     loaded_version_ = val;
   }
+  /// Get the version of loaded PropertyGraph (const)
   const katana::RDGVersion& GetLoadedVersion() const { return loaded_version_; }
+  /// Get the version of loaded PropertyGraph for using its member functions
   katana::RDGVersion& GetLoadedVersion() { return loaded_version_; }
 
   /// Add Node properties that do not exist in the current graph

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -78,9 +78,8 @@ private:
   std::unique_ptr<tsuba::RDGFile> file_;
   GraphTopology topology_;
 
-  /// the branch to write run-time PropertyGraph
-  /// by default it is the trunk inside graph_dir.
-  katana::RDGVersion branch_{katana::RDGVersion(0)};
+  /// true when the loaded version is not the latest
+  bool intermediate_{false};
 
   /// version loaded for current PropertyGraph
   /// since file_ is reserved for writing
@@ -719,16 +718,13 @@ public:
     }
   }
 
-  /// Set the targeted branch in graph_dir for writing PropertyGraph
-  /// If a positive num is provided, new graph should retain the version number
-  void SetBranch(const katana::RDGVersion& val, uint64_t num = 0) {
-    branch_ = val;
-    branch_.SetLeafNumber(num);
-  }
-  /// Get the targeted branch in graph_dir for writing PropertyGraph
-  katana::RDGVersion& GetBranch() { return branch_; }
+  /// Check if the loaded PropertyGraph is intermediate
+  bool IsIntermediate() { return intermediate_; }
 
-  /// Record the version of loaded PropertyGraph
+  /// Set if the loaded PropertyGraph is intermediate
+  void SetIntermediate(bool val) { intermediate_ = val; }
+
+  /// Set the version of loaded PropertyGraph
   void SetLoadedVersion(const katana::RDGVersion& val) {
     loaded_version_ = val;
   }

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -81,9 +81,10 @@ private:
   /// true when the loaded version is not the latest
   bool intermediate_{false};
 
-  /// version loaded for current PropertyGraph
-  /// since file_ is reserved for writing
-  katana::RDGVersion loaded_version_{katana::RDGVersion(0)};
+  /// version loaded for the current PropertyGraph
+  /// It changes when the graph is updated or forked to a branch.
+  /// In contrast, the version with the RDG file_ is immutable.
+  katana::RDGVersion current_version_{katana::RDGVersion(0)};
 
   /// Manages the relations between the node entity types
   EntityTypeManager node_entity_type_manager_;
@@ -724,14 +725,14 @@ public:
   /// Set if the loaded PropertyGraph is intermediate
   void SetIntermediate(bool val) { intermediate_ = val; }
 
-  /// Set the version of loaded PropertyGraph
-  void SetLoadedVersion(const katana::RDGVersion& val) {
-    loaded_version_ = val;
+  /// Set the current version of loaded PropertyGraph
+  void SetVersion(const katana::RDGVersion& val) {
+    current_version_ = val;
   }
   /// Get the version of loaded PropertyGraph (const)
-  const katana::RDGVersion& GetLoadedVersion() const { return loaded_version_; }
+  const katana::RDGVersion& GetVersion() const { return current_version_; }
   /// Get the version of loaded PropertyGraph for using its member functions
-  katana::RDGVersion& GetLoadedVersion() { return loaded_version_; }
+  katana::RDGVersion& GetVersion() { return current_version_; }
 
   /// Add Node properties that do not exist in the current graph
   Result<void> AddNodeProperties(const std::shared_ptr<arrow::Table>& props);

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -726,9 +726,7 @@ public:
   void SetIntermediate(bool val) { intermediate_ = val; }
 
   /// Set the current version of loaded PropertyGraph
-  void SetVersion(const katana::RDGVersion& val) {
-    current_version_ = val;
-  }
+  void SetVersion(const katana::RDGVersion& val) { current_version_ = val; }
   /// Get the version of loaded PropertyGraph (const)
   const katana::RDGVersion& GetVersion() const { return current_version_; }
   /// Get the version of loaded PropertyGraph for using its member functions

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -78,6 +78,14 @@ private:
   std::unique_ptr<tsuba::RDGFile> file_;
   GraphTopology topology_;
 
+  // branch_: the branch to write run-time PropertyGraph
+  // by default it is the trunk inside graph_dir.
+  katana::RDGVersion branch_{katana::RDGVersion(0)};
+
+  // loaded_version_: version loaded for current PropertyGraph
+  // since file_ is reserved for writing
+  katana::RDGVersion loaded_version_{katana::RDGVersion(0)};
+
   /// Manages the relations between the node entity types
   EntityTypeManager node_entity_type_manager_;
   /// Manages the relations between the edge entity types
@@ -271,6 +279,11 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       std::unique_ptr<tsuba::RDGFile> rdg_file, tsuba::RDG&& rdg);
 
+  /// Make a property graph from an RDG name with Version.
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      const std::string& rdg_name, katana::RDGVersion version,
+      const tsuba::RDGLoadOptions& opts);
+
   /// Make a property graph from an RDG name.
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const std::string& rdg_name,
@@ -379,6 +392,14 @@ public:
   void set_local_to_global_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
     rdg_.set_local_to_global_id(std::move(a));
   }
+
+  /// Create a new branch for a graph and write everything into it.
+  ///
+  /// \returns io_error if, for instance, a file already exists
+  /// branch: the id of the branch
+  Result<void> CreateBranch(
+      const std::string& rdg_name, const std::string& command_line,
+      const std::string& branch);
 
   /// Create a new storage location for a graph and write everything into it.
   ///
@@ -693,6 +714,30 @@ public:
   const EntityTypeManager& edge_entity_type_manager() const noexcept {
     return edge_entity_type_manager_;
   }
+
+  // Get the RDGFile version
+  katana::RDGVersion RDGFileVersion() {
+    if (file_ == nullptr) {
+      return katana::RDGVersion(0);
+    } else {
+      return rdg_.GetFileVersion(*file_);
+    }
+  }
+
+  // Set or Get the targeted branch in graph_dir for writing PropertyGraph
+  // If a positive num is provided, new graph should retain the version number
+  void SetBranch(const katana::RDGVersion& val, uint64_t num = 0) {
+    branch_ = val;
+    branch_.SetLeafNumber(num);
+  }
+  katana::RDGVersion& GetBranch() { return branch_; }
+
+  // Set or Get the version of loaded PropertyGraph
+  void SetLoadedVersion(const katana::RDGVersion& val) {
+    loaded_version_ = val;
+  }
+  const katana::RDGVersion& GetLoadedVersion() const { return loaded_version_; }
+  katana::RDGVersion& GetLoadedVersion() { return loaded_version_; }
 
   /// Add Node properties that do not exist in the current graph
   Result<void> AddNodeProperties(const std::shared_ptr<arrow::Table>& props);

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -271,20 +271,12 @@ katana::PropertyGraph::Make(
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
-    const std::string& rdg_name, katana::RDGVersion version,
-    const tsuba::RDGLoadOptions& opts) {
+    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
   tsuba::RDGFile rdg_file{
-      KATANA_CHECKED(tsuba::Open(rdg_name, version, tsuba::kReadWrite))};
+      KATANA_CHECKED(tsuba::Open(rdg_name, opts.version, tsuba::kReadWrite))};
   tsuba::RDG rdg = KATANA_CHECKED(tsuba::RDG::Make(rdg_file, opts));
-
   return katana::PropertyGraph::Make(
       std::make_unique<tsuba::RDGFile>(std::move(rdg_file)), std::move(rdg));
-}
-
-katana::Result<std::unique_ptr<katana::PropertyGraph>>
-katana::PropertyGraph::Make(
-    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
-  return Make(rdg_name, katana::RDGVersion(0), opts);
 };
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -707,8 +707,7 @@ katana::Result<void>
 katana::PropertyGraph::Write(
     const std::string& rdg_name, const std::string& command_line) {
   if (auto res = tsuba::Create(rdg_name); !res) {
-    KATANA_LOG_DEBUG("failed to create the first manifest file\n");
-    return res.error();
+    return res.error().WithContext("failed to create the first manifest file");
   }
 
   katana::RDGVersion version = GetLoadedVersion();
@@ -730,9 +729,6 @@ katana::PropertyGraph::CreateBranch(
 
   // Create a branch with v0 and the lineage is encoded in the version
   KATANA_CHECKED(tsuba::Create(rdg_name, version));
-  KATANA_LOG_DEBUG(
-      "CreateBranch in {} from version {} with command_line {}; ", rdg_name,
-      GetBranch().ToString(), command_line);
 
   // Set the branch for search the latest manifest in that branch
   SetBranch(version);
@@ -921,7 +917,7 @@ katana::PropertyGraph::UnloadEdgeProperty(const std::string& prop_name) {
 katana::Result<void>
 katana::PropertyGraph::InformPath(const std::string& input_path) {
   if (!rdg_.rdg_dir().empty()) {
-    KATANA_LOG_DEBUG("rdg dir from {} to {} ", rdg_.rdg_dir(), input_path);
+    KATANA_LOG_DEBUG("rdg dir from {} to {}", rdg_.rdg_dir(), input_path);
   }
   auto uri_res = katana::Uri::Make(input_path);
   if (!uri_res) {

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -271,14 +271,21 @@ katana::PropertyGraph::Make(
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
-    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
+    const std::string& rdg_name, katana::RDGVersion version,
+    const tsuba::RDGLoadOptions& opts) {
   tsuba::RDGFile rdg_file{
-      KATANA_CHECKED(tsuba::Open(rdg_name, tsuba::kReadWrite))};
+      KATANA_CHECKED(tsuba::Open(rdg_name, version, tsuba::kReadWrite))};
   tsuba::RDG rdg = KATANA_CHECKED(tsuba::RDG::Make(rdg_file, opts));
 
   return katana::PropertyGraph::Make(
       std::make_unique<tsuba::RDGFile>(std::move(rdg_file)), std::move(rdg));
 }
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Make(
+    const std::string& rdg_name, const tsuba::RDGLoadOptions& opts) {
+  return Make(rdg_name, katana::RDGVersion(0), opts);
+};
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(katana::GraphTopology&& topo_to_assign) {
@@ -455,17 +462,24 @@ katana::Result<void>
 katana::PropertyGraph::ConductWriteOp(
     const std::string& uri, const std::string& command_line,
     tsuba::RDG::RDGVersioningPolicy versioning_action) {
-  auto open_res = tsuba::Open(uri, tsuba::kReadWrite);
+  // Point the write to the intended branch
+  // katana::RDGVersion target = GetLoadedVersion(); //katana::RDGVersion(0);
+  katana::RDGVersion target = GetBranch();
+  auto open_res = tsuba::Open(uri, target, tsuba::kReadWrite);
   if (!open_res) {
     return open_res.error();
   }
+
   auto new_file = std::make_unique<tsuba::RDGFile>(open_res.value());
 
-  if (auto res = DoWrite(*new_file, command_line, versioning_action); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(DoWrite(*new_file, command_line, versioning_action));
 
   file_ = std::move(new_file);
+
+  // Get the version from the RDGFile
+  katana::RDGVersion new_version = RDGFileVersion();
+  SetLoadedVersion(new_version);
+  SetBranch(new_version);
 
   return katana::ResultSuccess();
 }
@@ -493,8 +507,20 @@ katana::PropertyGraph::Commit(const std::string& command_line) {
     }
     return WriteGraph(rdg_.rdg_dir().string(), command_line);
   }
-  return DoWrite(
-      *file_, command_line, tsuba::RDG::RDGVersioningPolicy::IncrementVersion);
+
+  katana::RDGVersion current = GetLoadedVersion();
+  SetBranch(current);
+
+  KATANA_CHECKED(DoWrite(
+      *file_, command_line, tsuba::RDG::RDGVersioningPolicy::IncrementVersion));
+
+  // file_ is already updated as an In/Out parameter.
+  // Get the version from the RDGFile
+  katana::RDGVersion new_version = RDGFileVersion();
+  SetLoadedVersion(new_version);
+  SetBranch(new_version);
+
+  return katana::ResultSuccess();
 }
 
 katana::Result<void>
@@ -681,9 +707,56 @@ katana::Result<void>
 katana::PropertyGraph::Write(
     const std::string& rdg_name, const std::string& command_line) {
   if (auto res = tsuba::Create(rdg_name); !res) {
+    KATANA_LOG_DEBUG("failed to create the first manifest file\n");
     return res.error();
   }
+
+  katana::RDGVersion version = GetLoadedVersion();
+  if (!version.IsNull()) {
+    // Set the correct branch for writing
+    SetBranch(version);
+  }
+
   return WriteGraph(rdg_name, command_line);
+}
+
+katana::Result<void>
+katana::PropertyGraph::CreateBranch(
+    const std::string& rdg_name, const std::string& command_line,
+    const std::string& branch) {
+  // Create the branch based on loaded version
+  katana::RDGVersion version = GetLoadedVersion();
+  version.AddBranch(branch);
+
+  // Create a branch with v0 and the lineage is encoded in the version
+  KATANA_CHECKED(tsuba::Create(rdg_name, version));
+  KATANA_LOG_DEBUG(
+      "CreateBranch in {} from version {} with command_line {}; ", rdg_name,
+      GetBranch().ToString(), command_line);
+
+  // Set the branch for search the latest manifest in that branch
+  SetBranch(version);
+
+  // Open the target'ed manifest from version, supposedly v0
+  auto open_res = tsuba::Open(rdg_name, version, tsuba::kReadWrite);
+  if (!open_res) {
+    return open_res.error();
+  }
+  auto new_file = std::make_unique<tsuba::RDGFile>(open_res.value());
+
+  KATANA_CHECKED(DoWrite(
+      *new_file, command_line,
+      tsuba::RDG::RDGVersioningPolicy::IncrementVersion));
+
+  // update RDGfile_ after writing
+  file_ = std::move(new_file);
+
+  // Get the version from the new RDGFile
+  katana::RDGVersion new_version = RDGFileVersion();
+  SetLoadedVersion(new_version);
+  SetBranch(new_version);
+
+  return katana::ResultSuccess();
 }
 
 katana::Result<void>
@@ -848,7 +921,7 @@ katana::PropertyGraph::UnloadEdgeProperty(const std::string& prop_name) {
 katana::Result<void>
 katana::PropertyGraph::InformPath(const std::string& input_path) {
   if (!rdg_.rdg_dir().empty()) {
-    KATANA_LOG_DEBUG("rdg dir from {} to {}", rdg_.rdg_dir(), input_path);
+    KATANA_LOG_DEBUG("rdg dir from {} to {} ", rdg_.rdg_dir(), input_path);
   }
   auto uri_res = katana::Uri::Make(input_path);
   if (!uri_res) {

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -454,7 +454,7 @@ katana::Result<void>
 katana::PropertyGraph::ConductWriteOp(
     const std::string& uri, const std::string& command_line,
     tsuba::RDG::RDGVersioningPolicy versioning_action) {
-  katana::RDGVersion target = GetLoadedVersion();
+  katana::RDGVersion target = GetVersion();
   auto open_res = tsuba::Open(uri, target, tsuba::kReadWrite);
   if (!open_res) {
     return open_res.error();
@@ -468,7 +468,7 @@ katana::PropertyGraph::ConductWriteOp(
 
   // Get the version from the RDGFile
   katana::RDGVersion new_version = RDGFileVersion();
-  SetLoadedVersion(new_version);
+  SetVersion(new_version);
   return katana::ResultSuccess();
 }
 
@@ -502,7 +502,7 @@ katana::PropertyGraph::Commit(const std::string& command_line) {
   // file_ is already updated as an In/Out parameter.
   // Get the version from the RDGFile
   katana::RDGVersion new_version = RDGFileVersion();
-  SetLoadedVersion(new_version);
+  SetVersion(new_version);
   return katana::ResultSuccess();
 }
 
@@ -693,7 +693,7 @@ katana::PropertyGraph::Write(
     return res.error().WithContext("failed to create the first manifest file");
   }
 
-  SetLoadedVersion(katana::RDGVersion(0));
+  SetVersion(katana::RDGVersion(0));
   return WriteGraph(rdg_name, command_line);
 }
 
@@ -702,7 +702,7 @@ katana::PropertyGraph::CreateBranch(
     const std::string& rdg_name, const std::string& command_line,
     const std::string& branch) {
   // Create the branch based on loaded version
-  katana::RDGVersion version = GetLoadedVersion();
+  katana::RDGVersion version = GetVersion();
   version.AddBranch(branch);
 
   // Create a branch with v0 and the lineage is encoded in the version
@@ -724,7 +724,7 @@ katana::PropertyGraph::CreateBranch(
 
   // Get the version from the new RDGFile
   katana::RDGVersion new_version = RDGFileVersion();
-  SetLoadedVersion(new_version);
+  SetVersion(new_version);
   return katana::ResultSuccess();
 }
 

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -30,6 +30,7 @@ set(sources
         src/Strings.cpp
         src/TextTracer.cpp
         src/URI.cpp
+        src/RDGVersion.cpp
 )
 
 target_sources(katana_support PRIVATE ${sources})

--- a/libsupport/include/katana/RDGVersion.h
+++ b/libsupport/include/katana/RDGVersion.h
@@ -25,7 +25,11 @@ struct KATANA_EXPORT RDGVersion {
   std::vector<std::string> branches_{"."};
 
   RDGVersion(const RDGVersion& in) = default;
-  RDGVersion& operator=(const RDGVersion& in) = default;
+  RDGVersion& operator=(const RDGVersion& in) {
+    numbers_ = in.numbers_;
+    branches_ = in.branches_;
+    return *this;
+  }
 
   RDGVersion(
       const std::vector<uint64_t>& nums,
@@ -38,8 +42,6 @@ struct KATANA_EXPORT RDGVersion {
   std::string ToString() const;
   uint64_t LeafNumber() const;
   bool ShareBranch(const RDGVersion& in) const;
-  bool NullNumber() const;
-  bool NullBranch() const;
   bool IsNull() const;
 
   // Mutators

--- a/libsupport/include/katana/RDGVersion.h
+++ b/libsupport/include/katana/RDGVersion.h
@@ -15,7 +15,8 @@
 namespace katana {
 
 const uint64_t kRDGVersionMaxID = (1 << 30);
-const uint64_t kRDGVersionIDLength = (20);
+const uint64_t kRDGVersionIDLength = (256);
+const int      kRDGVersionPaddingLength = (10);
 
 struct KATANA_EXPORT RDGVersion {
   // A vectorized version in the form of num:id

--- a/libsupport/include/katana/RDGVersion.h
+++ b/libsupport/include/katana/RDGVersion.h
@@ -42,7 +42,7 @@ struct KATANA_EXPORT RDGVersion {
   std::string ToString() const;
   uint64_t LeafNumber() const;
   bool ShareBranch(const RDGVersion& in) const;
-  bool IsNull() const;
+  bool IsZero() const;
 
   // Mutators
   void IncrementLeaf(uint64_t num = 1);

--- a/libsupport/include/katana/RDGVersion.h
+++ b/libsupport/include/katana/RDGVersion.h
@@ -16,7 +16,7 @@ namespace katana {
 
 const uint64_t kRDGVersionMaxID = (1 << 30);
 const uint64_t kRDGVersionIDLength = (256);
-const int      kRDGVersionPaddingLength = (10);
+const int kRDGVersionPaddingLength = (10);
 
 struct KATANA_EXPORT RDGVersion {
   // A vectorized version in the form of num:id

--- a/libsupport/include/katana/RDGVersion.h
+++ b/libsupport/include/katana/RDGVersion.h
@@ -1,0 +1,59 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_RDGVERSION_H_
+#define KATANA_LIBSUPPORT_KATANA_RDGVERSION_H_
+
+#include <cstring>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include "katana/Random.h"
+#include "katana/config.h"
+
+namespace katana {
+
+const uint64_t kRDGVersionMaxID = (1 << 30);
+const uint64_t kRDGVersionIDLength = (20);
+
+struct KATANA_EXPORT RDGVersion {
+  // A vectorized version in the form of num:id
+  // The last one has an empty branch "".
+  std::vector<uint64_t> numbers_{0};
+  std::vector<std::string> branches_{"."};
+
+  RDGVersion(const RDGVersion& in) = default;
+  RDGVersion& operator=(const RDGVersion& in) = default;
+
+  RDGVersion(
+      const std::vector<uint64_t>& nums,
+      const std::vector<std::string>& branches);
+  RDGVersion(const std::string& str);
+  explicit RDGVersion(uint64_t num = 0);
+
+  // Accessors
+  std::string ToPathName() const;
+  std::string ToString() const;
+  uint64_t LeafNumber() const;
+  bool ShareBranch(const RDGVersion& in) const;
+  bool NullNumber() const;
+  bool NullBranch() const;
+  bool IsNull() const;
+
+  // Mutators
+  void IncrementLeaf(uint64_t num = 1);
+  void SetLeafNumber(uint64_t num = 0);
+  void AddBranch(const std::string& name);
+};
+
+KATANA_EXPORT bool operator==(const RDGVersion& lhs, const RDGVersion& rhs);
+KATANA_EXPORT bool operator!=(const RDGVersion& lhs, const RDGVersion& rhs);
+KATANA_EXPORT bool operator>(const RDGVersion& lhs, const RDGVersion& rhs);
+KATANA_EXPORT bool operator<(const RDGVersion& lhs, const RDGVersion& rhs);
+
+void to_json(nlohmann::json& j, const RDGVersion& version);
+void from_json(const nlohmann::json& j, RDGVersion& version);
+}  // namespace katana
+
+#endif

--- a/libsupport/include/katana/Random.h
+++ b/libsupport/include/katana/Random.h
@@ -11,6 +11,8 @@ namespace katana {
 
 using RandGenerator = std::mt19937;
 
+const uint64_t kRandomIDLength = (12);
+
 /// Generate a random alphanumeric string of length \param len using
 /// \param gen if provided. If no generator is specified, use the output of
 /// GetGenerator

--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -14,6 +14,7 @@
 
 #include "katana/ErrorCode.h"
 #include "katana/Logging.h"
+#include "katana/RDGVersion.h"
 #include "katana/config.h"
 
 /// Code that needs to indicate an error to callers typically should use

--- a/libsupport/src/RDGVersion.cpp
+++ b/libsupport/src/RDGVersion.cpp
@@ -1,0 +1,182 @@
+#include "katana/RDGVersion.h"
+
+#include "katana/Logging.h"
+
+namespace katana {
+
+RDGVersion::RDGVersion(
+    const std::vector<uint64_t>& vers, const std::vector<std::string>& ids)
+    : numbers_(vers), branches_(ids) {}
+
+RDGVersion::RDGVersion(uint64_t num) { numbers_.back() = num; }
+
+RDGVersion::RDGVersion(const std::string& src) {
+  KATANA_LOG_DEBUG_ASSERT(src.size() == 20);
+  char dest[kRDGVersionIDLength + 1];
+  char* token;
+
+  strncpy(dest, src.c_str(), kRDGVersionIDLength);
+  dest[kRDGVersionIDLength] = '\0';
+  token = strtok(dest, "_");
+
+  if (token != NULL) {
+    numbers_.clear();
+    branches_.clear();
+    do {
+      uint64_t val = strtoul(token, nullptr, 10);
+      numbers_.emplace_back(val);
+      token = strtok(NULL, "_");
+      if (token != NULL) {
+        branches_.emplace_back(token);
+        token = strtok(NULL, "_");
+      } else {
+        branches_.emplace_back(".");
+        break;
+      }
+    } while (token != NULL);
+  }
+}
+
+std::string
+RDGVersion::ToPathName() const {
+  std::string vec = "";
+  if (numbers_.size() == 0) {
+    return vec;
+  }
+  for (uint32_t i = 0; (i + 1) < numbers_.size(); i++) {
+    vec += fmt::format("{:03d}_{}_", numbers_[i], branches_[i]);
+  }
+  // include only the number from the last pair, ignore "."
+  return fmt::format("{}{:03d}", vec, numbers_.back());
+}
+
+std::string
+RDGVersion::ToString() const {
+  return fmt::format("{}_{}", ToPathName(), branches_.back());
+}
+
+bool
+RDGVersion::NullNumber() const {
+  // No branch and no positive ID
+  return (numbers_.empty() || numbers_.back() == 0);
+}
+
+bool
+RDGVersion::NullBranch() const {
+  // No branch and no positive ID
+  return (branches_.empty() || branches_.back() == ".");
+}
+
+bool
+RDGVersion::IsNull() const {
+  // No branch and no positive ID
+  return (branches_.size() <= 1 && (numbers_.empty() || numbers_.back() == 0));
+}
+
+uint64_t
+RDGVersion::LeafNumber() const {
+  return numbers_.back();
+}
+
+bool
+RDGVersion::ShareBranch(const RDGVersion& in) const {
+  KATANA_LOG_DEBUG_ASSERT(
+      (branches_.size() == numbers_.size()) &&
+      (in.branches_.size() == in.numbers_.size()));
+  if (branches_.size() != in.branches_.size()) {
+    return false;
+  }
+
+  for (uint32_t i = 0; i < branches_.size(); i++) {
+    // take "" as equivalent to "."
+    if ((branches_[i] == "." || branches_[i] == "") &&
+        (in.branches_[i] == "." || in.branches_[i] == "")) {
+      continue;
+    } else if (branches_[i] != in.branches_[i]) {
+      return false;
+    }
+  }
+
+  for (uint32_t i = 0; (i + 1) < numbers_.size(); i++) {
+    if (numbers_[i] != in.numbers_[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void
+RDGVersion::IncrementLeaf(uint64_t num) {
+  numbers_.back() += num;
+}
+
+void
+RDGVersion::SetLeafNumber(uint64_t num) {
+  numbers_.back() = num;
+}
+
+void
+RDGVersion::AddBranch(const std::string& name) {
+  branches_.back() = name;
+  numbers_.emplace_back(0);
+  branches_.emplace_back(".");
+}
+
+bool
+operator==(const RDGVersion& lhs, const RDGVersion& rhs) {
+  RDGVersion tmp = lhs;
+  if (!tmp.ShareBranch(rhs))
+    return false;
+
+  if (lhs.numbers_ == rhs.numbers_)
+    return true;
+  else
+    return false;
+}
+
+bool
+operator!=(const RDGVersion& lhs, const RDGVersion& rhs) {
+  return (!(lhs == rhs));
+}
+
+bool
+operator>(const RDGVersion& lhs, const RDGVersion& rhs) {
+  uint32_t min = std::min(lhs.numbers_.size(), rhs.numbers_.size());
+
+  for (uint32_t i = 0; i < min; i++) {
+    if (lhs.numbers_[i] < rhs.numbers_[i]) {
+      return false;
+    }
+    if (lhs.numbers_[i] > rhs.numbers_[i]) {
+      return true;
+    }
+  }
+
+  if (lhs.numbers_.size() <= rhs.numbers_.size())
+    return false;
+
+  return true;
+}
+
+bool
+operator<(const RDGVersion& lhs, const RDGVersion& rhs) {
+  uint32_t min = std::min(lhs.numbers_.size(), rhs.numbers_.size());
+
+  for (uint32_t i = 0; i < min; i++) {
+    if (lhs.numbers_[i] > rhs.numbers_[i]) {
+      return false;
+    }
+    if (lhs.numbers_[i] < rhs.numbers_[i]) {
+      return true;
+    }
+  }
+
+  if (lhs.numbers_.size() >= rhs.numbers_.size()) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+}  // namespace katana

--- a/libsupport/src/RDGVersion.cpp
+++ b/libsupport/src/RDGVersion.cpp
@@ -38,19 +38,16 @@ RDGVersion::RDGVersion(const std::string& src) {
 
 std::string
 RDGVersion::ToPathName() const {
-  std::string vec = fmt::format("{0:0{1}d}",
-      0, kRDGVersionPaddingLength);
+  std::string vec = fmt::format("{0:0{1}d}", 0, kRDGVersionPaddingLength);
   if (numbers_.size() == 0) {
     return vec;
   }
   for (uint32_t i = 0; (i + 1) < numbers_.size(); i++) {
-    vec += fmt::format("{0:0{1}d}",
-        numbers_[i], kRDGVersionPaddingLength);
+    vec += fmt::format("{0:0{1}d}", numbers_[i], kRDGVersionPaddingLength);
     vec += fmt::format("_{}_", branches_[i]);
   }
   // include only the number from the last pair, ignore "."
-  vec += fmt::format("{0:0{1}d}",
-      numbers_.back(), kRDGVersionPaddingLength);
+  vec += fmt::format("{0:0{1}d}", numbers_.back(), kRDGVersionPaddingLength);
   return vec;
 }
 

--- a/libsupport/src/RDGVersion.cpp
+++ b/libsupport/src/RDGVersion.cpp
@@ -11,7 +11,6 @@ RDGVersion::RDGVersion(
 RDGVersion::RDGVersion(uint64_t num) { numbers_.back() = num; }
 
 RDGVersion::RDGVersion(const std::string& src) {
-  KATANA_LOG_DEBUG_ASSERT(src.size() == 20);
   char dest[kRDGVersionIDLength + 1];
   char* token;
 
@@ -39,15 +38,20 @@ RDGVersion::RDGVersion(const std::string& src) {
 
 std::string
 RDGVersion::ToPathName() const {
-  std::string vec = "";
+  std::string vec = fmt::format("{0:0{1}d}",
+      0, kRDGVersionPaddingLength);
   if (numbers_.size() == 0) {
     return vec;
   }
   for (uint32_t i = 0; (i + 1) < numbers_.size(); i++) {
-    vec += fmt::format("{:03d}_{}_", numbers_[i], branches_[i]);
+    vec += fmt::format("{0:0{1}d}",
+        numbers_[i], kRDGVersionPaddingLength);
+    vec += fmt::format("_{}_", branches_[i]);
   }
   // include only the number from the last pair, ignore "."
-  return fmt::format("{}{:03d}", vec, numbers_.back());
+  vec += fmt::format("{0:0{1}d}",
+      numbers_.back(), kRDGVersionPaddingLength);
+  return vec;
 }
 
 std::string

--- a/libsupport/src/RDGVersion.cpp
+++ b/libsupport/src/RDGVersion.cpp
@@ -60,18 +60,6 @@ RDGVersion::ToString() const {
 }
 
 bool
-RDGVersion::NullNumber() const {
-  // No branch and no positive ID
-  return (numbers_.empty() || numbers_.back() == 0);
-}
-
-bool
-RDGVersion::NullBranch() const {
-  // No branch and no positive ID
-  return (branches_.empty() || branches_.back() == ".");
-}
-
-bool
 RDGVersion::IsNull() const {
   // No branch and no positive ID
   return (branches_.size() <= 1 && (numbers_.empty() || numbers_.back() == 0));

--- a/libsupport/src/RDGVersion.cpp
+++ b/libsupport/src/RDGVersion.cpp
@@ -60,7 +60,7 @@ RDGVersion::ToString() const {
 }
 
 bool
-RDGVersion::IsNull() const {
+RDGVersion::IsZero() const {
   // No branch and no positive ID
   return (branches_.size() <= 1 && (numbers_.empty() || numbers_.back() == 0));
 }

--- a/libsupport/src/URI.cpp
+++ b/libsupport/src/URI.cpp
@@ -75,7 +75,7 @@ std::string
 AddRandComponent(const std::string& str) {
   std::string name(str);
   name += "-";
-  name += katana::RandomAlphanumericString(12);
+  name += katana::RandomAlphanumericString(katana::kRandomIDLength);
   return name;
 }
 

--- a/libsupport/test/random.cpp
+++ b/libsupport/test/random.cpp
@@ -11,7 +11,7 @@ main() {
   std::vector<std::thread> threads;
   for (int i = 0; i < 128; ++i) {
     threads.emplace_back([]() {
-      std::string s = katana::RandomAlphanumericString(12);
+      std::string s = katana::RandomAlphanumericString(katana::kRandomIDLength);
       KATANA_LOG_DEBUG("Got {}", s);
     });
   }
@@ -31,7 +31,8 @@ main() {
   std::vector<std::string> results(128);
   for (int i = 0; i < 128; ++i) {
     threads.emplace_back([&generators, &results, i]() {
-      results[i] = katana::RandomAlphanumericString(12, &generators[i]);
+      results[i] = katana::RandomAlphanumericString(
+          katana::kRandomIDLength, &generators[i]);
     });
   }
 

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -118,6 +118,9 @@ public:
         node_entity_type_manager, edge_entity_type_manager);
   }
 
+  /// @brief Get the current version from the RDGFile
+  katana::RDGVersion GetFileVersion(RDGHandle handle);
+
   /// @brief Store RDG with lineage based on command line and update version based on the versioning policy.
   /// @param handle :: handle indicating where to store RDG
   /// @param command_line :: added to metadata to track lineage of RDG
@@ -305,7 +308,7 @@ private:
   katana::Result<void> DoMake(
       const std::vector<PropStorageInfo*>& node_props_to_be_loaded,
       const std::vector<PropStorageInfo*>& edge_props_to_be_loaded,
-      const katana::Uri& metadata_dir);
+      const RDGManifest& manifest);
 
   static katana::Result<RDG> Make(
       const RDGManifest& manifest, const RDGLoadOptions& opts);

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -41,6 +41,9 @@ struct KATANA_EXPORT RDGLoadOptions {
   /// List of edge properties that should be loaded
   /// nullptr means all edge properties will be loaded
   std::optional<std::vector<std::string>> edge_properties{std::nullopt};
+
+  /// the version to be loaded, default is 0 (null version)
+  katana::RDGVersion version;
 };
 
 class KATANA_EXPORT RDG {

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -43,7 +43,7 @@ struct KATANA_EXPORT RDGLoadOptions {
   std::optional<std::vector<std::string>> edge_properties{std::nullopt};
 
   /// the version to be loaded, default is 0 (null version)
-  katana::RDGVersion version;
+  katana::RDGVersion version{katana::RDGVersion(0)};
 };
 
 class KATANA_EXPORT RDG {

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -8,6 +8,7 @@
 #include "katana/CommBackend.h"
 #include "katana/EntityTypeManager.h"
 #include "katana/Iterators.h"
+#include "katana/RDGVersion.h"
 #include "katana/Result.h"
 #include "katana/URI.h"
 #include "katana/config.h"
@@ -57,7 +58,7 @@ KATANA_EXPORT katana::Result<RDGHandle> Open(
     const std::string& rdg_name, uint32_t flags);
 
 KATANA_EXPORT katana::Result<RDGHandle> Open(
-    const std::string& rdg_name, uint64_t version, uint32_t flags);
+    const std::string& rdg_name, katana::RDGVersion version, uint32_t flags);
 
 /// Generate a new canonically named topology file name in the
 /// directory associated with handle. Exported to support
@@ -82,14 +83,15 @@ KATANA_EXPORT katana::Result<void> Close(RDGHandle handle);
 
 /// Create an RDG storage location
 /// \param name is storage location prefix that will be used to store the RDG
-KATANA_EXPORT katana::Result<void> Create(const std::string& name);
+KATANA_EXPORT katana::Result<void> Create(
+    const std::string& name, katana::RDGVersion = katana::RDGVersion(0));
 
 /// @brief Describes properties of RDGView
 /// The RDGView will describe will identify the view-type, the arguments used to
 /// create it, where it is stored, and the properties of the partioning strategy
 /// used to distribute its data across the hosts which will load it.
 struct KATANA_EXPORT RDGView {
-  uint64_t view_version{0};
+  katana::RDGVersion view_version{katana::RDGVersion(0)};
   std::string view_type;
   std::string view_args;
   std::string view_path;
@@ -106,6 +108,10 @@ struct KATANA_EXPORT RDGStat {
 
 /// Get Information about the graph
 KATANA_EXPORT katana::Result<RDGStat> Stat(const std::string& rdg_name);
+
+KATANA_EXPORT katana::Result<std::vector<RDGView>> ListAvailableViewsForVersion(
+    const std::string& rdg_dir, katana::RDGVersion version,
+    katana::RDGVersion* max_version);
 
 KATANA_EXPORT katana::Result<std::vector<RDGView>> ListAvailableViews(
     const std::string& rdg_dir);

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -68,10 +68,6 @@ RDGManifest::MakeFromStorage(const katana::Uri& uri) {
     return manifest_res.error().WithContext("cannot parse {}", uri.string());
   }
 
-  KATANA_LOG_DEBUG(
-      "parsed URI {} dir {} base {}", uri.string(), uri.DirName(),
-      uri.BaseName());
-
   auto manifest_name = uri.BaseName();
   auto view_name = ParseViewNameFromName(manifest_name);
   auto view_args = ParseViewArgsFromName(manifest_name);

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -33,15 +33,10 @@ const int MANIFEST_MATCH_VIEW_INDEX = 2;
 
 namespace {
 const int NODE_ZERO_PADDING_LENGTH = 5;
-const int VERS_ZERO_PADDING_LENGTH = 20;
 std::string
 ToVersionString(katana::RDGVersion version) {
   std::string str = version.ToPathName();
-  std::string leading_zeros =
-      fmt::format("{0:0{1}d}", 0, (VERS_ZERO_PADDING_LENGTH - str.size()));
-  KATANA_LOG_DEBUG_ASSERT(
-      leading_zeros.size() + str.size() == VERS_ZERO_PADDING_LENGTH);
-  return fmt::format("vers{}{}", leading_zeros, str);
+  return fmt::format("vers{}", str);
 }
 std::string
 ToNodeString(uint32_t node_id) {
@@ -113,7 +108,6 @@ RDGManifest::PartitionFileName(
     const std::string& view_type, uint32_t node_id,
     katana::RDGVersion version) {
   KATANA_LOG_ASSERT(!view_type.empty());
-  // TODO(wkyu): provide an alternative of variable length
   return fmt::format(
       "part_{}_{}_{}", ToVersionString(version), view_type,
       ToNodeString(node_id));

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -18,14 +18,12 @@ using json = nlohmann::json;
 
 namespace {
 
-Result<uint64_t>
-Parse(const std::string& str) {
-  uint64_t val = strtoul(str.c_str(), nullptr, 10);
-  if (errno == ERANGE) {
-    return KATANA_ERROR(
-        katana::ResultErrno(), "manifest file found with out of range version");
-  }
-  return val;
+Result<katana::RDGVersion>
+ParseVersion(const std::string& str) {
+  // The length of "vers" is 4.
+  std::string prefix = "vers";
+  std::string version = str.substr(prefix.size());
+  return katana::RDGVersion(version);
 }
 
 const int MANIFEST_MATCH_VERS_INDEX = 1;
@@ -37,8 +35,13 @@ namespace {
 const int NODE_ZERO_PADDING_LENGTH = 5;
 const int VERS_ZERO_PADDING_LENGTH = 20;
 std::string
-ToVersionString(uint64_t version) {
-  return fmt::format("vers{0:0{1}d}", version, VERS_ZERO_PADDING_LENGTH);
+ToVersionString(katana::RDGVersion version) {
+  std::string str = version.ToPathName();
+  std::string leading_zeros =
+      fmt::format("{0:0{1}d}", 0, (VERS_ZERO_PADDING_LENGTH - str.size()));
+  KATANA_LOG_DEBUG_ASSERT(
+      leading_zeros.size() + str.size() == VERS_ZERO_PADDING_LENGTH);
+  return fmt::format("vers{}{}", leading_zeros, str);
 }
 std::string
 ToNodeString(uint32_t node_id) {
@@ -48,7 +51,7 @@ ToNodeString(uint32_t node_id) {
 namespace tsuba {
 
 const std::regex RDGManifest::kManifestVersion(
-    "katana_vers(?:([0-9]+))_(?:([0-9A-Za-z-]+))\\.manifest$");
+    "katana_(?:(vers[0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))\\.manifest$");
 
 Result<tsuba::RDGManifest>
 RDGManifest::MakeFromStorage(const katana::Uri& uri) {
@@ -65,9 +68,14 @@ RDGManifest::MakeFromStorage(const katana::Uri& uri) {
     return manifest_res.error().WithContext("cannot parse {}", uri.string());
   }
 
+  KATANA_LOG_DEBUG(
+      "parsed URI {} dir {} base {}", uri.string(), uri.DirName(),
+      uri.BaseName());
+
   auto manifest_name = uri.BaseName();
   auto view_name = ParseViewNameFromName(manifest_name);
   auto view_args = ParseViewArgsFromName(manifest_name);
+  auto version_num = ParseVersionFromName(manifest_name);
 
   if (view_name) {
     manifest.set_viewtype(view_name.value());
@@ -78,12 +86,18 @@ RDGManifest::MakeFromStorage(const katana::Uri& uri) {
   } else {
     manifest.set_viewargs(std::vector<std::string>());
   }
+
+  if (version_num) {
+    manifest.set_version(std::move(katana::RDGVersion(version_num.value())));
+  }
+
   return manifest;
 }
 
 Result<RDGManifest>
 RDGManifest::Make(
-    const katana::Uri& uri, const std::string& view_type, uint64_t version) {
+    const katana::Uri& uri, const std::string& view_type,
+    katana::RDGVersion version) {
   return MakeFromStorage(FileName(uri, view_type, version));
 }
 
@@ -100,8 +114,10 @@ RDGManifest::Make(const katana::Uri& uri) {
 
 std::string
 RDGManifest::PartitionFileName(
-    const std::string& view_type, uint32_t node_id, uint64_t version) {
+    const std::string& view_type, uint32_t node_id,
+    katana::RDGVersion version) {
   KATANA_LOG_ASSERT(!view_type.empty());
+  // TODO(wkyu): provide an alternative of variable length
   return fmt::format(
       "part_{}_{}_{}", ToVersionString(version), view_type,
       ToNodeString(node_id));
@@ -109,7 +125,7 @@ RDGManifest::PartitionFileName(
 
 katana::Uri
 RDGManifest::PartitionFileName(
-    const katana::Uri& uri, uint32_t node_id, uint64_t version) {
+    const katana::Uri& uri, uint32_t node_id, katana::RDGVersion version) {
   return uri.Join(
       PartitionFileName(tsuba::kDefaultRDGViewType, node_id, version));
 }
@@ -117,7 +133,7 @@ RDGManifest::PartitionFileName(
 katana::Uri
 RDGManifest::PartitionFileName(
     const std::string& view_type, const katana::Uri& uri, uint32_t node_id,
-    uint64_t version) {
+    katana::RDGVersion version) {
   KATANA_LOG_DEBUG_ASSERT(!IsManifestUri(uri));
   return uri.Join(PartitionFileName(view_type, node_id, version));
 }
@@ -138,7 +154,8 @@ RDGManifest::ToJsonString() const {
 // e.g., rdg_dir == s3://witchel-tests-east2/fault/simple/
 katana::Uri
 RDGManifest::FileName(
-    const katana::Uri& uri, const std::string& view_name, uint64_t version) {
+    const katana::Uri& uri, const std::string& view_name,
+    katana::RDGVersion version) {
   KATANA_LOG_DEBUG_ASSERT(uri.empty() || !IsManifestUri(uri));
   KATANA_LOG_ASSERT(!view_name.empty());
   return uri.Join(fmt::format(
@@ -152,14 +169,14 @@ RDGManifest::IsManifestUri(const katana::Uri& uri) {
   return res;
 }
 
-Result<uint64_t>
+Result<katana::RDGVersion>
 RDGManifest::ParseVersionFromName(const std::string& file) {
   std::smatch sub_match;
   if (!std::regex_match(file, sub_match, kManifestVersion)) {
     return tsuba::ErrorCode::InvalidArgument;
   }
   //Manifest file
-  return Parse(sub_match[MANIFEST_MATCH_VERS_INDEX]);
+  return ParseVersion(sub_match[MANIFEST_MATCH_VERS_INDEX]);
 }
 
 Result<std::string>
@@ -226,7 +243,7 @@ RDGManifest::FileNames() {
     if (!header_res) {
       KATANA_LOG_DEBUG(
           "problem uri: {} host: {} ver: {} view_name: {}  : {}", header_uri, i,
-          version(), view_specifier(), header_res.error());
+          version().LeafNumber(), view_specifier(), header_res.error());
     } else {
       auto header = std::move(header_res.value());
       for (const auto& node_prop : header.node_prop_info_list()) {
@@ -248,11 +265,27 @@ RDGManifest::FileNames() {
 }  // namespace tsuba
 
 void
+katana::to_json(json& j, const katana::RDGVersion& version) {
+  j = json{
+      {"numbers", version.numbers_},
+      {"branches", version.branches_},
+  };
+}
+
+void
+katana::from_json(const json& j, katana::RDGVersion& version) {
+  j.at("numbers").get_to(version.numbers_);
+  j.at("branches").get_to(version.branches_);
+}
+
+void
 tsuba::to_json(json& j, const tsuba::RDGManifest& manifest) {
+  katana::RDGVersion ver = manifest.version_;
+  katana::RDGVersion prev = manifest.previous_version_;
   j = json{
       {"magic", kRDGMagicNo},
-      {"version", manifest.version_},
-      {"previous_version", manifest.previous_version_},
+      {"version_vec", manifest.version_},
+      {"previous_version_vec", manifest.previous_version_},
       {"num_hosts", manifest.num_hosts_},
       {"policy_id", manifest.policy_id_},
       {"transpose", manifest.transpose_},
@@ -264,13 +297,20 @@ void
 tsuba::from_json(const json& j, tsuba::RDGManifest& manifest) {
   uint32_t magic;
   j.at("magic").get_to(magic);
-  j.at("version").get_to(manifest.version_);
   j.at("num_hosts").get_to(manifest.num_hosts_);
+  if (auto it = j.find("version"); it != j.end()) {
+    it->get_to(manifest.version_.numbers_.back());
+  } else {
+    j.at("version_vec").get_to(manifest.version_);
+  }
 
   // these values are temporarily optional
   if (auto it = j.find("previous_version"); it != j.end()) {
-    it->get_to(manifest.previous_version_);
+    it->get_to(manifest.previous_version_.numbers_.back());
+  } else if (auto it = j.find("previous_version_vec"); it != j.end()) {
+    j.at("previous_version_vec").get_to(manifest.previous_version_);
   }
+
   if (auto it = j.find("policy_id"); it != j.end()) {
     it->get_to(manifest.policy_id_);
   }

--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -7,6 +7,8 @@
 
 #include "katana/JSON.h"
 #include "katana/Logging.h"
+#include "katana/RDGVersion.h"
+#include "katana/Random.h"
 #include "katana/URI.h"
 #include "katana/config.h"
 #include "tsuba/RDGLineage.h"
@@ -25,8 +27,10 @@ class KATANA_EXPORT RDGManifest {
   //
   // Persisted
   //
-  uint64_t version_{0};
-  uint64_t previous_version_{0};
+
+  katana::RDGVersion version_{katana::RDGVersion(0)};
+  katana::RDGVersion previous_version_{katana::RDGVersion(0)};
+
   uint32_t num_hosts_{0};  // 0 is a reserved value for the empty RDG when
   // tsuba views policy_id as zero (not partitioned) or not zero (partitioned
   // according to a CuSP-specific policy)
@@ -47,8 +51,9 @@ class KATANA_EXPORT RDGManifest {
   }
 
   RDGManifest(
-      uint64_t version, uint64_t previous_version, uint32_t num_hosts,
-      uint32_t policy_id, bool transpose, katana::Uri dir, RDGLineage lineage)
+      katana::RDGVersion version, katana::RDGVersion previous_version,
+      uint32_t num_hosts, uint32_t policy_id, bool transpose, katana::Uri dir,
+      RDGLineage lineage)
       : dir_(std::move(dir)),
         version_(version),
         previous_version_(previous_version),
@@ -60,7 +65,8 @@ class KATANA_EXPORT RDGManifest {
   static katana::Result<RDGManifest> MakeFromStorage(const katana::Uri& uri);
 
   static std::string PartitionFileName(
-      const std::string& view_type, uint32_t node_id, uint64_t version);
+      const std::string& view_type, uint32_t node_id,
+      katana::RDGVersion version);
 
   std::string view_specifier() const {
     if (view_args_.size())
@@ -74,15 +80,20 @@ public:
   RDGManifest NextVersion(
       uint32_t num_hosts, uint32_t policy_id, bool transpose,
       const RDGLineage& lineage) const {
+    katana::RDGVersion next_version(version_.numbers_, version_.branches_);
+    next_version.IncrementLeaf();
+    // progress the version numbers
     return RDGManifest(
-        version_ + 1, version_, num_hosts, policy_id, transpose, dir_, lineage);
+        next_version, version_, num_hosts, policy_id, transpose, dir_, lineage);
   }
 
   RDGManifest SameVersion(
       uint32_t num_hosts, uint32_t policy_id, bool transpose,
       const RDGLineage& lineage) const {
+    // retain both current and previous versions
     return RDGManifest(
-        version_, version_, num_hosts, policy_id, transpose, dir_, lineage);
+        version_, previous_version_, num_hosts, policy_id, transpose, dir_,
+        lineage);
   }
 
   bool IsEmptyRDG() const { return num_hosts() == 0; }
@@ -101,16 +112,20 @@ public:
   /// \param version is the version of the RDG to load
   /// \returns the constructed RDGManifest and the directory of its contents
   static katana::Result<RDGManifest> Make(
-      const katana::Uri& uri, const std::string& view_type, uint64_t version);
+      const katana::Uri& uri, const std::string& view_type,
+      katana::RDGVersion version);
 
   const katana::Uri& dir() const { return dir_; }
-  uint64_t version() const { return version_; }
+  katana::RDGVersion version() const { return version_; }
   uint32_t num_hosts() const { return num_hosts_; }
   uint32_t policy_id() const { return policy_id_; }
-  uint64_t previous_version() const { return previous_version_; }
+  katana::RDGVersion previous_version() const { return previous_version_; }
   const std::string& viewtype() const { return view_type_; }
   void set_viewtype(std::string v) { view_type_ = v; }
   void set_viewargs(std::vector<std::string> v) { view_args_ = v; }
+  void set_version(katana::RDGVersion val) { version_ = val; }
+  void set_previous_version(katana::RDGVersion val) { previous_version_ = val; }
+  void increment_version() { version_.IncrementLeaf(); }
   const std::string& view_type() const { return view_type_; }
   bool transpose() const { return transpose_; }
 
@@ -122,16 +137,18 @@ public:
 
   // Canonical naming
   static katana::Uri FileName(
-      const katana::Uri& uri, const std::string& view_type, uint64_t version);
+      const katana::Uri& uri, const std::string& view_type,
+      katana::RDGVersion version);
 
   static katana::Uri PartitionFileName(
-      const katana::Uri& uri, uint32_t node_id, uint64_t version);
+      const katana::Uri& uri, uint32_t node_id, katana::RDGVersion version);
 
   static katana::Uri PartitionFileName(
       const std::string& view_type, const katana::Uri& uri, uint32_t node_id,
-      uint64_t version);
+      katana::RDGVersion version);
 
-  static katana::Result<uint64_t> ParseVersionFromName(const std::string& file);
+  static katana::Result<katana::RDGVersion> ParseVersionFromName(
+      const std::string& file);
   static katana::Result<std::string> ParseViewNameFromName(
       const std::string& file);
   static katana::Result<std::vector<std::string>> ParseViewArgsFromName(

--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -80,7 +80,7 @@ public:
   RDGManifest NextVersion(
       uint32_t num_hosts, uint32_t policy_id, bool transpose,
       const RDGLineage& lineage) const {
-    katana::RDGVersion next_version(version_.numbers_, version_.branches_);
+    katana::RDGVersion next_version = version_;
     next_version.IncrementLeaf();
     // progress the version numbers
     return RDGManifest(

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -107,11 +107,19 @@ RDGPartHeader::Write(
     return KATANA_ERROR(ArrowToTsuba(res.code()), "arrow error: {}", res);
   }
 
-  auto next_version =
-      (retain_version == tsuba::RDG::RDGVersioningPolicy::RetainVersion)
-          ? handle.impl_->rdg_manifest().version()
-          : (handle.impl_->rdg_manifest().version() + 1);
-  KATANA_LOG_DEBUG("Next verison: {}", next_version);
+  // Assume the same version unless an increment.
+  katana::RDGVersion next_version = handle.impl_->rdg_manifest().version();
+  if (retain_version == tsuba::RDG::RDGVersioningPolicy::IncrementVersion) {
+    next_version.IncrementLeaf();
+  }
+
+  KATANA_LOG_DEBUG(
+      "PartHeader file {} for version: {}; ",
+      RDGManifest::PartitionFileName(
+          handle.impl_->rdg_manifest().viewtype(),
+          handle.impl_->rdg_manifest().dir(), Comm()->ID, next_version),
+      next_version.ToString());
+
   ff->Bind(RDGManifest::PartitionFileName(
                handle.impl_->rdg_manifest().viewtype(),
                handle.impl_->rdg_manifest().dir(), Comm()->ID, next_version)

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -189,7 +189,7 @@ tsuba::Create(const std::string& name, katana::RDGVersion version) {
   KATANA_LOG_DEBUG_ASSERT(!RDGManifest::IsManifestUri(uri));
 
   tsuba::RDGManifest manifest{};
-  if (!version.IsNull()) {
+  if (!version.IsZero()) {
     // start a new branch with v0
     version.SetLeafNumber(0);
     manifest.set_version(version);

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -69,9 +69,6 @@ FindManifestFileForVersion(
     }
   }
 
-  KATANA_LOG_DEBUG(
-      "found manifest [{}] for target {}; ", found_manifest, target.ToString());
-
   if (found_manifest.empty()) {
     return KATANA_ERROR(
         tsuba::ErrorCode::NotFound,
@@ -103,9 +100,6 @@ FindLatestManifestFile(const katana::Uri& name) {
       }
     }
   }
-
-  KATANA_LOG_DEBUG("found latest manifest [{}] ", found_manifest);
-
   if (found_manifest.empty()) {
     return KATANA_ERROR(
         tsuba::ErrorCode::NotFound,
@@ -143,9 +137,6 @@ tsuba::Open(
     return uri_res.error();
   }
   katana::Uri uri = std::move(uri_res.value());
-
-  KATANA_LOG_DEBUG(
-      "tsuba::Open: made uri {} from rdg path {}; ", uri.string(), rdg_name);
 
   if (RDGManifest::IsManifestUri(uri)) {
     auto manifest_res = tsuba::RDGManifest::Make(uri);
@@ -279,8 +270,7 @@ tsuba::ListAvailableViewsForVersion(
 
   auto list_res = FileList(rdg_dir);
   if (!list_res) {
-    KATANA_LOG_DEBUG("failed to list files in {}", rdg_dir);
-    return list_res.error();
+    return list_res.error().WithContext("failed to list files in {}", rdg_dir);
   }
 
   katana::RDGVersion current_max = katana::RDGVersion(0);

--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -6,7 +6,9 @@ import os
 import shutil
 import tarfile
 import urllib.request
+import re
 from pathlib import Path
+from typing import List, Optional
 
 __all__ = ["get_input", "get_input_as_url"]
 
@@ -66,3 +68,41 @@ def get_input_as_url(rel_path) -> str:
     """
     path = get_input(rel_path).resolve()
     return f"file://{path}"
+
+def parse_version(source) -> dict:
+    s = re.split(r'_', source[4:])
+    version = {}
+    version["Numbers"]=[]
+    version["Branches"]=[]
+    if len(s) == 0 :
+        version["Numbers"]=[0]
+        version["Branches"]=["."]
+        return version
+    i = 0
+    while i<len(s) :
+        version["Numbers"].append(int(s[i]))
+        i += 1
+        if i<len(s):
+            version["Branches"].append(s[i])
+            i += 1
+        else:
+            version["Branches"].append(".")
+    return version
+
+
+def get_rdgs(graph_dir, version: Optional[dict] = None):
+    s = re.compile(r"katana_(?P<version>(?:vers.*))_(?P<view_type>(?:rdg.*)).manifest$")
+    precursors = [s.match(f).groupdict() for f in os.listdir(graph_dir) if s.match(f)]
+    rdgs = []
+    for precursor in precursors:
+        rdg = {}
+        rdg["version"] = parse_version(precursor["version"])
+        rdg["view_type"] = precursor["view_type"]
+        rdgs.append(rdg)
+    if version is None:
+        return rdgs
+    else:
+        for rdg in rdgs:
+            if rdg["version"] == version:
+                rdgs.remove(rdg)
+    return rdgs

--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -3,10 +3,10 @@ Utilities which download example data for testing and experimentation.
 """
 
 import os
+import re
 import shutil
 import tarfile
 import urllib.request
-import re
 from pathlib import Path
 from typing import List, Optional
 
@@ -69,20 +69,21 @@ def get_input_as_url(rel_path) -> str:
     path = get_input(rel_path).resolve()
     return f"file://{path}"
 
+
 def parse_version(source) -> dict:
-    s = re.split(r'_', source[4:])
+    s = re.split(r"_", source[4:])
     version = {}
-    version["Numbers"]=[]
-    version["Branches"]=[]
-    if len(s) == 0 :
-        version["Numbers"]=[0]
-        version["Branches"]=["."]
+    version["Numbers"] = []
+    version["Branches"] = []
+    if len(s) == 0:
+        version["Numbers"] = [0]
+        version["Branches"] = ["."]
         return version
     i = 0
-    while i<len(s) :
+    while i < len(s):
         version["Numbers"].append(int(s[i]))
         i += 1
-        if i<len(s):
+        if i < len(s):
             version["Branches"].append(s[i])
             i += 1
         else:

--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -102,8 +102,7 @@ def get_rdgs(graph_dir, version: Optional[dict] = None):
         rdgs.append(rdg)
     if version is None:
         return rdgs
-    else:
-        for rdg in rdgs:
-            if rdg["version"] == version:
-                rdgs.remove(rdg)
+    for rdg in rdgs:
+        if rdg["version"] == version:
+            rdgs.remove(rdg)
     return rdgs

--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -3,12 +3,10 @@ Utilities which download example data for testing and experimentation.
 """
 
 import os
-import re
 import shutil
 import tarfile
 import urllib.request
 from pathlib import Path
-from typing import List, Optional
 
 __all__ = ["get_input", "get_input_as_url"]
 
@@ -68,41 +66,3 @@ def get_input_as_url(rel_path) -> str:
     """
     path = get_input(rel_path).resolve()
     return f"file://{path}"
-
-
-def parse_version(source) -> dict:
-    s = re.split(r"_", source[4:])
-    version = {}
-    version["Numbers"] = []
-    version["Branches"] = []
-    if len(s) == 0:
-        version["Numbers"] = [0]
-        version["Branches"] = ["."]
-        return version
-    i = 0
-    while i < len(s):
-        version["Numbers"].append(int(s[i]))
-        i += 1
-        if i < len(s):
-            version["Branches"].append(s[i])
-            i += 1
-        else:
-            version["Branches"].append(".")
-    return version
-
-
-def get_rdgs(graph_dir, version: Optional[dict] = None):
-    s = re.compile(r"katana_(?P<version>(?:vers.*))_(?P<view_type>(?:rdg.*)).manifest$")
-    precursors = [s.match(f).groupdict() for f in os.listdir(graph_dir) if s.match(f)]
-    rdgs = []
-    for precursor in precursors:
-        rdg = {}
-        rdg["version"] = parse_version(precursor["version"])
-        rdg["view_type"] = precursor["view_type"]
-        rdgs.append(rdg)
-    if version is None:
-        return rdgs
-    for rdg in rdgs:
-        if rdg["version"] == version:
-            rdgs.remove(rdg)
-    return rdgs


### PR DESCRIPTION
Changed the version of an RDG from an uint64 to a pair of vectors (int and string).

Added a function in libtsuba to find a specific version of RDG.

Updated tsuba::{Open,Create} functions and RDGManifest management accordingly. 

A sister PR (https://github.com/KatanaGraph/katana-enterprise/pull/1824) is created for katana-enterprise too.

An RFC is drafted to reflect the design and implementation of these two PRs, available from here (https://docs.google.com/document/d/11YYP7i00Mh8_li0q1kYWHATUXR1DKMElRk-CD5hS5sI/edit#)