### PR TITLE
tsuba: Copy RDG support

### DIFF
--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -110,8 +110,12 @@ KATANA_EXPORT katana::Result<std::vector<std::pair<katana::Uri, katana::Uri>>>
 CreateSrcDestFromViewsForCopy(
     const std::string& src_dir, const std::string& dst_dir, uint64_t version);
 
+/// Copies RDG files from each respective file's src to its destination.
+/// E.g. SRC_DIR/part_vers0003_rdg_node00000 -> DST_DIR/part_vers0001_rdg_node_00000
+/// \param src_dst_files is a vector of src-dest pairs for individual RDG files
+/// \returns a Result to indicate whether the method succeeded or failed
 KATANA_EXPORT katana::Result<void> CopyRDG(
-    std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_pairs);
+    std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_files);
 
 // Setup and tear down
 KATANA_EXPORT katana::Result<void> Init(katana::CommBackend* comm);

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -110,8 +110,10 @@ KATANA_EXPORT katana::Result<std::vector<std::pair<katana::Uri, katana::Uri>>>
 CreateSrcDestFromViewsForCopy(
     const std::string& src_dir, const std::string& dst_dir, uint64_t version);
 
-/// Copies RDG files from each respective file's src to its destination.
+/// CopyRDG copies RDG files from a source to a destination.
 /// E.g. SRC_DIR/part_vers0003_rdg_node00000 -> DST_DIR/part_vers0001_rdg_node_00000
+/// The argument is a list of source and destination pairs as an RDG consists of many files.
+/// See CreateSrcDestFromViewsForCopy for how to generate this list from an RDG prefix and version
 /// \param src_dst_files is a vector of src-dest pairs for individual RDG files
 /// \returns a Result to indicate whether the method succeeded or failed
 KATANA_EXPORT katana::Result<void> CopyRDG(

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -109,8 +109,10 @@ ListAvailableViews(
 KATANA_EXPORT katana::Result<std::vector<RDGView>>
 ListAvailableViewsFromVersion(const std::string& rdg_dir, uint64_t version);
 
-KATANA_EXPORT katana::Result<void> CopyRDG(
-    const std::string& src_dir, const std::string& dest_dir, uint64_t version);
+KATANA_EXPORT katana::Result<std::vector<katana::Uri>>
+ListAllFilesFromViews(const std::string& src_dir, uint64_t version);
+
+KATANA_EXPORT katana::Result<void> CopyRDG(std::vector<katana::Uri> file_uris, const std::string& dst_dir);
 
 // Setup and tear down
 KATANA_EXPORT katana::Result<void> Init(katana::CommBackend* comm);

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -106,6 +106,12 @@ KATANA_EXPORT katana::Result<std::pair<uint64_t, std::vector<RDGView>>>
 ListAvailableViews(
     const std::string& rdg_dir, std::optional<uint64_t> version = std::nullopt);
 
+KATANA_EXPORT katana::Result<std::vector<RDGView>>
+ListAvailableViewsFromVersion(const std::string& rdg_dir, uint64_t version);
+
+KATANA_EXPORT katana::Result<void> CopyRDG(
+    const std::string& src_dir, const std::string& dest_dir, uint64_t version);
+
 // Setup and tear down
 KATANA_EXPORT katana::Result<void> Init(katana::CommBackend* comm);
 KATANA_EXPORT katana::Result<void> Init();

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -106,9 +106,6 @@ KATANA_EXPORT katana::Result<std::pair<uint64_t, std::vector<RDGView>>>
 ListAvailableViews(
     const std::string& rdg_dir, std::optional<uint64_t> version = std::nullopt);
 
-KATANA_EXPORT katana::Result<std::vector<RDGView>>
-ListAvailableViewsFromVersion(const std::string& rdg_dir, uint64_t version);
-
 KATANA_EXPORT katana::Result<std::vector<std::pair<katana::Uri, katana::Uri>>>
 CreateSrcDestFromViewsForCopy(
     const std::string& src_dir, const std::string& dst_dir, uint64_t version);

--- a/libtsuba/include/tsuba/tsuba.h
+++ b/libtsuba/include/tsuba/tsuba.h
@@ -109,10 +109,12 @@ ListAvailableViews(
 KATANA_EXPORT katana::Result<std::vector<RDGView>>
 ListAvailableViewsFromVersion(const std::string& rdg_dir, uint64_t version);
 
-KATANA_EXPORT katana::Result<std::vector<katana::Uri>>
-ListAllFilesFromViews(const std::string& src_dir, uint64_t version);
+KATANA_EXPORT katana::Result<std::vector<std::pair<katana::Uri, katana::Uri>>>
+CreateSrcDestFromViewsForCopy(
+    const std::string& src_dir, const std::string& dst_dir, uint64_t version);
 
-KATANA_EXPORT katana::Result<void> CopyRDG(std::vector<katana::Uri> file_uris, const std::string& dst_dir);
+KATANA_EXPORT katana::Result<void> CopyRDG(
+    std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_pairs);
 
 // Setup and tear down
 KATANA_EXPORT katana::Result<void> Init(katana::CommBackend* comm);

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -30,6 +30,7 @@ Parse(const std::string& str) {
 
 const int MANIFEST_MATCH_VERS_INDEX = 1;
 const int MANIFEST_MATCH_VIEW_INDEX = 2;
+const int PARTITION_MATCH_HOST_INDEX = 3;
 
 }  // namespace
 
@@ -49,6 +50,9 @@ namespace tsuba {
 
 const std::regex RDGManifest::kManifestVersion(
     "katana_vers(?:([0-9]+))_(?:([0-9A-Za-z-]+))\\.manifest$");
+
+const std::regex RDGManifest::kPartitionFile(
+    "part_(?:(vers[0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_(?:(node[0-9]*))$");
 
 Result<tsuba::RDGManifest>
 RDGManifest::MakeFromStorage(const katana::Uri& uri) {
@@ -152,6 +156,12 @@ RDGManifest::IsManifestUri(const katana::Uri& uri) {
   return res;
 }
 
+bool
+RDGManifest::IsPartitionFileUri(const katana::Uri& uri) {
+  bool res = std::regex_match(uri.BaseName(), kPartitionFile);
+  return res;
+}
+
 Result<uint64_t>
 RDGManifest::ParseVersionFromName(const std::string& file) {
   std::smatch sub_match;
@@ -206,6 +216,17 @@ RDGManifest::ParseViewArgsFromName(const std::string& file) {
     view_args.erase(view_args.begin());
   }
   return view_args;
+}
+
+Result<uint64_t>
+RDGManifest::ParseHostFromPartitionFile(const std::string& file) {
+  std::smatch sub_match;
+  if (!std::regex_match(file, sub_match, kPartitionFile)) {
+    return tsuba::ErrorCode::InvalidArgument;
+  }
+  //Partition file
+  KATANA_LOG_WARN("sub_match: {}", sub_match[PARTITION_MATCH_HOST_INDEX]);
+  return Parse(sub_match[PARTITION_MATCH_HOST_INDEX]);
 }
 
 // Return the set of file names that hold this RDG's data by reading partition files

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -51,9 +51,6 @@ namespace tsuba {
 const std::regex RDGManifest::kManifestVersion(
     "katana_vers(?:([0-9]+))_(?:([0-9A-Za-z-]+))\\.manifest$");
 
-const std::regex RDGManifest::kPartitionFile(
-    "part_(?:(vers[0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_(?:(node[0-9]*))$");
-
 Result<tsuba::RDGManifest>
 RDGManifest::MakeFromStorage(const katana::Uri& uri) {
   tsuba::FileView fv;
@@ -156,12 +153,6 @@ RDGManifest::IsManifestUri(const katana::Uri& uri) {
   return res;
 }
 
-bool
-RDGManifest::IsPartitionFileUri(const katana::Uri& uri) {
-  bool res = std::regex_match(uri.BaseName(), kPartitionFile);
-  return res;
-}
-
 Result<uint64_t>
 RDGManifest::ParseVersionFromName(const std::string& file) {
   std::smatch sub_match;
@@ -216,17 +207,6 @@ RDGManifest::ParseViewArgsFromName(const std::string& file) {
     view_args.erase(view_args.begin());
   }
   return view_args;
-}
-
-Result<uint64_t>
-RDGManifest::ParseHostFromPartitionFile(const std::string& file) {
-  std::smatch sub_match;
-  if (!std::regex_match(file, sub_match, kPartitionFile)) {
-    return tsuba::ErrorCode::InvalidArgument;
-  }
-  //Partition file
-  KATANA_LOG_WARN("sub_match: {}", sub_match[PARTITION_MATCH_HOST_INDEX]);
-  return Parse(sub_match[PARTITION_MATCH_HOST_INDEX]);
 }
 
 // Return the set of file names that hold this RDG's data by reading partition files

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -30,7 +30,6 @@ Parse(const std::string& str) {
 
 const int MANIFEST_MATCH_VERS_INDEX = 1;
 const int MANIFEST_MATCH_VIEW_INDEX = 2;
-const int PARTITION_MATCH_HOST_INDEX = 3;
 
 }  // namespace
 

--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -19,7 +19,6 @@ static const char* kDefaultRDGViewType = "rdg";
 // Struct version of main graph metadatafile
 class KATANA_EXPORT RDGManifest {
   static const std::regex kManifestVersion;
-  static const std::regex kPartitionFile;
 
   katana::Uri dir_;  // not persisted; inferred from name
 
@@ -79,7 +78,7 @@ public:
         version_ + 1, version_, num_hosts, policy_id, transpose, dir_, lineage);
   }
 
-  // This should have previous_version_ for the second argument, no?
+  // TODO(vkarthik): This should have previous_version_ for the second argument, no?
   RDGManifest SameVersion(
       uint32_t num_hosts, uint32_t policy_id, bool transpose,
       const RDGLineage& lineage) const {
@@ -144,10 +143,7 @@ public:
   static katana::Result<std::vector<std::string>> ParseViewArgsFromName(
       const std::string& file);
 
-  static katana::Result<uint64_t> ParseHostFromPartitionFile(
-      const std::string& file);
   static bool IsManifestUri(const katana::Uri& uri);
-  static bool IsPartitionFileUri(const katana::Uri& uri);
   std::string ToJsonString() const;
 
   /// Return the set of file names that hold this RDG's data by reading partition files

--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -19,6 +19,7 @@ static const char* kDefaultRDGViewType = "rdg";
 // Struct version of main graph metadatafile
 class KATANA_EXPORT RDGManifest {
   static const std::regex kManifestVersion;
+  static const std::regex kPartitionFile;
 
   katana::Uri dir_;  // not persisted; inferred from name
 
@@ -78,6 +79,7 @@ public:
         version_ + 1, version_, num_hosts, policy_id, transpose, dir_, lineage);
   }
 
+  // This should have previous_version_ for the second argument, no?
   RDGManifest SameVersion(
       uint32_t num_hosts, uint32_t policy_id, bool transpose,
       const RDGLineage& lineage) const {
@@ -86,6 +88,11 @@ public:
   }
 
   bool IsEmptyRDG() const { return num_hosts() == 0; }
+
+  void ResetVersion() {
+    version_ = 1;
+    previous_version_ = 0;
+  }
 
   static katana::Result<RDGManifest> Make(RDGHandle handle);
 
@@ -137,8 +144,10 @@ public:
   static katana::Result<std::vector<std::string>> ParseViewArgsFromName(
       const std::string& file);
 
+  static katana::Result<uint64_t> ParseHostFromPartitionFile(
+      const std::string& file);
   static bool IsManifestUri(const katana::Uri& uri);
-
+  static bool IsPartitionFileUri(const katana::Uri& uri);
   std::string ToJsonString() const;
 
   /// Return the set of file names that hold this RDG's data by reading partition files

--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -88,12 +88,6 @@ public:
 
   bool IsEmptyRDG() const { return num_hosts() == 0; }
 
-  // TODO(vkarthik): Should we expose this here? Or should we have setter methods instead?
-  void ResetVersion() {
-    version_ = 1;
-    previous_version_ = 0;
-  }
-
   static katana::Result<RDGManifest> Make(RDGHandle handle);
 
   /// Create an RDGManifest
@@ -122,6 +116,10 @@ public:
   bool transpose() const { return transpose_; }
 
   void set_dir(katana::Uri dir) { dir_ = std::move(dir); }
+  void set_version(uint64_t version) { version_ = version; }
+  void set_prev_version(uint64_t prev_version) {
+    previous_version_ = prev_version;
+  }
 
   katana::Uri PartitionFileName(uint32_t host_id) const;
 

--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -88,6 +88,7 @@ public:
 
   bool IsEmptyRDG() const { return num_hosts() == 0; }
 
+  // TODO(vkarthik): Should we expose this here? Or should we have setter methods instead?
   void ResetVersion() {
     version_ = 1;
     previous_version_ = 0;

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -149,8 +149,6 @@ RDGPartHeader::ParseHostFromPartitionFile(const std::string& file) {
   if (!std::regex_match(file, sub_match, kPartitionFile)) {
     return tsuba::ErrorCode::InvalidArgument;
   }
-  //Partition file
-  KATANA_LOG_WARN("sub_match: {}", sub_match[PARTITION_MATCH_HOST_INDEX]);
   return Parse(sub_match[PARTITION_MATCH_HOST_INDEX]);
 }
 

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -55,7 +55,28 @@ CopyProperty(
 
 }  // namespace
 
+// TODO(vkarthik): repetitive code from RDGManifest, try to unify
+namespace {
+
+katana::Result<uint64_t>
+Parse(const std::string& str) {
+  uint64_t val = strtoul(str.c_str(), nullptr, 10);
+  if (errno == ERANGE) {
+    return KATANA_ERROR(
+        katana::ResultErrno(), "manifest file found with out of range version");
+  }
+  return val;
+}
+
+const int PARTITION_MATCH_HOST_INDEX = 3;
+
+}  // namespace
+
 namespace tsuba {
+
+// Regex for partition files
+const std::regex RDGPartHeader::kPartitionFile(
+    "part_(?:(vers[0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_(?:(node[0-9]*))$");
 
 katana::Result<RDGPartHeader>
 RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
@@ -120,6 +141,23 @@ RDGPartHeader::Write(
   writes->StartStore(std::move(ff));
   TSUBA_PTP(internal::FaultSensitivity::Normal);
   return katana::ResultSuccess();
+}
+
+katana::Result<uint64_t>
+RDGPartHeader::ParseHostFromPartitionFile(const std::string& file) {
+  std::smatch sub_match;
+  if (!std::regex_match(file, sub_match, kPartitionFile)) {
+    return tsuba::ErrorCode::InvalidArgument;
+  }
+  //Partition file
+  KATANA_LOG_WARN("sub_match: {}", sub_match[PARTITION_MATCH_HOST_INDEX]);
+  return Parse(sub_match[PARTITION_MATCH_HOST_INDEX]);
+}
+
+bool
+RDGPartHeader::IsPartitionFileUri(const katana::Uri& uri) {
+  bool res = std::regex_match(uri.BaseName(), kPartitionFile);
+  return res;
 }
 
 bool

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -61,22 +61,21 @@ namespace {
 katana::Result<uint64_t>
 Parse(const std::string& str) {
   uint64_t val = strtoul(str.c_str(), nullptr, 10);
-  if (errno == ERANGE) {
+  if (val == ULONG_MAX && errno == ERANGE) {
     return KATANA_ERROR(
         katana::ResultErrno(), "manifest file found with out of range version");
   }
   return val;
 }
 
-const int PARTITION_MATCH_HOST_INDEX = 3;
-
 }  // namespace
 
 namespace tsuba {
 
 // Regex for partition files
-const std::regex RDGPartHeader::kPartitionFile(
+const std::regex kPartitionFile(
     "part_(?:(vers[0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_(?:(node[0-9]*))$");
+const int kPartitionMatchHostIndex = 3;
 
 katana::Result<RDGPartHeader>
 RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
@@ -149,7 +148,7 @@ RDGPartHeader::ParseHostFromPartitionFile(const std::string& file) {
   if (!std::regex_match(file, sub_match, kPartitionFile)) {
     return tsuba::ErrorCode::InvalidArgument;
   }
-  return Parse(sub_match[PARTITION_MATCH_HOST_INDEX]);
+  return Parse(sub_match[kPartitionMatchHostIndex]);
 }
 
 bool

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -126,6 +126,7 @@ class KATANA_EXPORT RDGPartHeader {
 public:
   static katana::Result<RDGPartHeader> Make(const katana::Uri& partition_path);
 
+  // Helper function to parse
   katana::Result<void> Validate() const;
 
   katana::Result<void> Write(

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstddef>
 #include <optional>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -126,7 +127,6 @@ class KATANA_EXPORT RDGPartHeader {
 public:
   static katana::Result<RDGPartHeader> Make(const katana::Uri& partition_path);
 
-  // Helper function to parse
   katana::Result<void> Validate() const;
 
   katana::Result<void> Write(
@@ -139,6 +139,12 @@ public:
       const katana::Uri& old_location, const katana::Uri& new_location);
 
   katana::Result<void> ValidateEntityTypeIDStructures() const;
+  static bool IsPartitionFileUri(const katana::Uri& uri);
+  // TODO(vkarthik): Move this somewhere else because this depends on the Parse function here. Might
+  // need to reorganize all the parsing properly.
+  static katana::Result<uint64_t> ParseHostFromPartitionFile(
+      const std::string& file);
+
   bool IsEntityTypeIDsOutsideProperties() const;
   //
   // Property manipulation
@@ -491,6 +497,9 @@ private:
       const katana::EntityTypeIDToAtomicTypeNameMap& edge_entity_type_id_name) {
     edge_entity_type_id_name_ = edge_entity_type_id_name;
   }
+
+  // Regex for partition files
+  static const std::regex kPartitionFile;
 
   std::vector<PropStorageInfo> part_prop_info_list_;
   std::vector<PropStorageInfo> node_prop_info_list_;

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -498,9 +498,6 @@ private:
     edge_entity_type_id_name_ = edge_entity_type_id_name;
   }
 
-  // Regex for partition files
-  static const std::regex kPartitionFile;
-
   std::vector<PropStorageInfo> part_prop_info_list_;
   std::vector<PropStorageInfo> node_prop_info_list_;
   std::vector<PropStorageInfo> edge_prop_info_list_;

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -7,8 +7,8 @@
 #include "katana/Plugin.h"
 #include "katana/Signals.h"
 #include "tsuba/Errors.h"
-#include "tsuba/file.h"
 #include "tsuba/FileView.h"
+#include "tsuba/file.h"
 
 namespace {
 
@@ -255,56 +255,105 @@ tsuba::ListAvailableViewsFromVersion(
   return views_found;
 }
 
+katana::Result<std::vector<std::pair<katana::Uri, katana::Uri>>>
+tsuba::CreateSrcDestFromViewsForCopy(
+    const std::string& src_dir, const std::string& dst_dir, uint64_t version) {
+  std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_pairs;
 
-katana::Result<std::vector<katana::Uri>>
-tsuba::ListAllFilesFromViews(const std::string& src_dir, uint64_t version) {
-  std::vector<katana::Uri> filenames;
   // List out all the files in a given view
-  auto rdg_views_res = tsuba::ListAvailableViewsFromVersion(
-      src_dir, version);
+  auto rdg_views_res = tsuba::ListAvailableViewsFromVersion(src_dir, version);
   for (const auto& rdg_view : rdg_views_res.value()) {
     KATANA_LOG_WARN("view_path: {}", rdg_view.view_path);
     auto uri = KATANA_CHECKED(katana::Uri::Make(src_dir));
 
-    auto rdg_manifest_res = tsuba::RDGManifest::Make(
-        uri, rdg_view.view_type, version);
+    auto rdg_manifest_res =
+        tsuba::RDGManifest::Make(uri, rdg_view.view_type, version);
     if (!rdg_manifest_res) {
       continue;
     }
+
     auto fnames = KATANA_CHECKED(rdg_manifest_res.value().FileNames());
     for (auto fname : fnames) {
-      auto file_path = katana::Uri::JoinPath(src_dir, fname);
-      auto file_uri = KATANA_CHECKED(katana::Uri::Make(file_path));
-      filenames.push_back(file_uri);
-    }
-  }
-  return filenames;
-}
+      auto src_file_path = katana::Uri::JoinPath(src_dir, fname);
+      auto src_file_uri = KATANA_CHECKED(katana::Uri::Make(src_file_path));
 
-
-katana::Result<void>
-tsuba::CopyRDG(std::vector<katana::Uri> file_uris, const std::string& dst_dir) {
-  // TODO: make sure that manifests are written at the end!
-  // TODO: add do_all loop
-  std::vector<katana::Uri> manifest_uris;
-  for (const auto src_file_uri : file_uris) {
-      auto src_filename = src_file_uri.BaseName();
-      auto dst_file_path = katana::Uri::JoinPath(dst_dir, src_filename);
-      KATANA_LOG_WARN("dst_file_path: {}", dst_file_path);
-      auto dst = KATANA_CHECKED(katana::Uri::Make(dst_file_path));
-
-      // We save the names of all the manifest files and we write them out at the end.
+      // If we are a manifest, we need to change our version to 1.
       if (tsuba::RDGManifest::IsManifestUri(src_file_uri)) {
-        manifest_uris.push_back(src_file_uri);
         continue;
       }
-      tsuba::FileView fv;
-      KATANA_CHECKED(fv.Bind(src_file_uri.path(), false));
-      KATANA_CHECKED(tsuba::FileStore(dst.path(), fv.ptr<char>(), fv.size()));
+
+      // Check to see if we have a partition file
+      // If we have a partition file, the dst path should be based on PartitionFileName using rdg manifest info
+      // We're batching this now because we want to rely on having the RDG manifest file in case things
+      // change in the future.
+      katana::Uri dst_file_uri;
+      if (tsuba::RDGManifest::IsPartitionFileUri(src_file_uri)) {
+        KATANA_LOG_WARN("src_file_uri partition: {}", src_file_uri);
+        auto host_id =
+            KATANA_CHECKED(tsuba::RDGManifest::ParseHostFromPartitionFile(
+                src_file_uri.BaseName()));
+        auto dst_dir_uri = KATANA_CHECKED(katana::Uri::Make(dst_dir));
+        dst_file_uri = tsuba::RDGManifest::PartitionFileName(
+            rdg_manifest_res.value().view_type(), dst_dir_uri, host_id, 1);
+        KATANA_LOG_WARN("dst_file_uri partition: {}", dst_file_uri);
+      } else {
+        auto dst_file_path = katana::Uri::JoinPath(dst_dir, fname);
+        dst_file_uri = KATANA_CHECKED(katana::Uri::Make(dst_file_path));
+        KATANA_LOG_WARN("src_file_uri: {}", src_file_uri);
+        KATANA_LOG_WARN("dst_file_uri: {}", dst_file_uri);
+      }
+      
+      src_dst_pairs.push_back(std::make_pair(src_file_uri, dst_file_uri));
+    }
+
+    // We add the manifest file to the vector
+    // Set the version to be 1
+    auto rdg_manifest_uri = rdg_manifest_res.value().FileName();
+    rdg_manifest_res.value().ResetVersion();
+    auto dst_rdg_manifest_path = katana::Uri::JoinPath(
+        dst_dir, rdg_manifest_res.value().FileName().BaseName());
+    auto dst_rdg_manifest_uri =
+        KATANA_CHECKED(katana::Uri::Make(dst_rdg_manifest_path));
+    KATANA_LOG_WARN("rdg_manifest_uri: {}", rdg_manifest_uri);
+    KATANA_LOG_WARN("dst_rdg_manifest_uri: {}", dst_rdg_manifest_uri);
+    src_dst_pairs.push_back(
+        std::make_pair(rdg_manifest_uri, dst_rdg_manifest_uri));
+  }
+  return src_dst_pairs;
+}
+
+katana::Result<void>
+tsuba::CopyRDG(std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_pairs) {
+  // TODO: make sure that manifests are written at the end!
+  // TODO: add do_all loop
+  std::vector<uint64_t> manifest_uri_idxs;
+  for (uint64_t i = 0; i < src_dst_pairs.size(); i++) {
+    auto [src_file_uri, dst_file_uri] = src_dst_pairs[i];
+    // We save the names of all the manifest files and we write them out at the end.
+    if (tsuba::RDGManifest::IsManifestUri(src_file_uri)) {
+      manifest_uri_idxs.push_back(i);
+      continue;
+    }
+    tsuba::FileView fv;
+    KATANA_CHECKED(fv.Bind(src_file_uri.path(), false));
+    KATANA_CHECKED(
+        tsuba::FileStore(dst_file_uri.path(), fv.ptr<char>(), fv.size()));
   }
 
-  // Process all the manifest files
-
+  // Process all the manifest files, write them out.
+  // We want to write this last so that we know whether a write fully finished or not.
+  for (auto idx : manifest_uri_idxs) {
+    auto [src_file_uri, dst_file_uri] = src_dst_pairs[idx];
+    auto rdg_manifest = KATANA_CHECKED(tsuba::RDGManifest::Make(src_file_uri));
+    // These are hard-coded for now. Will what we copy always be version 1?
+    // Should we clear the lineage as well?
+    rdg_manifest.ResetVersion();
+    auto rdg_manifest_json = rdg_manifest.ToJsonString();
+    KATANA_CHECKED(tsuba::FileStore(
+        dst_file_uri.path(),
+        reinterpret_cast<const uint8_t*>(rdg_manifest_json.data()),
+        rdg_manifest_json.size()));
+  }
   return katana::ResultSuccess();
 }
 

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -255,168 +255,10 @@ tsuba::ListAvailableViewsFromVersion(
   return views_found;
 }
 
-// From CSVImport.cpp
-katana::Result<uint64_t>
-Weigh(const std::string& file) {
-  tsuba::StatBuf buf;
-  auto res = tsuba::FileStat(file, &buf);
-  if (!res) {
-    return res.error().WithContext(
-        "cannot stat the file {}; with error {}.", file, res.error());
-  }
-  return buf.size;
-}
 
-// From CSVImport.cpp
-katana::Result<std::vector<uint64_t>>
-WeighFiles(const std::vector<std::string>& ops) {
-  auto& net = katana::getSystemNetworkInterface();
-  auto [begin_file_idx, end_file_idx] =
-      katana::block_range(uint64_t{0}, uint64_t{ops.size()}, net.ID, net.Num);
-
-  std::vector<uint64_t> result(
-      ops.size(), std::numeric_limits<uint64_t>::max());
-
-  katana::PerThreadStorage<std::optional<katana::CopyableErrorInfo>> error;
-  katana::do_all(
-      katana::iterate(begin_file_idx, end_file_idx),
-      [&](uint64_t i) {
-        if (error.getLocal()->has_value()) {
-          return;
-        }
-        auto weigh_res = Weigh(ops[i].op.file);
-        if (!weigh_res) {
-          *error.getLocal() = katana::CopyableErrorInfo(
-              weigh_res.error().WithContext("reading {}", ops[i].op.file));
-          return;
-        }
-        result[i] = weigh_res.value();
-      },
-      katana::steal());
-
-  for (auto local_error : error) {
-    if (local_error) {
-      return KATANA_ERROR(local_error->error_code(), "{}", *local_error);
-    }
-  }
-
-  for (katana::HostID id = katana::HostID{0}; id.value() < net.Num; ++id) {
-    if (id.value() == net.ID) {
-      continue;
-    }
-    katana::SendBuffer buf;
-    katana::gSerialize(
-        buf, begin_file_idx,
-        std::vector<uint64_t>(
-            result.begin() + begin_file_idx, result.begin() + end_file_idx));
-    net.Send(id.value(), std::move(buf));
-  }
-
-  for (katana::HostID id = katana::HostID{0}; id.value() < net.Num; ++id) {
-    if (id.value() == net.ID) {
-      continue;
-    }
-    uint64_t other_begin;
-    std::vector<uint64_t> other_result;
-
-    auto recv_result = net.Recv();
-    katana::gDeserialize(recv_result.second, other_begin, other_result);
-
-    std::copy(
-        other_result.begin(), other_result.end(), result.begin() + other_begin);
-  }
-  net.EndCommunicationPhase();
-
-  return result;
-}
-
-// Adapted from CSVImport.cpp
-std::pair<std::pair<uint64_t, uint64_t>, std::pair<uint64_t, uint64_t>>
-SliceWeightedVectorForHost(
-    std::vector<uint64_t> weights, katana::HostID host_id,
-    katana::HostID num_hosts) {
-  if (weights.empty()) {
-    return std::make_pair(std::make_pair(0, 0), std::make_pair(0, 0));
-  }
-  if (weights.size() <= num_hosts) {
-    return std::make_pair(
-        std::make_pair(std::min(size_t{host_id.value()}, weights.size()), 0),
-        std::make_pair(
-            std::min(size_t{host_id.value() + 1}, weights.size()), 0));
-  }
-  katana::ParallelSTL::partial_sum(
-      weights.begin(), weights.end(), weights.begin());
-
-  uint64_t host_weight =
-      (weights.back() + num_hosts.value() - 1) / num_hosts.value();
-
-  std::vector<uint64_t> per_host_end_idx(num_hosts.value());
-  for (katana::HostID i = katana::HostID{0}; i < num_hosts; ++i) {
-    auto it = std::upper_bound(
-        weights.begin(), weights.end(), (i.value() + 1) * host_weight);
-    per_host_end_idx[i.value()] = std::distance(weights.begin(), it);
-  }
-
-  KATANA_LOG_VASSERT(
-      per_host_end_idx.back() == weights.size(), "{} vs {}",
-      per_host_end_idx.back(), weights.size());
-
-  auto files_assigned_to_neighbors = [&per_host_end_idx](uint64_t host_id) {
-    uint64_t last = per_host_end_idx.size() - 1;
-    uint64_t on_the_left =
-        (host_id == 0 ? 0
-                      : per_host_end_idx[host_id - 1] -
-                            (host_id <= 1 ? 0 : per_host_end_idx[host_id - 2]));
-    uint64_t on_the_right =
-        (host_id == last
-             ? 0
-             : per_host_end_idx[host_id + 1] - per_host_end_idx[host_id]);
-
-    return std::make_pair(on_the_left, on_the_right);
-  };
-
-  // deterministically move things around to make sure every host has at least
-  // one value (required for now)
-  uint32_t hosts_with_no_files;
-  do {
-    hosts_with_no_files = num_hosts.value();
-    for (uint64_t i = 0; i < per_host_end_idx.size(); ++i) {
-      uint64_t start = i == 0 ? 0 : per_host_end_idx[i - 1];
-      uint64_t end = per_host_end_idx[i];
-      if (start != end) {
-        --hosts_with_no_files;
-        continue;
-      }
-      auto [on_left, on_right] = files_assigned_to_neighbors(i);
-      if (on_left > 0 && on_left >= on_right) {
-        --per_host_end_idx[i - 1];
-        if (on_left <= 1) {
-          hosts_with_no_files += 1;
-        }
-      } else if (on_right > 0) {
-        ++per_host_end_idx[i];
-      }
-      --hosts_with_no_files;
-    }
-  } while (hosts_with_no_files > 0);
-
-  uint64_t start = (host_id == 0 ? 0 : per_host_end_idx[host_id.value() - 1]);
-  uint64_t end = per_host_end_idx[host_id.value()];
-  return std::make_pair(std::make_pair(start, 0), std::make_pair(end, 0));
-}
-
-
-katana::Result<std::vector<std::pair<std::string, std::string>>>
-tsuba::ListAllFilesFromView(const std::string& src_dir, const std::string& dst_sir, uint64_t version) {
-  std::vector<std::pair<std::string, std::string>>> src_dest_pairs;
-
-  return src_dest_pairs;
-}
-
-
-katana::Result<void>
-tsuba::CopyRDG(
-    const std::string& src_dir, const std::string& dst_dir, uint64_t version) {
+katana::Result<std::vector<katana::Uri>>
+tsuba::ListAllFilesFromViews(const std::string& src_dir, uint64_t version) {
+  std::vector<katana::Uri> filenames;
   // List out all the files in a given view
   auto rdg_views_res = tsuba::ListAvailableViewsFromVersion(
       src_dir, version);
@@ -430,38 +272,39 @@ tsuba::CopyRDG(
       continue;
     }
     auto fnames = KATANA_CHECKED(rdg_manifest_res.value().FileNames());
+    for (auto fname : fnames) {
+      auto file_path = katana::Uri::JoinPath(src_dir, fname);
+      auto file_uri = KATANA_CHECKED(katana::Uri::Make(file_path));
+      filenames.push_back(file_uri);
+    }
+  }
+  return filenames;
+}
 
-    std::string manifest_file{};
-    // Write out the data first
-    for (const auto fname : fnames) {
-      KATANA_LOG_WARN("view_fname: {}", fname);
-      auto src_joined_path = katana::Uri::JoinPath(src_dir, fname);
-      KATANA_LOG_WARN("src_joined_path: {}", src_joined_path);
-      auto src = KATANA_CHECKED(katana::Uri::Make(src_joined_path));
 
-      // Let's skip copying this over for now. Let's just get the pure name of the file
-      if (tsuba::RDGManifest::IsManifestUri(src)) {
-        KATANA_LOG_WARN("found a manifest file");
-        manifest_file = fname;
+katana::Result<void>
+tsuba::CopyRDG(std::vector<katana::Uri> file_uris, const std::string& dst_dir) {
+  // TODO: make sure that manifests are written at the end!
+  // TODO: add do_all loop
+  std::vector<katana::Uri> manifest_uris;
+  for (const auto src_file_uri : file_uris) {
+      auto src_filename = src_file_uri.BaseName();
+      auto dst_file_path = katana::Uri::JoinPath(dst_dir, src_filename);
+      KATANA_LOG_WARN("dst_file_path: {}", dst_file_path);
+      auto dst = KATANA_CHECKED(katana::Uri::Make(dst_file_path));
+
+      // We save the names of all the manifest files and we write them out at the end.
+      if (tsuba::RDGManifest::IsManifestUri(src_file_uri)) {
+        manifest_uris.push_back(src_file_uri);
         continue;
       }
-      auto dst_joined_path = katana::Uri::JoinPath(dst_dir, fname);
-      KATANA_LOG_WARN("dst_joined_path: {}", dst_joined_path);
-      auto dst = KATANA_CHECKED(katana::Uri::Make(dst_joined_path));
-
-      // Now copy it over
       tsuba::FileView fv;
-      KATANA_CHECKED(fv.Bind(src.path(), false));
+      KATANA_CHECKED(fv.Bind(src_file_uri.path(), false));
       KATANA_CHECKED(tsuba::FileStore(dst.path(), fv.ptr<char>(), fv.size()));
-    }
-    // Write out the manifest file as a final commit!
-    // TODO: make sure to change the version?
-    tsuba::FileView fv;
-    auto dst_manifest_path = katana::Uri::JoinPath(dst_dir, manifest_file);
-    KATANA_LOG_WARN("dst_manifest_path: {}", dst_manifest_path);
-    KATANA_CHECKED(fv.Bind(rdg_view.view_path, false));
-    KATANA_CHECKED(tsuba::FileStore(dst_manifest_path, fv.ptr<char>(), fv.size()));
   }
+
+  // Process all the manifest files
+
   return katana::ResultSuccess();
 }
 

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -215,7 +215,6 @@ tsuba::CreateSrcDestFromViewsForCopy(
   // List out all the files in a given view
   auto rdg_views = KATANA_CHECKED(tsuba::ListAvailableViews(src_dir, version));
   for (const auto& rdg_view : rdg_views.second) {
-    KATANA_LOG_WARN("view_path: {}", rdg_view.view_path);
     auto uri = KATANA_CHECKED(katana::Uri::Make(src_dir));
 
     auto rdg_manifest_res =
@@ -240,19 +239,15 @@ tsuba::CreateSrcDestFromViewsForCopy(
       // change in the future.
       katana::Uri dst_file_uri;
       if (tsuba::RDGPartHeader::IsPartitionFileUri(src_file_uri)) {
-        KATANA_LOG_WARN("src_file_uri partition: {}", src_file_uri);
         auto host_id =
             KATANA_CHECKED(tsuba::RDGPartHeader::ParseHostFromPartitionFile(
                 src_file_uri.BaseName()));
         auto dst_dir_uri = KATANA_CHECKED(katana::Uri::Make(dst_dir));
         dst_file_uri = tsuba::RDGManifest::PartitionFileName(
             rdg_manifest_res.value().view_type(), dst_dir_uri, host_id, 1);
-        KATANA_LOG_WARN("dst_file_uri partition: {}", dst_file_uri);
       } else {
         auto dst_file_path = katana::Uri::JoinPath(dst_dir, fname);
         dst_file_uri = KATANA_CHECKED(katana::Uri::Make(dst_file_path));
-        KATANA_LOG_WARN("src_file_uri: {}", src_file_uri);
-        KATANA_LOG_WARN("dst_file_uri: {}", dst_file_uri);
       }
 
       src_dst_files.push_back(std::make_pair(src_file_uri, dst_file_uri));
@@ -266,8 +261,6 @@ tsuba::CreateSrcDestFromViewsForCopy(
         dst_dir, rdg_manifest_res.value().FileName().BaseName());
     auto dst_rdg_manifest_uri =
         KATANA_CHECKED(katana::Uri::Make(dst_rdg_manifest_path));
-    KATANA_LOG_WARN("rdg_manifest_uri: {}", rdg_manifest_uri);
-    KATANA_LOG_WARN("dst_rdg_manifest_uri: {}", dst_rdg_manifest_uri);
     src_dst_files.push_back(
         std::make_pair(rdg_manifest_uri, dst_rdg_manifest_uri));
   }

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -261,8 +261,9 @@ tsuba::CreateSrcDestFromViewsForCopy(
   std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_pairs;
 
   // List out all the files in a given view
-  auto rdg_views_res = tsuba::ListAvailableViewsFromVersion(src_dir, version);
-  for (const auto& rdg_view : rdg_views_res.value()) {
+  auto rdg_views =
+      KATANA_CHECKED(tsuba::ListAvailableViewsFromVersion(src_dir, version));
+  for (const auto& rdg_view : rdg_views) {
     KATANA_LOG_WARN("view_path: {}", rdg_view.view_path);
     auto uri = KATANA_CHECKED(katana::Uri::Make(src_dir));
 
@@ -302,7 +303,7 @@ tsuba::CreateSrcDestFromViewsForCopy(
         KATANA_LOG_WARN("src_file_uri: {}", src_file_uri);
         KATANA_LOG_WARN("dst_file_uri: {}", dst_file_uri);
       }
-      
+
       src_dst_pairs.push_back(std::make_pair(src_file_uri, dst_file_uri));
     }
 

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -8,6 +8,7 @@
 #include "katana/Signals.h"
 #include "tsuba/Errors.h"
 #include "tsuba/file.h"
+#include "tsuba/FileView.h"
 
 namespace {
 
@@ -203,6 +204,265 @@ tsuba::ListAvailableViews(
   }
 
   return std::make_pair(latest_version, views_found);
+}
+
+// vkarthik: We could combine this with the function above. I just didn't want to clutter it.
+katana::Result<std::vector<tsuba::RDGView>>
+tsuba::ListAvailableViewsFromVersion(
+    const std::string& rdg_dir, uint64_t version) {
+  std::vector<tsuba::RDGView> views_found;
+  KATANA_LOG_DEBUG("ListAvailableViewsFromVersion");
+  auto list_res = FileList(rdg_dir);
+  if (!list_res) {
+    KATANA_LOG_DEBUG("failed to list files in {}", rdg_dir);
+    return list_res.error();
+  }
+
+  for (const std::string& file : list_res.value()) {
+    auto view_type_res = tsuba::RDGManifest::ParseViewNameFromName(file);
+    auto view_args_res = tsuba::RDGManifest::ParseViewArgsFromName(file);
+    auto view_version_res = tsuba::RDGManifest::ParseVersionFromName(file);
+
+    if (!view_type_res || !view_args_res || !view_version_res ||
+        view_version_res.value() != version) {
+      continue;
+    }
+
+    std::string rdg_path = fmt::format("{}/{}", rdg_dir, file);
+
+    auto rdg_uri = katana::Uri::Make(rdg_path);
+    if (!rdg_uri)
+      continue;
+
+    auto rdg_res = RDGManifest::Make(rdg_uri.value());
+    if (!rdg_res)
+      continue;
+
+    RDGManifest manifest = rdg_res.value();
+
+    std::vector<std::string> args_vector = std::move(view_args_res.value());
+    views_found.push_back(tsuba::RDGView{
+        .view_version = view_version_res.value(),
+        .view_type = view_type_res.value(),
+        .view_args = fmt::format("{}", fmt::join(args_vector, "-")),
+        .view_path = fmt::format("{}/{}", rdg_dir, file),
+        .num_partitions = manifest.num_hosts(),
+        .policy_id = manifest.policy_id(),
+        .transpose = manifest.transpose(),
+    });
+  }
+
+  return views_found;
+}
+
+// From CSVImport.cpp
+katana::Result<uint64_t>
+Weigh(const std::string& file) {
+  tsuba::StatBuf buf;
+  auto res = tsuba::FileStat(file, &buf);
+  if (!res) {
+    return res.error().WithContext(
+        "cannot stat the file {}; with error {}.", file, res.error());
+  }
+  return buf.size;
+}
+
+// From CSVImport.cpp
+katana::Result<std::vector<uint64_t>>
+WeighFiles(const std::vector<std::string>& ops) {
+  auto& net = katana::getSystemNetworkInterface();
+  auto [begin_file_idx, end_file_idx] =
+      katana::block_range(uint64_t{0}, uint64_t{ops.size()}, net.ID, net.Num);
+
+  std::vector<uint64_t> result(
+      ops.size(), std::numeric_limits<uint64_t>::max());
+
+  katana::PerThreadStorage<std::optional<katana::CopyableErrorInfo>> error;
+  katana::do_all(
+      katana::iterate(begin_file_idx, end_file_idx),
+      [&](uint64_t i) {
+        if (error.getLocal()->has_value()) {
+          return;
+        }
+        auto weigh_res = Weigh(ops[i].op.file);
+        if (!weigh_res) {
+          *error.getLocal() = katana::CopyableErrorInfo(
+              weigh_res.error().WithContext("reading {}", ops[i].op.file));
+          return;
+        }
+        result[i] = weigh_res.value();
+      },
+      katana::steal());
+
+  for (auto local_error : error) {
+    if (local_error) {
+      return KATANA_ERROR(local_error->error_code(), "{}", *local_error);
+    }
+  }
+
+  for (katana::HostID id = katana::HostID{0}; id.value() < net.Num; ++id) {
+    if (id.value() == net.ID) {
+      continue;
+    }
+    katana::SendBuffer buf;
+    katana::gSerialize(
+        buf, begin_file_idx,
+        std::vector<uint64_t>(
+            result.begin() + begin_file_idx, result.begin() + end_file_idx));
+    net.Send(id.value(), std::move(buf));
+  }
+
+  for (katana::HostID id = katana::HostID{0}; id.value() < net.Num; ++id) {
+    if (id.value() == net.ID) {
+      continue;
+    }
+    uint64_t other_begin;
+    std::vector<uint64_t> other_result;
+
+    auto recv_result = net.Recv();
+    katana::gDeserialize(recv_result.second, other_begin, other_result);
+
+    std::copy(
+        other_result.begin(), other_result.end(), result.begin() + other_begin);
+  }
+  net.EndCommunicationPhase();
+
+  return result;
+}
+
+// Adapted from CSVImport.cpp
+std::pair<std::pair<uint64_t, uint64_t>, std::pair<uint64_t, uint64_t>>
+SliceWeightedVectorForHost(
+    std::vector<uint64_t> weights, katana::HostID host_id,
+    katana::HostID num_hosts) {
+  if (weights.empty()) {
+    return std::make_pair(std::make_pair(0, 0), std::make_pair(0, 0));
+  }
+  if (weights.size() <= num_hosts) {
+    return std::make_pair(
+        std::make_pair(std::min(size_t{host_id.value()}, weights.size()), 0),
+        std::make_pair(
+            std::min(size_t{host_id.value() + 1}, weights.size()), 0));
+  }
+  katana::ParallelSTL::partial_sum(
+      weights.begin(), weights.end(), weights.begin());
+
+  uint64_t host_weight =
+      (weights.back() + num_hosts.value() - 1) / num_hosts.value();
+
+  std::vector<uint64_t> per_host_end_idx(num_hosts.value());
+  for (katana::HostID i = katana::HostID{0}; i < num_hosts; ++i) {
+    auto it = std::upper_bound(
+        weights.begin(), weights.end(), (i.value() + 1) * host_weight);
+    per_host_end_idx[i.value()] = std::distance(weights.begin(), it);
+  }
+
+  KATANA_LOG_VASSERT(
+      per_host_end_idx.back() == weights.size(), "{} vs {}",
+      per_host_end_idx.back(), weights.size());
+
+  auto files_assigned_to_neighbors = [&per_host_end_idx](uint64_t host_id) {
+    uint64_t last = per_host_end_idx.size() - 1;
+    uint64_t on_the_left =
+        (host_id == 0 ? 0
+                      : per_host_end_idx[host_id - 1] -
+                            (host_id <= 1 ? 0 : per_host_end_idx[host_id - 2]));
+    uint64_t on_the_right =
+        (host_id == last
+             ? 0
+             : per_host_end_idx[host_id + 1] - per_host_end_idx[host_id]);
+
+    return std::make_pair(on_the_left, on_the_right);
+  };
+
+  // deterministically move things around to make sure every host has at least
+  // one value (required for now)
+  uint32_t hosts_with_no_files;
+  do {
+    hosts_with_no_files = num_hosts.value();
+    for (uint64_t i = 0; i < per_host_end_idx.size(); ++i) {
+      uint64_t start = i == 0 ? 0 : per_host_end_idx[i - 1];
+      uint64_t end = per_host_end_idx[i];
+      if (start != end) {
+        --hosts_with_no_files;
+        continue;
+      }
+      auto [on_left, on_right] = files_assigned_to_neighbors(i);
+      if (on_left > 0 && on_left >= on_right) {
+        --per_host_end_idx[i - 1];
+        if (on_left <= 1) {
+          hosts_with_no_files += 1;
+        }
+      } else if (on_right > 0) {
+        ++per_host_end_idx[i];
+      }
+      --hosts_with_no_files;
+    }
+  } while (hosts_with_no_files > 0);
+
+  uint64_t start = (host_id == 0 ? 0 : per_host_end_idx[host_id.value() - 1]);
+  uint64_t end = per_host_end_idx[host_id.value()];
+  return std::make_pair(std::make_pair(start, 0), std::make_pair(end, 0));
+}
+
+
+katana::Result<std::vector<std::pair<std::string, std::string>>>
+tsuba::ListAllFilesFromView(const std::string& src_dir, const std::string& dst_sir, uint64_t version) {
+  std::vector<std::pair<std::string, std::string>>> src_dest_pairs;
+
+  return src_dest_pairs;
+}
+
+
+katana::Result<void>
+tsuba::CopyRDG(
+    const std::string& src_dir, const std::string& dst_dir, uint64_t version) {
+  // List out all the files in a given view
+  auto rdg_views_res = tsuba::ListAvailableViewsFromVersion(
+      src_dir, version);
+  for (const auto& rdg_view : rdg_views_res.value()) {
+    KATANA_LOG_WARN("view_path: {}", rdg_view.view_path);
+    auto uri = KATANA_CHECKED(katana::Uri::Make(src_dir));
+
+    auto rdg_manifest_res = tsuba::RDGManifest::Make(
+        uri, rdg_view.view_type, version);
+    if (!rdg_manifest_res) {
+      continue;
+    }
+    auto fnames = KATANA_CHECKED(rdg_manifest_res.value().FileNames());
+
+    std::string manifest_file{};
+    // Write out the data first
+    for (const auto fname : fnames) {
+      KATANA_LOG_WARN("view_fname: {}", fname);
+      auto src_joined_path = katana::Uri::JoinPath(src_dir, fname);
+      KATANA_LOG_WARN("src_joined_path: {}", src_joined_path);
+      auto src = KATANA_CHECKED(katana::Uri::Make(src_joined_path));
+
+      // Let's skip copying this over for now. Let's just get the pure name of the file
+      if (tsuba::RDGManifest::IsManifestUri(src)) {
+        KATANA_LOG_WARN("found a manifest file");
+        manifest_file = fname;
+        continue;
+      }
+      auto dst_joined_path = katana::Uri::JoinPath(dst_dir, fname);
+      KATANA_LOG_WARN("dst_joined_path: {}", dst_joined_path);
+      auto dst = KATANA_CHECKED(katana::Uri::Make(dst_joined_path));
+
+      // Now copy it over
+      tsuba::FileView fv;
+      KATANA_CHECKED(fv.Bind(src.path(), false));
+      KATANA_CHECKED(tsuba::FileStore(dst.path(), fv.ptr<char>(), fv.size()));
+    }
+    // Write out the manifest file as a final commit!
+    // TODO: make sure to change the version?
+    tsuba::FileView fv;
+    auto dst_manifest_path = katana::Uri::JoinPath(dst_dir, manifest_file);
+    KATANA_LOG_WARN("dst_manifest_path: {}", dst_manifest_path);
+    KATANA_CHECKED(fv.Bind(rdg_view.view_path, false));
+    KATANA_CHECKED(tsuba::FileStore(dst_manifest_path, fv.ptr<char>(), fv.size()));
+  }
+  return katana::ResultSuccess();
 }
 
 katana::Uri

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -2,6 +2,7 @@
 
 #include "GlobalState.h"
 #include "RDGHandleImpl.h"
+#include "RDGPartHeader.h"
 #include "katana/CommBackend.h"
 #include "katana/Env.h"
 #include "katana/Plugin.h"
@@ -288,10 +289,10 @@ tsuba::CreateSrcDestFromViewsForCopy(
       // We're batching this now because we want to rely on having the RDG manifest file in case things
       // change in the future.
       katana::Uri dst_file_uri;
-      if (tsuba::RDGManifest::IsPartitionFileUri(src_file_uri)) {
+      if (tsuba::RDGPartHeader::IsPartitionFileUri(src_file_uri)) {
         KATANA_LOG_WARN("src_file_uri partition: {}", src_file_uri);
         auto host_id =
-            KATANA_CHECKED(tsuba::RDGManifest::ParseHostFromPartitionFile(
+            KATANA_CHECKED(tsuba::RDGPartHeader::ParseHostFromPartitionFile(
                 src_file_uri.BaseName()));
         auto dst_dir_uri = KATANA_CHECKED(katana::Uri::Make(dst_dir));
         dst_file_uri = tsuba::RDGManifest::PartitionFileName(
@@ -325,8 +326,8 @@ tsuba::CreateSrcDestFromViewsForCopy(
 
 katana::Result<void>
 tsuba::CopyRDG(std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_pairs) {
-  // TODO: make sure that manifests are written at the end!
-  // TODO: add do_all loop
+  // TODO(vkarthik): make sure that manifests are written at the end!
+  // TODO(vkarthik): add do_all loop
   std::vector<uint64_t> manifest_uri_idxs;
   for (uint64_t i = 0; i < src_dst_pairs.size(); i++) {
     auto [src_file_uri, dst_file_uri] = src_dst_pairs[i];


### PR DESCRIPTION
Hi folks,

This PR comes from a longstanding request to implement proper semantics for CopyRDGOperation where we actually copy over the RDG to the graph path instead of loading in memory and then writing it out. There's a good amount to unpack here but I took the liberty to implement things in a bit of a scrappy manner. Some things I wanted to point out.

- There are still some `KATANA_LOG_WARN` messages that I left in and will clean up
- I decided to make `CopyRDG` take in pairs of src and destinations mainly because I felt like it made more sense to batch them up in this manner before sending them out to be copied over. This API made more sense in my mind and felt cleaner, but I may have overcomplicated things.
- I went ahead and added some partition header functions in RDGManifest. I wasn't sure of what was the best place for this so please let me know. 
- I'm following the semantics where the version and views I copy over are going to be interpreted as version 1 in the newly loaded graph path. This can be modified based on discussion and such.

I may be missing some other things but please make some good nits at the code as this is the first time I've really worked with some of the storage interfaces! 

See: https://github.com/KatanaGraph/katana-enterprise/pull/1843