### PR TITLE
Type cleanup

### DIFF
--- a/libgalois/include/katana/PropertyGraphRetractor.h
+++ b/libgalois/include/katana/PropertyGraphRetractor.h
@@ -69,10 +69,18 @@ public:
     return pg_->rdg_.edge_properties();
   }
 
+  /// Return true if type information has been loaded separate from properties.
+  /// Return false otherwise.
+  bool NeedsEntityTypeIDInference() {
+    return pg_->rdg_.IsEntityTypeIDsOutsideProperties();
+  }
+
+  /// This is exposed because type id mappings change sometimes.
   void ReplaceNodeTypeManager(EntityTypeManager&& manager) {
     pg_->node_entity_type_manager_ = std::move(manager);
   }
 
+  /// This is exposed because type id mappings change sometimes.
   void ReplaceEdgeTypeManager(EntityTypeManager&& manager) {
     pg_->edge_entity_type_manager_ = std::move(manager);
   }

--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -88,7 +88,7 @@ public:
             std::move(atomic_entity_type_id_to_entity_type_ids)) {}
 
   /// This function can be used to convert "old style" graphs (storage format 1,
-  /// where types are represented by bool or uint8 properties) and "new style"
+  /// where types are represented by uint8 properties) and "new style"
   /// graphs (version > 2, where types are represented in our native type
   /// represenation). This function is serial but it likely iterates over
   /// O(nodes) and O(edges) vectors, so it is very slow. It should only be used
@@ -137,12 +137,6 @@ public:
     // assign the type ID for each row
     for (int64_t row = 0; row < num_rows; ++row) {
       TypeProperties::FieldEntity field_indices;
-      for (auto& bool_property : type_properties.bool_properties) {
-        if (bool_property.array->IsValid(row) &&
-            bool_property.array->Value(row)) {
-          field_indices.emplace_back(bool_property.field_index);
-        }
-      }
       for (auto& uint8_property : type_properties.uint8_properties) {
         if (uint8_property.array->IsValid(row) &&
             uint8_property.array->Value(row)) {
@@ -406,7 +400,6 @@ private:
 
   // Used by AssignEntityTypeIDsFromProperties()
   struct TypeProperties {
-    std::vector<PropertyColumn<arrow::BooleanArray>> bool_properties;
     std::vector<PropertyColumn<arrow::UInt8Array>> uint8_properties;
     using FieldEntity = std::vector<int>;
     std::map<FieldEntity, katana::EntityTypeID> type_field_indices_to_id;


### PR DESCRIPTION
Unfortunately, `PropertyGraph` just doesn't have enough context to perform all of its own loading logic. So this PR adds some functionality to `PropertyGraphRetractor` to help out the classes that help load `PropertyGraph`s. It propagates information about whether or not types need to be inferred from properties and it exposes direct access to the underlying type id arrays because the pointer is ugly and this isn't going away any time soon.

This PR also changes the logic for inferring types to only treat `uint8` properties as types (and not `boolean` types). The boolean types are not widely used and they pose a problem because Cypher allows boolean properties but we are treating every boolean property as a type.