### PR TITLE
Simplify VisitArrow

### DIFF
--- a/docs/reference/cxx/arrow.rst
+++ b/docs/reference/cxx/arrow.rst
@@ -1,0 +1,21 @@
+=====
+Arrow
+=====
+
+Inspecting Arrow Data
+=====================
+
+In addition to the Arrow API, there are some support functions in the Katana
+library to help inspect Arrow data in a type-safe way.
+
+.. doxygenfunction:: katana::VisitArrow
+
+.. doxygenclass:: katana::ArrowVisitor
+
+.. doxygenfunction:: katana::GetArrowTypeID(const arrow::Scalar&)
+
+.. doxygenfunction:: katana::GetArrowTypeID(const arrow::Array&)
+
+.. doxygenfunction:: katana::GetArrowTypeID(const arrow::ArrayBuilder*)
+
+.. doxygenfunction:: katana::ArrayFromScalars

--- a/docs/reference/cxx/index.rst
+++ b/docs/reference/cxx/index.rst
@@ -3,6 +3,7 @@ C++ Library
 ===========
 
 .. toctree::
+   arrow
    error-handling
    property-graph
    tracing

--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -279,9 +279,6 @@ TableBuilder::AddColumn(const ColumnOptions& options) {
   columns_.emplace_back(std::make_shared<arrow::ChunkedArray>(chunks));
 }
 
-////////////////////////////////////////////
-// Arrow utilities
-
 /// Return a ChunkeArray of Nulls of the given type and length
 KATANA_EXPORT std::shared_ptr<arrow::ChunkedArray> NullChunkedArray(
     const std::shared_ptr<arrow::DataType>& type, int64_t length);

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -30,6 +30,11 @@ add_unit_test(tracing)
 add_unit_test(uri)
 add_unit_test(zip_iterator)
 
+add_executable(arrow-bench arrow-bench.cpp)
+target_link_libraries(arrow-bench katana_support benchmark::benchmark)
+add_test(NAME arrow-bench COMMAND arrow-bench --benchmark_filter=/1024)
+set_tests_properties(arrow-bench PROPERTIES LABELS quick)
+
 add_executable(result-bench result-bench.cpp)
 target_link_libraries(result-bench katana_support benchmark::benchmark)
 add_test(NAME result-bench COMMAND result-bench --benchmark_filter=KatanaResultWithContext/1/1024/3/16)

--- a/libsupport/test/arrow-bench.cpp
+++ b/libsupport/test/arrow-bench.cpp
@@ -1,0 +1,457 @@
+#include <memory>
+#include <random>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <arrow/api.h>
+#include <arrow/scalar.h>
+#include <arrow/type.h>
+#include <arrow/type_traits.h>
+#include <benchmark/benchmark.h>
+
+#include "katana/ArrowVisitor.h"
+#include "katana/ErrorCode.h"
+#include "katana/Random.h"
+#include "katana/Result.h"
+
+arrow::Type::type
+GetArrowTypeID(const arrow::Scalar& scalar) {
+  return scalar.type->id();
+}
+
+template <typename T>
+constexpr decltype(auto)
+DispatchCast(const arrow::Scalar& scalar) {
+  using CalleeType = const typename arrow::TypeTraits<T>::ScalarType&;
+  return static_cast<CalleeType>(scalar);
+}
+
+namespace {
+
+void
+MakeArguments(benchmark::internal::Benchmark* b) {
+  for (long size : {1024, 64 * 1024, 1024 * 1024}) {
+    b->Args({size});
+  }
+}
+
+struct GetValueVisitor {
+  using ReturnType = int64_t;
+  using ResultType = katana::Result<ReturnType>;
+
+  template <typename ArrowType, typename ScalarType>
+  std::enable_if_t<arrow::is_number_type<ArrowType>::value, ResultType> Call(
+      const ScalarType& scalar) {
+    return scalar.value;
+  }
+
+  template <typename... ArrowTypes>
+  ResultType Call(...) {
+    return KATANA_ERROR(katana::ErrorCode::ArrowError, "no matching call");
+  }
+};
+
+std::vector<std::unique_ptr<arrow::Scalar>>
+MakeInput(long size) {
+  std::vector<std::unique_ptr<arrow::Scalar>> ret;
+
+  std::vector<std::function<std::unique_ptr<arrow::Scalar>()>> generators{
+      []() { return std::make_unique<arrow::Int64Scalar>(1); },
+      []() { return std::make_unique<arrow::Int32Scalar>(1); },
+      []() { return std::make_unique<arrow::Int16Scalar>(1); },
+      []() { return std::make_unique<arrow::Int8Scalar>(1); },
+      []() { return std::make_unique<arrow::UInt64Scalar>(1); },
+      []() { return std::make_unique<arrow::UInt32Scalar>(1); },
+      []() { return std::make_unique<arrow::UInt16Scalar>(1); },
+      []() { return std::make_unique<arrow::UInt8Scalar>(1); },
+      []() { return std::make_unique<arrow::FloatScalar>(1); },
+      []() { return std::make_unique<arrow::DoubleScalar>(1); },
+  };
+
+  std::uniform_int_distribution<int> dist(0, generators.size() - 1);
+  ret.reserve(size);
+
+  for (int i = 0; i < size; ++i) {
+    int idx = dist(katana::GetGenerator());
+    ret.emplace_back(generators[idx]());
+  }
+
+  return ret;
+}
+
+void
+RunVisit(const std::vector<std::unique_ptr<arrow::Scalar>>& scalars) {
+  GetValueVisitor v;
+  size_t total = 0;
+  for (const auto& s : scalars) {
+    auto res = katana::VisitArrow(*s, v);
+    KATANA_LOG_VASSERT(res, "unexpected errror {}", res.error());
+    total += res.value();
+  }
+
+  KATANA_LOG_VASSERT(
+      total == scalars.size(), "{} != {}", total, scalars.size());
+}
+
+void
+Visit(benchmark::State& state) {
+  long size = state.range(0);
+  auto input = MakeInput(size);
+
+  for (auto _ : state) {
+    RunVisit(input);
+  }
+
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+template <class ScalarType>
+int64_t
+GetValue(ScalarType* scalar) {
+  return scalar->value;
+}
+
+template <class ScalarType>
+katana::Result<int64_t>
+GetValueResult(ScalarType* scalar) {
+  return scalar->value;
+}
+
+void
+RunDynamicCast(const std::vector<std::unique_ptr<arrow::Scalar>>& scalars) {
+  size_t total = 0;
+  for (const auto& s : scalars) {
+    if (auto* p = dynamic_cast<arrow::Int8Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::Int16Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::Int32Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::Int64Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::UInt8Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::UInt16Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::UInt32Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::UInt64Scalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::FloatScalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else if (auto* p = dynamic_cast<arrow::DoubleScalar*>(s.get()); p) {
+      total += GetValue(p);
+    } else {
+      continue;
+    }
+  }
+
+  KATANA_LOG_VASSERT(
+      total == scalars.size(), "{} != {}", total, scalars.size());
+}
+
+void
+DynamicCast(benchmark::State& state) {
+  long size = state.range(0);
+  auto input = MakeInput(size);
+
+  for (auto _ : state) {
+    RunDynamicCast(input);
+  }
+
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+void
+RunInlineSwitch(const std::vector<std::unique_ptr<arrow::Scalar>>& scalars) {
+  size_t total = 0;
+  for (const auto& s : scalars) {
+    switch (s->type->id()) {
+    case arrow::Type::INT8:
+    case arrow::Type::UINT8:
+    case arrow::Type::INT16:
+    case arrow::Type::UINT16:
+    case arrow::Type::INT32:
+    case arrow::Type::UINT32:
+    case arrow::Type::INT64:
+    case arrow::Type::UINT64:
+    case arrow::Type::FLOAT:
+    case arrow::Type::DOUBLE:
+      total += 1;
+      break;
+    default:
+      continue;
+    }
+  }
+
+  KATANA_LOG_VASSERT(
+      total == scalars.size(), "{} != {}", total, scalars.size());
+}
+
+void
+InlineSwitch(benchmark::State& state) {
+  long size = state.range(0);
+  auto input = MakeInput(size);
+
+  for (auto _ : state) {
+    RunInlineSwitch(input);
+  }
+
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+void
+RunSwitchCast(const std::vector<std::unique_ptr<arrow::Scalar>>& scalars) {
+  size_t total = 0;
+  for (const auto& s : scalars) {
+    switch (s->type->id()) {
+#define CASE(EnumType, ArrowType)                                              \
+  case arrow::Type::EnumType: {                                                \
+    total += GetValue(static_cast<ArrowType*>(s.get()));                       \
+    break;                                                                     \
+  }
+      CASE(INT8, arrow::Int8Scalar)
+      CASE(UINT8, arrow::UInt8Scalar)
+      CASE(INT16, arrow::Int16Scalar)
+      CASE(UINT16, arrow::UInt16Scalar)
+      CASE(INT32, arrow::Int32Scalar)
+      CASE(UINT32, arrow::UInt32Scalar)
+      CASE(INT64, arrow::Int64Scalar)
+      CASE(UINT64, arrow::UInt64Scalar)
+      CASE(FLOAT, arrow::FloatScalar)
+      CASE(DOUBLE, arrow::DoubleScalar)
+#undef CASE
+    default:
+      continue;
+    }
+  }
+
+  KATANA_LOG_VASSERT(
+      total == scalars.size(), "{} != {}", total, scalars.size());
+}
+
+void
+SwitchCast(benchmark::State& state) {
+  long size = state.range(0);
+  auto input = MakeInput(size);
+
+  for (auto _ : state) {
+    RunSwitchCast(input);
+  }
+
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+void
+RunSwitchCastResult(
+    const std::vector<std::unique_ptr<arrow::Scalar>>& scalars) {
+  size_t total = 0;
+  for (const auto& s : scalars) {
+    switch (s->type->id()) {
+#define CASE(EnumType, ArrowType)                                              \
+  case arrow::Type::EnumType: {                                                \
+    auto res = GetValueResult(static_cast<ArrowType*>(s.get()));               \
+    KATANA_LOG_ASSERT(res);                                                    \
+    total += res.value();                                                      \
+    break;                                                                     \
+  }
+      CASE(INT8, arrow::Int8Scalar)
+      CASE(UINT8, arrow::UInt8Scalar)
+      CASE(INT16, arrow::Int16Scalar)
+      CASE(UINT16, arrow::UInt16Scalar)
+      CASE(INT32, arrow::Int32Scalar)
+      CASE(UINT32, arrow::UInt32Scalar)
+      CASE(INT64, arrow::Int64Scalar)
+      CASE(UINT64, arrow::UInt64Scalar)
+      CASE(FLOAT, arrow::FloatScalar)
+      CASE(DOUBLE, arrow::DoubleScalar)
+#undef CASE
+    default:
+      continue;
+    }
+  }
+
+  KATANA_LOG_VASSERT(
+      total == scalars.size(), "{} != {}", total, scalars.size());
+}
+
+void
+SwitchCastResult(benchmark::State& state) {
+  long size = state.range(0);
+  auto input = MakeInput(size);
+
+  for (auto _ : state) {
+    RunSwitchCastResult(input);
+  }
+
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+struct Dispatcher {
+  /// CanCall returns true if visitor.Call<ArrowTypes...>(Args...) exists.
+  template <typename Visitor, typename... ArrowTypes>
+  struct CanCall {
+    // Most of the ugliness comes from supporting member functions versus free
+    // functions.
+    template <typename... Args>
+    constexpr static std::enable_if_t<
+        std::is_invocable<
+            decltype(std::declval<Visitor>().template Call<ArrowTypes...>(
+                std::declval<Args>()...)) (Visitor::*)(Args...),
+            Visitor&, Args...>::value,
+        bool>
+    test(void*) {
+      return true;
+    }
+
+    template <typename...>
+    constexpr static bool test(...) {
+      return false;
+    }
+
+    template <typename... Args>
+    constexpr static bool value = test<Args...>(nullptr);
+  };
+
+  template <typename V, typename Tuple, size_t... I>
+  constexpr static bool TupleContains(std::index_sequence<I...>) {
+    return (std::is_same_v<V, std::tuple_element_t<I, Tuple>> || ...);
+  }
+
+  // CouldAccept returns true if the ith ArrowType is contained in the ith
+  // Visitor::AcceptType tuple.
+  template <size_t I, typename Visitor>
+  constexpr static bool CouldAccept() {
+    return true;
+  }
+
+  template <
+      size_t I, typename Visitor, typename ArrowType, typename... ArrowTypes>
+  constexpr static bool CouldAccept() {
+    using Current =
+        std::tuple_element_t<I, std::tuple<ArrowType, ArrowTypes...>>;
+    using CurrentAcceptTuple =
+        std::tuple_element_t<I, typename Visitor::AcceptType>;
+    constexpr size_t N = std::tuple_size_v<CurrentAcceptTuple>;
+    return TupleContains<Current, CurrentAcceptTuple>(
+        std::make_index_sequence<N>());
+  }
+
+  template <typename... ArrowTypes, typename Visitor, typename... Args>
+  static typename std::decay_t<Visitor>::ReturnType Call(
+      Visitor&& visitor, Args&&... args) {
+    constexpr auto index = sizeof...(ArrowTypes) - 1;
+    if constexpr (!CouldAccept<index, std::decay_t<Visitor>, ArrowTypes...>()) {
+      return visitor.AcceptFailed(std::forward<Args>(args)...);
+    } else if constexpr (index + 1 == sizeof...(Args)) {
+      if constexpr (CanCall<std::decay_t<Visitor>, ArrowTypes...>::
+                        template value<Args...>) {
+        return visitor.template Call<ArrowTypes...>(
+            DispatchCast<ArrowTypes>(std::forward<Args>(args))...);
+      } else {
+        return visitor.AcceptFailed(std::forward<Args>(args)...);
+      }
+    } else {
+      return Dispatch<ArrowTypes...>(
+          std::forward<Visitor>(visitor), std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename... ArrowTypes, typename Visitor, typename... Args>
+  static typename std::decay_t<Visitor>::ReturnType Dispatch(
+      Visitor&& visitor, Args&&... args) {
+    constexpr auto index = sizeof...(ArrowTypes);
+    auto type_id =
+        GetArrowTypeID(std::get<index>(std::forward_as_tuple(args...)));
+
+    switch (type_id) {
+#define CASE(EnumType)                                                         \
+  case arrow::Type::EnumType: {                                                \
+    using ArrowType =                                                          \
+        typename arrow::TypeIdTraits<arrow::Type::EnumType>::Type;             \
+    return Call<ArrowTypes..., ArrowType>(                                     \
+        std::forward<Visitor>(visitor), std::forward<Args>(args)...);          \
+  }
+      CASE(INT8)
+      CASE(UINT8)
+      CASE(INT16)
+      CASE(UINT16)
+      CASE(INT32)
+      CASE(UINT32)
+      CASE(INT64)
+      CASE(UINT64)
+      CASE(FLOAT)
+      CASE(DOUBLE)
+#undef CASE
+    default:
+      return visitor.AcceptFailed(std::forward<Args>(args)...);
+    }
+  }
+};
+
+using NumericLike = std::tuple<
+    arrow::Int8Type, arrow::UInt8Type, arrow::Int16Type, arrow::UInt16Type,
+    arrow::Int32Type, arrow::UInt32Type, arrow::Int64Type, arrow::UInt64Type,
+    arrow::FloatType, arrow::DoubleType>;
+
+static_assert(Dispatcher::TupleContains<arrow::Int8Type, NumericLike>(
+    std::make_index_sequence<std::tuple_size_v<NumericLike>>()));
+
+struct Visitor {
+  using ReturnType = katana::Result<int64_t>;
+  using AcceptType = std::tuple<NumericLike>;
+
+  template <typename... ArrowTypes, typename ScalarType>
+  ReturnType Call(const ScalarType& scalar) {
+    return scalar.value;
+  }
+
+  ReturnType AcceptFailed(const arrow::Scalar& scalar) {
+    std::stringstream ss;
+
+    return KATANA_ERROR(
+        katana::ErrorCode::ArrowError, "no matching type {}",
+        scalar.type->name());
+  }
+};
+
+static_assert(Dispatcher::CanCall<Visitor, arrow::UInt8Type>::value<
+              const arrow::UInt8Scalar&>);
+
+void
+RunDispatch(const std::vector<std::unique_ptr<arrow::Scalar>>& scalars) {
+  size_t total = 0;
+  Visitor visitor;
+  for (const auto& s : scalars) {
+    auto res = Dispatcher::Call(visitor, *s.get());
+    KATANA_LOG_VASSERT(res, "{}", res.error());
+    total += res.value();
+  }
+
+  KATANA_LOG_VASSERT(
+      total == scalars.size(), "{} != {}", total, scalars.size());
+}
+
+void
+Dispatch(benchmark::State& state) {
+  long size = state.range(0);
+  auto input = MakeInput(size);
+
+  for (auto _ : state) {
+    RunDispatch(input);
+  }
+
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+BENCHMARK(InlineSwitch)->Apply(MakeArguments);
+BENCHMARK(Visit)->Apply(MakeArguments);
+BENCHMARK(DynamicCast)->Apply(MakeArguments);
+BENCHMARK(SwitchCast)->Apply(MakeArguments);
+BENCHMARK(SwitchCastResult)->Apply(MakeArguments);
+BENCHMARK(Dispatch)->Apply(MakeArguments);
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/libsupport/test/arrow.cpp
+++ b/libsupport/test/arrow.cpp
@@ -1,11 +1,123 @@
+#include <memory>
 #include <type_traits>
 
 #include <arrow/api.h>
+#include <arrow/scalar.h>
 #include <arrow/type_traits.h>
 
 #include "katana/ArrowVisitor.h"
+#include "katana/ErrorCode.h"
+#include "katana/Result.h"
 
 namespace {
+
+struct NoCopy {
+  NoCopy() = default;
+  NoCopy(const NoCopy&) = delete;
+  NoCopy& operator=(const NoCopy&) = delete;
+};
+
+struct DerivedNoCopy : public NoCopy {};
+
+constexpr arrow::Type::type
+GetArrowTypeID(const NoCopy&) {
+  return arrow::Type::INT8;
+}
+
+template <typename T>
+constexpr decltype(auto)
+VisitArrowCast(const NoCopy& no_copy) {
+  return no_copy;
+}
+
+struct NoCopyVisitor : public katana::ArrowVisitor {
+  using ResultType = katana::Result<int64_t>;
+  using AcceptTypes = std::tuple<
+      katana::AcceptNumericArrowTypes, katana::AcceptNumericArrowTypes>;
+
+  template <typename... ArrowTypes>
+  ResultType Call(const NoCopy&, const NoCopy&) {
+    return 1;
+  }
+
+  ResultType AcceptFailed(const NoCopy&, const NoCopy&) {
+    return KATANA_ERROR(katana::ErrorCode::ArrowError, "no matching type");
+  }
+};
+
+struct ManyVisitor : public katana::ArrowVisitor {
+  using ResultType = katana::Result<int64_t>;
+
+  using ArgType = std::tuple<arrow::Int8Type>;
+  using AcceptTypes = std::tuple<ArgType, ArgType, ArgType, ArgType, ArgType>;
+
+  ResultType AcceptFailed(
+      const NoCopy&, const NoCopy&, const NoCopy&, const NoCopy&,
+      const NoCopy&) {
+    return KATANA_ERROR(katana::ErrorCode::ArrowError, "no matching type");
+  }
+
+  template <typename... ArrowTypes>
+  ResultType Call(
+      const NoCopy&, const NoCopy&, const NoCopy&, const NoCopy&,
+      const NoCopy&) {
+    return 1;
+  }
+};
+
+void
+TestNoCopy() {
+  NoCopy value;
+  NoCopyVisitor visitor;
+
+  auto res = katana::VisitArrow(visitor, value, value);
+  KATANA_LOG_ASSERT(res);
+}
+
+void
+TestDerivedNoCopy() {
+  DerivedNoCopy value;
+  NoCopyVisitor visitor;
+
+  auto res = katana::VisitArrow(visitor, value, value);
+  KATANA_LOG_ASSERT(res);
+}
+
+void
+TestMultipleParameters() {
+  NoCopy value;
+
+  ManyVisitor many_visitor;
+
+  // Without pruning instantiations, the following will generally crash a
+  // compiler
+  auto res =
+      katana::VisitArrow(many_visitor, value, value, value, value, value);
+  KATANA_LOG_ASSERT(res);
+}
+
+void
+TestTupleContains() {
+  using Dispatcher = katana::internal::ArrowDispatcher;
+
+  using Int8Tuple = std::tuple<arrow::Int8Type>;
+
+  static_assert(Dispatcher::TupleContains<arrow::Int8Type, Int8Tuple>(
+      std::make_index_sequence<std::tuple_size_v<Int8Tuple>>()));
+
+  static_assert(!Dispatcher::TupleContains<arrow::ListType, Int8Tuple>(
+      std::make_index_sequence<std::tuple_size_v<Int8Tuple>>()));
+
+  static_assert(Dispatcher::TupleContains<
+                arrow::Int8Type, katana::AcceptNumericArrowTypes>(
+      std::make_index_sequence<
+          std::tuple_size_v<katana::AcceptNumericArrowTypes>>()));
+
+  static_assert(!Dispatcher::TupleContains<
+                arrow::ListType, katana::AcceptNumericArrowTypes>(
+      std::make_index_sequence<
+          std::tuple_size_v<katana::AcceptNumericArrowTypes>>()));
+}
 
 template <typename T>
 std::enable_if_t<arrow::is_string_like_type<T>::value, int>
@@ -37,4 +149,12 @@ TestIsStringLikeTypePatchedNeeded() {
 int
 main() {
   TestIsStringLikeTypePatchedNeeded();
+
+  TestNoCopy();
+
+  TestDerivedNoCopy();
+
+  TestMultipleParameters();
+
+  TestTupleContains();
 }


### PR DESCRIPTION
I added `CouldAccept` to support multiple arguments better and it works well enough on a few number of arguments assuming that most instantiations can be pruned.

I'm not super happy with how parameter types ("caller" types) are added to VisitArrow
https://github.com/KatanaGraph/katana/pull/536/files#diff-530f8996865d146ccf2fe0d9269f3e551b7cf2883fb01d75e50474a9011505d3R60 in this PR.

The current way doesn't handle cases where the caller may have a mix of downcasted and general types, e.g., `VisitArrow(visitor, arrow::Scalar, arrow::StringScalar)`. I'm thinking of reworking VisitArrow to call some function on each one of its arguments to allow callers to customize the casting rules on input. This should also remove the need for all these decays everywhere as this is normalize the caller types as well.

Note the previous implementation required homogeneous parameter types, which seems like an odd restriction once we support multiple parameters. 

Anyway, the state is good enough to get some feedback and I'm open to thoughts on how to improve the interface since I have been mucking around with VisitArrow anyway.

```
    libsupport: Simplify VisitArrow

    Switch to simplified VisitArrow implementation, which supports template
    instantiation pruning, ensures no intermediate or shared_ptr copying and
    reduces the number of template variables (for improved readability).

    Performance results below. The current implementation is now called
    Visit. See previous commit for performance of previous implementation.

      spork$ external/katana/libsupport/test/arrow-bench  --benchmark_filter=/1048576
      2021-09-10T01:14:23-07:00
      Running external/katana/libsupport/test/arrow-bench
      Run on (12 X 4500 MHz CPU s)
      CPU Caches:
        L1 Data 32 KiB (x6)
        L1 Instruction 32 KiB (x6)
        L2 Unified 256 KiB (x6)
        L3 Unified 12288 KiB (x1)
      Load Average: 0.27, 0.56, 1.00
      ***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
      -----------------------------------------------------------------------------------
      Benchmark                         Time             CPU   Iterations UserCounters...
      -----------------------------------------------------------------------------------
      InlineSwitch/1048576        4621561 ns      4621457 ns          156 items_per_second=226.893M/s
      Visit/1048576              13067725 ns     13067640 ns           53 items_per_second=80.2422M/s
      DynamicCast/1048576       301830300 ns    301824285 ns            2 items_per_second=3.47413M/s
      SwitchCast/1048576         11785539 ns     11785325 ns           64 items_per_second=88.973M/s
      SwitchCastResult/1048576   11102731 ns     11102656 ns           63 items_per_second=94.4437M/s
```

```
    libsupport: Add VisitArrow benchmark

    In preparation of refactoring katana::VisitArrow, benchmark various
    alternative implementation strategies.

    The variants compared are:

    - Visit is the current implementation
    - InlineSwitch is a hand-optimized version, a performance ceiling.
    - DynamicCast, SwitchCast, SwitchCastResult are possible implementation
      strategies
    - Dispatch is the proposed alternative to Visit

    Below are the performance results.

      spork$ external/katana/libsupport/test/arrow-bench  --benchmark_filter=/1048576
      2021-09-10T01:22:47-07:00
      Running external/katana/libsupport/test/arrow-bench
      Run on (12 X 4500 MHz CPU s)
      CPU Caches:
        L1 Data 32 KiB (x6)
        L1 Instruction 32 KiB (x6)
        L2 Unified 256 KiB (x6)
        L3 Unified 12288 KiB (x1)
      Load Average: 3.41, 1.50, 1.12
      ***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
      -----------------------------------------------------------------------------------
      Benchmark                         Time             CPU   Iterations UserCounters...
      -----------------------------------------------------------------------------------
      InlineSwitch/1048576        4315897 ns      4315869 ns          163 items_per_second=242.958M/s
      Visit/1048576              14571726 ns     14571503 ns           48 items_per_second=71.9607M/s
      DynamicCast/1048576       290699798 ns    290694342 ns            2 items_per_second=3.60714M/s
      SwitchCast/1048576         10870668 ns     10870484 ns           64 items_per_second=96.4608M/s
      SwitchCastResult/1048576   10878910 ns     10878452 ns           65 items_per_second=96.3902M/s
      Dispatch/1048576           11092319 ns     11092303 ns           63 items_per_second=94.5319M/s

    After some investigation, the main reason for the difference between
    Visit and the other switch-based implementations (include Dispatch) is
    due to excessive copying of std::shared_ptr<arrow::DataType> in
    Type(const arrow::Scalar&). Once this is fixed, all variants have
    roughly the same throughput.

    The Dispatch implementation is still an improvement over Visit in terms
    of readability and maintainability and it supports multi-arguments
    better due to its support for pruning instantiations.

```
