### PR TITLE
Fix handling of backward 1.6 conda package

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -6,7 +6,7 @@ channels:
  - metagraph
 dependencies:
  - arrow-cpp>=4.0,<5.0.0a0
- - backward-cpp>=1.4
+ - backward-cpp=1.4
  - benchmark
  - black=19.10
  - breathe>=4.30

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -32,7 +32,7 @@ dependencies:
  - ninja
  - ncurses>=6.1
  - nlohmann_json>=3.7.3
- - numba
+ - numba=0.53.1
  - numpy
  - openblas>=0.3.12
  - packaging

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - jinja2
     - cython>=0.29.12
     - pyarrow {{ arrow_cpp }}
-    - numba>=0.50,<1.0a0
+    - numba=0.53.1
     - python {{ python }}
     - {{ compiler('cxx') }}
     - {{ cdt('numactl-devel') }}
@@ -116,7 +116,7 @@ outputs:
         - jinja2
         - cython>=0.29.12
         - pyarrow {{ arrow_cpp }}
-        - numba>=0.50,<1.0a0
+        - numba=0.53.1
         - python {{ python }}
       run:
         - {{ pin_subpackage('katana-cpp', exact=True) }}

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ cdt('numactl-devel') }}
     - arrow-cpp {{ arrow_cpp }}
-    - backward-cpp>=1.4
+    - backward-cpp=1.4
     - boost-cpp>=1.74
     - elfutils
     - fmt>=6.2.1
@@ -66,7 +66,7 @@ outputs:
       host:
         - {{ cdt('numactl-devel') }}
         - arrow-cpp {{ arrow_cpp }}
-        - backward-cpp>=1.4
+        - backward-cpp=1.4
         - boost-cpp>=1.74
         - elfutils
         - fmt>=6.2.1
@@ -83,7 +83,7 @@ outputs:
         - fmt
         - nlohmann_json
         - libcurl
-        - backward-cpp
+        - backward-cpp=1.4
         - elfutils
         - libxml2
     run_exports:

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -73,14 +73,8 @@ endif()
 target_link_libraries(katana_support PUBLIC ${curl_lib})
 
 # Backtrace support
-if (ENV{CONDA_PREFIX})
-  find_package(Backward REQUIRED
-               # This is a hack to handle a package bug in conda package upstream
-               # TODO(amp): Remove the hack once https://github.com/conda-forge/backward-cpp-feedstock/issues/18 is fixed.
-               HINTS $ENV{CONDA_PREFIX}/lib64 $ENV{PREFIX}/lib64)
-else()
-  find_package(Backward REQUIRED)
-endif()
+
+find_package(Backward REQUIRED)
 target_link_libraries(katana_support PUBLIC Backward::Backward)
 
 find_package(fmt REQUIRED)

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -73,10 +73,14 @@ endif()
 target_link_libraries(katana_support PUBLIC ${curl_lib})
 
 # Backtrace support
-find_package(Backward REQUIRED
-             # This is a hack to handle a package bug in conda package upstream
-             # TODO(amp): Remove the hack once https://github.com/conda-forge/backward-cpp-feedstock/issues/18 is fixed.
-             HINTS $ENV{CONDA_PREFIX}/lib64 $ENV{PREFIX}/lib64)
+if (ENV{CONDA_PREFIX})
+  find_package(Backward REQUIRED
+               # This is a hack to handle a package bug in conda package upstream
+               # TODO(amp): Remove the hack once https://github.com/conda-forge/backward-cpp-feedstock/issues/18 is fixed.
+               HINTS $ENV{CONDA_PREFIX}/lib64 $ENV{PREFIX}/lib64)
+else()
+  find_package(Backward REQUIRED)
+endif()
 target_link_libraries(katana_support PUBLIC Backward::Backward)
 
 find_package(fmt REQUIRED)

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(katana_support PUBLIC ${curl_lib})
 find_package(Backward REQUIRED
              # This is a hack to handle a package bug in conda package upstream
              # TODO(amp): Remove the hack once https://github.com/conda-forge/backward-cpp-feedstock/issues/18 is fixed.
-             PATHS $ENV{CONDA_PREFIX}/lib64)
+             PATHS $ENV{CONDA_PREFIX}/lib64 $ENV{PREFIX}/lib64)
 target_link_libraries(katana_support PUBLIC Backward::Backward)
 
 find_package(fmt REQUIRED)

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(katana_support PUBLIC ${curl_lib})
 find_package(Backward REQUIRED
              # This is a hack to handle a package bug in conda package upstream
              # TODO(amp): Remove the hack once https://github.com/conda-forge/backward-cpp-feedstock/issues/18 is fixed.
-             PATHS $ENV{CONDA_PREFIX}/lib64 $ENV{PREFIX}/lib64)
+             HINTS $ENV{CONDA_PREFIX}/lib64 $ENV{PREFIX}/lib64)
 target_link_libraries(katana_support PUBLIC Backward::Backward)
 
 find_package(fmt REQUIRED)

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -73,7 +73,10 @@ endif()
 target_link_libraries(katana_support PUBLIC ${curl_lib})
 
 # Backtrace support
-find_package(Backward REQUIRED)
+find_package(Backward REQUIRED
+             # This is a hack to handle a package bug in conda package upstream
+             # TODO(amp): Remove the hack once https://github.com/conda-forge/backward-cpp-feedstock/issues/18 is fixed.
+             PATHS $ENV{CONDA_PREFIX}/lib64)
 target_link_libraries(katana_support PUBLIC Backward::Backward)
 
 find_package(fmt REQUIRED)

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -449,7 +449,7 @@ def setup_coverage():
 def setup(*, source_dir, package_name, additional_requires=None, package_data=None, **kwargs):
     package_data = package_data or {}
     # TODO(amp): Dependencies are yet again repeated here. This needs to come from a central deps list.
-    requires = ["pyarrow (<3.0)", "numpy", "numba (>=0.50,<1.0a0)"]
+    requires = ["pyarrow (<5.0)", "numpy", "numba (=0.53)"]
     if additional_requires:
         requires.extend(additional_requires)
 

--- a/python/katana_setup.py
+++ b/python/katana_setup.py
@@ -449,7 +449,7 @@ def setup_coverage():
 def setup(*, source_dir, package_name, additional_requires=None, package_data=None, **kwargs):
     package_data = package_data or {}
     # TODO(amp): Dependencies are yet again repeated here. This needs to come from a central deps list.
-    requires = ["pyarrow (<5.0)", "numpy", "numba (=0.53)"]
+    requires = ["pyarrow (<5.0)", "numpy", "numba (==0.53)"]
     if additional_requires:
         requires.extend(additional_requires)
 


### PR DESCRIPTION
The upstream conda package put the cmake config file in the wrong place (lib64 instead of lib). This just checks that path to find it.

JIRA: KAT-1427