### PR TITLE
tsuba: RDGPartHeader fix partition file regex

### DIFF
--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -74,7 +74,7 @@ namespace tsuba {
 
 // Regex for partition files
 const std::regex kPartitionFile(
-    "part_(?:(vers[0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_(?:(node[0-9]*))$");
+    "part_vers(?:([0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_node(?:([0-9]*))$");
 const int kPartitionMatchHostIndex = 3;
 
 katana::Result<RDGPartHeader>

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -74,7 +74,7 @@ namespace tsuba {
 
 // Regex for partition files
 const std::regex kPartitionFile(
-    "part_vers(?:([0-9A-Za-z_]+))_(?:(rdg[0-9A-Za-z-]*))_node(?:([0-9]*))$");
+    "part_vers([0-9]+)_(rdg[0-9A-Za-z-]*)_node([0-9]+)$");
 const int kPartitionMatchHostIndex = 3;
 
 katana::Result<RDGPartHeader>

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -220,6 +220,7 @@ tsuba::CreateSrcDestFromViewsForCopy(
     auto rdg_manifest_res =
         tsuba::RDGManifest::Make(uri, rdg_view.view_type, version);
     if (!rdg_manifest_res) {
+      KATANA_LOG_WARN("not a valid manifest file, uri: {}", uri.string());
       continue;
     }
 
@@ -246,12 +247,11 @@ tsuba::CreateSrcDestFromViewsForCopy(
                 src_file_uri.BaseName()));
         auto dst_dir_uri = KATANA_CHECKED(katana::Uri::Make(dst_dir));
         dst_file_uri = tsuba::RDGManifest::PartitionFileName(
-            rdg_manifest.view_type(), dst_dir_uri, host_id, 1);
+            rdg_manifest.view_type(), dst_dir_uri, host_id, 1 /* version */);
       } else {
         auto dst_file_path = katana::Uri::JoinPath(dst_dir, fname);
         dst_file_uri = KATANA_CHECKED(katana::Uri::Make(dst_file_path));
       }
-
       src_dst_files.push_back(std::make_pair(src_file_uri, dst_file_uri));
     }
 


### PR DESCRIPTION
This PR intends to fix a bug found with the deployment. There was an issue where every partition file was being copied over with the same node id. This was because there was an issue with the regex parsing which caused every partition file to be copied over with the same node id of 0, hence the copies were getting butchered. I also wrote a test to catch this edge case.

Linked PR: https://github.com/KatanaGraph/katana-enterprise/pull/1980