### PR TITLE
Fixup: invert behavior of PropertyGraph::NeedsInference()

### DIFF
--- a/libgalois/include/katana/PropertyGraphRetractor.h
+++ b/libgalois/include/katana/PropertyGraphRetractor.h
@@ -69,10 +69,10 @@ public:
     return pg_->rdg_.edge_properties();
   }
 
-  /// Return true if type information has been loaded separate from properties.
-  /// Return false otherwise.
+  /// Return false if type information has been loaded separate from properties.
+  /// Return true otherwise.
   bool NeedsEntityTypeIDInference() {
-    return pg_->rdg_.IsEntityTypeIDsOutsideProperties();
+    return !pg_->rdg_.IsEntityTypeIDsOutsideProperties();
   }
 
   /// This is exposed because type id mappings change sometimes.


### PR DESCRIPTION
PropertyGraph::NeedsTypeInference() passes through the logic of
RDG::IsEntityTypeIDsOutsideProperties(), but the name suggests that it
will return the inverse value of what the RDG function returns. Invert
the logic and keep the name.