### PR TITLE
libsupport: Improve compatibility with nvcc

### DIFF
--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -122,8 +122,13 @@ public:
           num_rows, entity_type_ids->size());
     }
 
-    TypeProperties type_properties = KATANA_CHECKED(
-        DoAssignEntityTypeIDsFromProperties(properties, entity_type_manager));
+    // We cannot use KATANA_CHECKED here because nvcc cannot handle it.
+    auto res =
+        DoAssignEntityTypeIDsFromProperties(properties, entity_type_manager);
+    if (!res) {
+      return ResultError(std::move(res.error()));
+    }
+    TypeProperties type_properties = std::move(res.value());
 
     // assign the type ID for each row
     for (int64_t row = 0; row < num_rows; ++row) {

--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -447,9 +447,14 @@ operator!=(const CopyableErrorInfo& a, const CopyableErrorInfo& b) {
   return !(a == b);
 }
 
-//TODO (serge): make these functions back inline after the issue in nvcc is fixed. Currently nvcc fails in CI if this is inline and leaks to .cu files.
+// TODO (serge): make these functions back inline after the issue in nvcc is
+// fixed. Currently nvcc fails in CI if this is inline and leaks to .cu files.
 KATANA_EXPORT Result<void> ResultSuccess();
 KATANA_EXPORT CopyableResult<void> CopyableResultSuccess();
+// TODO(ddn): nvcc has trouble applying implicit conversions while other
+// compilers can apply the implicit conversion from ErrorInfo to Result.R emove
+// this function when nvcc improves.
+KATANA_EXPORT Result<void> ResultError(ErrorInfo&& info);
 
 inline std::error_code
 ResultErrno() {

--- a/libsupport/src/Result.cpp
+++ b/libsupport/src/Result.cpp
@@ -164,6 +164,11 @@ katana::ResultSuccess() {
   return BOOST_OUTCOME_V2_NAMESPACE::success();
 }
 
+katana::Result<void>
+katana::ResultError(ErrorInfo&& info) {
+  return Result<void>(std::move(info));
+}
+
 katana::CopyableResult<void>
 katana::CopyableResultSuccess() {
   return BOOST_OUTCOME_V2_NAMESPACE::success();


### PR DESCRIPTION
nvcc (versions 11.1, 11.3 at least) does not allow non-trivial classes
to be defined inside statement expressions, which leads to errors like:

  a class that is not trivially copyable cannot be defined inside a statement expression

when using KATANA_CHECKED in any file that nvcc could see. Besides
actual CUDA files, this category includes any header files included by
CUDA files. nvcc also has trouble recognizing implicit conversions to
katana::Result.

Workaround these problems point-wise by avoiding KATANA_CHECKED and
implicit conversions to katana::Result.