### PR TITLE
PropertyGraph accessors for indexes

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -762,6 +762,27 @@ public:
   edge_indexes() const {
     return edge_indexes_;
   }
+
+  // Returns true of an index exists for the named property
+  bool HasNodePropertyIndex(const std::string& property_name) const {
+    for (const auto& index : node_indexes()) {
+      if (index->column_name() == property_name) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Returns the property index associated with the named property
+  katana::Result<katana::PropertyIndex<GraphTopology::Node>*>
+  GetNodePropertyIndex(const std::string& property_name) const {
+    for (const auto& index : node_indexes()) {
+      if (index->column_name() == property_name) {
+        return index.get();
+      }
+    }
+    return KATANA_ERROR(katana::ErrorCode::NotFound, "node index not found");
+  }
 };
 
 /// SortAllEdgesByDest sorts edges for each node by destination

--- a/libgalois/include/katana/PropertyIndex.h
+++ b/libgalois/include/katana/PropertyIndex.h
@@ -30,13 +30,14 @@ public:
   // The set key type is either a node/edge id (all the keys in the actual set)
   // or a value representing the search key.
   using set_key_type = typename std::variant<
-      IndexID, bool, int64_t, double_t, std::string_view*>;
+      IndexID, bool, uint8_t, int64_t, double_t, std::string_view*>;
 
   // PropertyIndex::iterator returns a sequence of node or edge ids.
   using base_iterator = typename std::multiset<set_key_type>::iterator;
   class iterator : public base_iterator {
   public:
     explicit iterator(const base_iterator& base) : base_iterator(base) {}
+    iterator() : base_iterator(0) {}
     const node_or_edge& operator*() const {
       return std::get<IndexID>(base_iterator::operator*()).id;
     }
@@ -145,6 +146,8 @@ private:
 template <typename node_or_edge>
 class KATANA_EXPORT StringPropertyIndex : public PropertyIndex<node_or_edge> {
 public:
+  using ArrowArrayType =
+      typename arrow::TypeTraits<arrow::LargeStringType>::ArrayType;
   using IndexID = typename PropertyIndex<node_or_edge>::IndexID;
   using iterator = typename PropertyIndex<node_or_edge>::iterator;
   using set_key_type = typename PropertyIndex<node_or_edge>::set_key_type;

--- a/libgalois/src/PropertyIndex.cpp
+++ b/libgalois/src/PropertyIndex.cpp
@@ -17,6 +17,10 @@ MakeTypedIndex(
     index = std::make_unique<PrimitivePropertyIndex<node_or_edge, bool>>(
         column_name, num_entities, property);
     break;
+  case arrow::Type::UINT8:
+    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, uint8_t>>(
+        column_name, num_entities, property);
+    break;
   case arrow::Type::INT64:
     index = std::make_unique<PrimitivePropertyIndex<node_or_edge, int64_t>>(
         column_name, num_entities, property);


### PR DESCRIPTION
* Add property index accessors.
* Include support for `uint8`.