### PR TITLE
Make ProgressScope nodiscard

### DIFF
--- a/libsupport/include/katana/ProgressTracer.h
+++ b/libsupport/include/katana/ProgressTracer.h
@@ -180,11 +180,11 @@ private:
 
 KATANA_EXPORT ProgressTracer& GetTracer();
 
-class KATANA_EXPORT ProgressScope {
+class KATANA_EXPORT [[nodiscard]] ProgressScope {
 public:
   ~ProgressScope();
   ProgressScope(const ProgressScope&) = delete;
-  ProgressScope(ProgressScope&&) = delete;
+  ProgressScope(ProgressScope &&) = delete;
   ProgressScope& operator=(const ProgressScope&) = delete;
   ProgressScope& operator=(ProgressScope&&) = delete;
 


### PR DESCRIPTION
It is probably a bug to not capture a ProgressScope in a local variable
as the alternative would create and immediately close a span. Use
nodiscard to enforce this policy.