### PR TITLE
Quieter native plugin loader

### DIFF
--- a/libsupport/src/Plugin.cpp
+++ b/libsupport/src/Plugin.cpp
@@ -54,7 +54,6 @@ public:
     auto path = katana::GetPluginPath();
     std::vector<boost::filesystem::path> plugin_paths;
     for (const auto& p : path) {
-      KATANA_LOG_VERBOSE("loading plugins from: {}", p);
       for (const boost::filesystem::directory_entry& entry :
            boost::filesystem::directory_iterator(
                p, boost::filesystem::directory_options::none)) {


### PR DESCRIPTION
I did leave the prints when a specific plugin is loaded. I think this is very useful given that bad plugins could cause crashes.