### PR TITLE
tsuba: Update manifest.FileNames to only return files that exist

### DIFF
--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -38,6 +38,10 @@ set_common_katana_library_options(tsuba ALWAYS_SHARED)
 
 target_link_libraries(tsuba PUBLIC katana_support)
 
+if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
 install(
   DIRECTORY include/
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -240,8 +240,12 @@ RDGManifest::FileNames() {
       }
       // Duplicates eliminated by set
       fnames.emplace(header.topology_path());
-      fnames.emplace(header.node_entity_type_id_array_path());
-      fnames.emplace(header.edge_entity_type_id_array_path());
+      if (const auto& n = header.node_entity_type_id_array_path(); !n.empty()) {
+        fnames.emplace(n);
+      }
+      if (const auto& n = header.edge_entity_type_id_array_path(); !n.empty()) {
+        fnames.emplace(n);
+      }
     }
   }
   return fnames;

--- a/libtsuba/test/CMakeLists.txt
+++ b/libtsuba/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(manifest-test manifest.cpp)
+target_link_libraries(manifest-test tsuba)
+target_include_directories(manifest-test PRIVATE ../src)
+add_test(NAME manifest COMMAND manifest-test ${BASEINPUT}/propertygraphs/rmat15/katana_vers00000000000000000001_rdg.manifest)
+set_property(TEST manifest APPEND PROPERTY LABELS quick)

--- a/libtsuba/test/manifest.cpp
+++ b/libtsuba/test/manifest.cpp
@@ -1,0 +1,60 @@
+#include <boost/filesystem.hpp>
+
+#include "RDGManifest.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+#include "tsuba/RDG.h"
+
+namespace fs = boost::filesystem;
+
+katana::Result<void>
+TestFileNames(const std::string& path) {
+  auto uri = KATANA_CHECKED(katana::Uri::MakeFromFile(path));
+  auto manifest = KATANA_CHECKED(tsuba::RDGManifest::Make(uri));
+
+  fs::path p = path;
+  p = p.parent_path();
+
+  std::set<std::string> names = KATANA_CHECKED(manifest.FileNames());
+  for (const auto& name : names) {
+    fs::path n = p / name;
+
+    if (!fs::exists(n) || !fs::is_regular(n)) {
+      return KATANA_ERROR(
+          katana::ErrorCode::AssertionFailed,
+          "path {} does not exist or is not a regular file",
+          std::quoted(n.string()));
+    }
+  }
+
+  return katana::ResultSuccess();
+}
+
+katana::Result<void>
+TestAll(const std::string& path) {
+  KATANA_CHECKED_CONTEXT(TestFileNames(path), "TestFileNames");
+
+  return katana::ResultSuccess();
+}
+
+int
+main(int argc, char* argv[]) {
+  if (auto init_good = tsuba::Init(); !init_good) {
+    KATANA_LOG_FATAL("tsuba::Init: {}", init_good.error());
+  }
+
+  if (argc <= 1) {
+    KATANA_LOG_FATAL("manifest <rdg prefix>");
+  }
+
+  auto res = TestAll(argv[1]);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  if (auto fini_good = tsuba::Fini(); !fini_good) {
+    KATANA_LOG_FATAL("tsuba::Fini: {}", fini_good.error());
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Entity arrays do not exist for all RDGs; for backward compatibility,
only return entity array names when they are actually present.