### PR TITLE
Allow the property cache to evict during RDG initialization

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -633,12 +633,10 @@ public:
 
   /// Write a node property column out to storage and de-allocate the memory
   /// it was using
-  Result<void> UnloadNodeProperty(int i);
   Result<void> UnloadNodeProperty(const std::string& prop_name);
 
   /// Write an edge property column out to storage and de-allocate the
   /// memory it was using
-  Result<void> UnloadEdgeProperty(int i);
   Result<void> UnloadEdgeProperty(const std::string& prop_name);
 
   /// Load a node property by name put it in the table at index i

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -817,11 +817,6 @@ katana::PropertyGraph::RemoveNodeProperty(const std::string& prop_name) {
 }
 
 katana::Result<void>
-katana::PropertyGraph::UnloadNodeProperty(int i) {
-  return rdg_.UnloadNodeProperty(i);
-}
-
-katana::Result<void>
 katana::PropertyGraph::LoadNodeProperty(const std::string& name, int i) {
   return rdg_.LoadNodeProperty(name, i);
 }
@@ -847,12 +842,7 @@ katana::PropertyGraph::ListEdgeProperties() const {
 
 katana::Result<void>
 katana::PropertyGraph::UnloadNodeProperty(const std::string& prop_name) {
-  auto col_names = rdg_.node_properties()->ColumnNames();
-  auto pos = std::find(col_names.cbegin(), col_names.cend(), prop_name);
-  if (pos != col_names.cend()) {
-    return rdg_.UnloadNodeProperty(std::distance(col_names.cbegin(), pos));
-  }
-  return katana::ErrorCode::PropertyNotFound;
+  return rdg_.UnloadNodeProperty(prop_name);
 }
 
 katana::Result<void>
@@ -901,8 +891,8 @@ katana::PropertyGraph::RemoveEdgeProperty(const std::string& prop_name) {
 }
 
 katana::Result<void>
-katana::PropertyGraph::UnloadEdgeProperty(int i) {
-  return rdg_.UnloadEdgeProperty(i);
+katana::PropertyGraph::UnloadEdgeProperty(const std::string& prop_name) {
+  return rdg_.UnloadEdgeProperty(prop_name);
 }
 
 katana::Result<void>
@@ -918,16 +908,6 @@ katana::PropertyGraph::EnsureEdgePropertyLoaded(const std::string& name) {
     return katana::ResultSuccess();
   }
   return LoadEdgeProperty(name);
-}
-
-katana::Result<void>
-katana::PropertyGraph::UnloadEdgeProperty(const std::string& prop_name) {
-  auto col_names = rdg_.edge_properties()->ColumnNames();
-  auto pos = std::find(col_names.cbegin(), col_names.cend(), prop_name);
-  if (pos != col_names.cend()) {
-    return rdg_.UnloadEdgeProperty(std::distance(col_names.cbegin(), pos));
-  }
-  return katana::ErrorCode::PropertyNotFound;
 }
 
 // Build an index over nodes.

--- a/libsupport/test/cache.cpp
+++ b/libsupport/test/cache.cpp
@@ -102,7 +102,8 @@ TestLRUBytes(
   size_t byte_size = 4;
   katana::Cache<PropertyCacheKey, CacheValue> cache(
       byte_size, [](const CacheValue& value) { return BytesInValue(value); },
-      [&](const PropertyCacheKey&) { count_evictions++; });
+      [&](const PropertyCacheKey&, [[maybe_unused]] uint64_t approx_bytes,
+          void*) { count_evictions++; });
 
   PropertyCacheKey key(NodeEdge::kNode, "not gonna happen");
   KATANA_LOG_ASSERT(!cache.Get(key).has_value());
@@ -143,7 +144,9 @@ TestLRUSize(
     const std::vector<PropertyCacheKey>& edge_keys) {
   count_evictions = 0;
   katana::Cache<PropertyCacheKey, CacheValue> cache(
-      lru_size, [&](const PropertyCacheKey&) { count_evictions++; });
+      lru_size,
+      [&](const PropertyCacheKey&, [[maybe_unused]] uint64_t approx_bytes,
+          void*) { count_evictions++; });
 
   InsertRandom(node_keys, cache);
 

--- a/libtsuba/include/tsuba/PropertyCache.h
+++ b/libtsuba/include/tsuba/PropertyCache.h
@@ -5,34 +5,51 @@
 
 namespace tsuba {
 
-enum class NodeEdge { kNode = 10, kEdge };
+enum class NodeEdge { kNode = 10, kEdge, kNeitherNodeNorEdge };
 
-struct KATANA_EXPORT PropertyCacheKey {
-  NodeEdge node_edge;
-  std::string name;
-  PropertyCacheKey(NodeEdge _node_edge) : node_edge(_node_edge) {}
+class KATANA_EXPORT PropertyCacheKey {
+public:
+  PropertyCacheKey(
+      NodeEdge node_edge, const std::string& rdg_dir,
+      const std::string& prop_name)
+      : node_edge_(node_edge), rdg_dir_(rdg_dir), prop_name_(prop_name) {}
   bool operator==(const PropertyCacheKey& o) const {
-    return node_edge == o.node_edge && name == o.name;
+    return node_edge_ == o.node_edge_ && rdg_dir_ == o.rdg_dir_ &&
+           prop_name_ == o.prop_name_;
   }
+  const char* TypeAsConstChar() const {
+    return (node_edge_ == NodeEdge::kNode) ? "node" : "edge";
+  }
+  NodeEdge node_edge() const { return node_edge_; }
+  std::string prop_name() const { return prop_name_; }
   struct Hash {
     std::size_t operator()(const PropertyCacheKey& k) const {
       using boost::hash_combine;
       using boost::hash_value;
 
       std::size_t seed = 0;
-      hash_combine(seed, hash_value(k.node_edge));
-      hash_combine(seed, hash_value(k.name));
+      hash_combine(seed, hash_value(k.node_edge_));
+      hash_combine(seed, hash_value(k.rdg_dir_));
+      hash_combine(seed, hash_value(k.prop_name_));
 
       // Return the result.
       return seed;
     }
   };
+
+private:
+  // Is this a node or edge property name
+  NodeEdge node_edge_;
+  // What RDG does this property belong to
+  std::string rdg_dir_;
+  // Node property names are unique, and we enforce that.
+  // Edge property names are unique, and we enforce that.
+  std::string prop_name_;
 };
 
-// Property names are unique, and we enforce that.
-// Each table should only contain a single column.
+class RDG;
 using PropertyCache =
-    katana::Cache<PropertyCacheKey, std::shared_ptr<arrow::Table>>;
+    katana::Cache<PropertyCacheKey, std::shared_ptr<arrow::Table>, RDG*>;
 
 }  // namespace tsuba
 

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -42,6 +42,9 @@ struct KATANA_EXPORT RDGLoadOptions {
   /// List of edge properties that should be loaded
   /// nullptr means all edge properties will be loaded
   std::optional<std::vector<std::string>> edge_properties{std::nullopt};
+  // Each table should only contain a single column.
+  // Callback provides a pointer to the RDG so we can evict
+  // even before the PropertyGraph is created.
   tsuba::PropertyCache* prop_cache{nullptr};
 };
 
@@ -153,10 +156,12 @@ public:
   /// Ensure the node property at index `i` was written back to storage
   /// then free its memory
   katana::Result<void> UnloadNodeProperty(int i);
+  katana::Result<void> UnloadNodeProperty(const std::string& name);
 
   /// Ensure the edge property at index `i` was written back to storage
   /// then free its memory
   katana::Result<void> UnloadEdgeProperty(int i);
+  katana::Result<void> UnloadEdgeProperty(const std::string& name);
 
   /// Load node property with a particular name and insert it into the
   /// property table at index. If index is invalid, the property is put
@@ -344,7 +349,7 @@ private:
 
   std::unique_ptr<RDGCore> core_;
   // Optional property cache
-  PropertyCache* prop_cache_{nullptr};
+  tsuba::PropertyCache* prop_cache_{nullptr};
 
   std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
   std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;

--- a/libtsuba/src/AddProperties.h
+++ b/libtsuba/src/AddProperties.h
@@ -18,8 +18,8 @@ KATANA_EXPORT katana::Result<std::shared_ptr<arrow::Table>> LoadPropertySlice(
     int64_t offset, int64_t length);
 
 KATANA_EXPORT katana::Result<void> AddProperties(
-    const katana::Uri& uri, tsuba::PropertyCacheKey* key,
-    tsuba::PropertyCache* cache,
+    const katana::Uri& uri, tsuba::NodeEdge node_edge,
+    tsuba::PropertyCache* cache, tsuba::RDG* rdg,
     const std::vector<tsuba::PropStorageInfo*>& properties, ReadGroup* grp,
     const std::function<katana::Result<void>(std::shared_ptr<arrow::Table>)>&
         add_fn);


### PR DESCRIPTION
The cache provides the callback function with the size of the object
being evicted.  The cache also provides an RDG pointer, which is
vital if the RDG is in the process of being constructed.

Also elminate Unload*Property(int i) because properties should
be referred to by name, not position.

Jira: KAT-855