### PR TITLE
Set CI to run on release branches and on release tagged commits.

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -3,7 +3,8 @@ name: C/C++ CI
 on:
   push:
     branches:
-    - master
+      - 'master'
+      - 'release/*'
   pull_request:
 
 # Cancel any previous runs with the same key.

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,7 +3,10 @@ name: Python CI
 on:
   push:
     branches:
-    - master
+      - 'master'
+      - 'release/*'
+    tags:
+      - 'v*'
   pull_request:
 
 # Cancel any previous runs with the same key.
@@ -42,8 +45,9 @@ jobs:
   do_python_test:
     needs:
       - do_python
+    # Don't run this in tag CI runs. It's useless since it doesn't produce meaningful artifacts.
     if: |
-      github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' && !startsWith(github.ref, "refs/tags/") ||
       (
         !contains(github.event.pull_request.body, '[no test]') &&
         !contains(github.event.pull_request.body, '[no Python test]')
@@ -131,7 +135,6 @@ jobs:
       run: |
         . .github/workflows/activate_miniconda.sh
         REPO_ROOT="$(cd "$(dirname scripts/conda_build.sh)/.."; pwd)"
-        set -euo pipefail
         export KATANA_VERSION=$("$REPO_ROOT"/scripts/version show --pep440)
         echo $KATANA_VERSION
         cd metagraph-plugin/conda_recipe
@@ -181,7 +184,10 @@ jobs:
         run: python3 test/install_conda_packages_test.py pkgs ${{matrix.image}}
 
   upload_conda_packages:
-    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'KatanaGraph/katana' }}
+    if: |
+      (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/v')
+        || startsWith(github.ref, 'refs/tags/v'))
+      && github.event_name == 'push' && github.repository == 'KatanaGraph/katana'
     environment: AnacondaUpload
     needs: test_conda_package_install
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -47,7 +47,7 @@ jobs:
       - do_python
     # Don't run this in tag CI runs. It's useless since it doesn't produce meaningful artifacts.
     if: |
-      github.event_name != 'pull_request' && !startsWith(github.ref, "refs/tags/") ||
+      github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/') ||
       (
         !contains(github.event.pull_request.body, '[no test]') &&
         !contains(github.event.pull_request.body, '[no Python test]')

--- a/scripts/katana_version/version.py
+++ b/scripts/katana_version/version.py
@@ -121,6 +121,13 @@ def get_version(
                 ke_commit, config.enterprise, pretend_clean=pretend_clean, exclude_dirty=(SUBMODULE_PATH,), abbrev=6,
             )
 
+    if len(explicit_version.release) != 3:
+        raise ValueError(
+            f"Versions must have 3 main components (x.y.z). The version specified {explicit_version} "
+            f"(in a git tag, version.txt, or environment variable) has {len(explicit_version.release)} "
+            f"main components."
+        )
+
     computed_version = katana_version(
         *explicit_version.release,
         k_count,


### PR DESCRIPTION
I'm going to test this on my own fork. I'll link results in a comment. Obviously normal CI runs are pretty meaningless for testing this kind of thing.