### PR TITLE
fix storing id_array files when graph is moved

### DIFF
--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -421,6 +421,7 @@ katana::PropertyGraph::DoWrite(
   std::unique_ptr<tsuba::FileFrame> edge_entity_type_id_array_res = nullptr;
 
   if (!rdg_.topology_file_storage().Valid()) {
+    KATANA_LOG_DEBUG("topology file store invalid, writing");
     auto res = WriteTopology(topology());
     if (!res) {
       return res.error();
@@ -429,6 +430,7 @@ katana::PropertyGraph::DoWrite(
   }
 
   if (!rdg_.node_entity_type_id_array_file_storage().Valid()) {
+    KATANA_LOG_DEBUG("node_entity_type_id_array file store invalid, writing");
     auto res = WriteEntityTypeIDsArray(node_entity_type_ids_);
     if (!res) {
       return res.error();
@@ -437,6 +439,7 @@ katana::PropertyGraph::DoWrite(
   }
 
   if (!rdg_.edge_entity_type_id_array_file_storage().Valid()) {
+    KATANA_LOG_DEBUG("edge_entity_type_id_array file store invalid, writing");
     auto res = WriteEntityTypeIDsArray(edge_entity_type_ids_);
     if (!res) {
       return res.error();

--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -99,6 +99,7 @@ public:
       const std::shared_ptr<arrow::Table>& properties,
       katana::EntityTypeManager* entity_type_manager,
       EntityTypeArray* entity_type_ids) {
+    KATANA_LOG_WARN("assigning entity type ids from properties");
     static_assert(
         std::is_same_v<typename EntityTypeArray::value_type, EntityTypeID>);
     if (entity_type_ids->size() != topo_size) {

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -240,6 +240,8 @@ RDGManifest::FileNames() {
       }
       // Duplicates eliminated by set
       fnames.emplace(header.topology_path());
+      fnames.emplace(header.node_entity_type_id_array_path());
+      fnames.emplace(header.edge_entity_type_id_array_path());
     }
   }
   return fnames;

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -218,7 +218,12 @@ RDGPartHeader::ChangeStorageLocation(
       prop.WasModified(prop.type());
     }
   }
+
+  // clear out specific file paths so that we know to store them later
   topology_path_ = "";
+  node_entity_type_id_array_path_ = "";
+  edge_entity_type_id_array_path_ = "";
+
   return katana::ResultSuccess();
 }
 


### PR DESCRIPTION
When an RDG is moved, the topology, node_id_array, and edge_id_array
files must also be moved
previously, this was determined by checking if the headers path to these
files was empty. This relied on ChangeStorageLocation() actually
emptying them.

- make ChangeStorageLocation empty the node/edge id_array paths
- store the topology, node/edge id_array files if the rdg path
  no longer matches the old rdg path

- add node/edge id array files to RDGManifest::FileNames
- add handful of debug log lines to the store/write path
- explicitly log when EntityTypeIds are being assigned from
  properties
- we also would end up storing the id_array files twice, remove second
  place

this bug was exercised when:
1) take a graph that already has EntityTypeID structures
2) load it
3) store it in a new location
4) load from the new location

our existing tests only do:
1) take a graph *without* EntityTypeID structures
2) load it
3) store it in a new location, which stores the new EntityTypeID structures
4) load from the new location

so this path got missed. Will push a future PR with a new test for this path. 