### PR TITLE
Apply dynamic_cast consistently

### DIFF
--- a/libsupport/include/katana/ArrowVisitor.h
+++ b/libsupport/include/katana/ArrowVisitor.h
@@ -299,9 +299,8 @@ public:
     if (!scalar.is_valid) {
       return AppendNull();
     }
-    auto builder = dynamic_cast<BuilderType*>(builder_);
-    KATANA_LOG_DEBUG_ASSERT(builder);
-    if (auto st = builder->Append(scalar.value); !st.ok()) {
+    auto& builder = dynamic_cast<BuilderType&>(*builder_);
+    if (auto st = builder.Append(scalar.value); !st.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to allocate table: {}", st);
     }
@@ -315,9 +314,8 @@ public:
     if (!scalar.is_valid) {
       return AppendNull();
     }
-    auto builder = dynamic_cast<BuilderType*>(builder_);
-    KATANA_LOG_DEBUG_ASSERT(builder);
-    if (auto st = builder->Append(scalar.value->ToString()); !st.ok()) {
+    auto& builder = dynamic_cast<BuilderType&>(*builder_);
+    if (auto st = builder.Append(scalar.value->ToString()); !st.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to allocate table: {}", st);
     }
@@ -332,13 +330,12 @@ public:
     }
 
     using BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
-    auto builder = dynamic_cast<BuilderType*>(builder_);
-    KATANA_LOG_DEBUG_ASSERT(builder);
-    if (auto st = builder->Append(); !st.ok()) {
+    auto& builder = dynamic_cast<BuilderType&>(*builder_);
+    if (auto st = builder.Append(); !st.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to allocate table: {}", st);
     }
-    AppendScalarToBuilder visitor(builder->value_builder());
+    AppendScalarToBuilder visitor(builder.value_builder());
     for (int64_t i = 0, n = scalar.value->length(); i < n; ++i) {
       auto scalar_res = scalar.value->GetScalar(i);
       if (!scalar_res.ok()) {
@@ -360,14 +357,13 @@ public:
       return AppendNull();
     }
 
-    auto* builder = dynamic_cast<arrow::StructBuilder*>(builder_);
-    KATANA_LOG_DEBUG_ASSERT(builder);
-    if (auto st = builder->Append(); !st.ok()) {
+    auto& builder = dynamic_cast<arrow::StructBuilder&>(*builder_);
+    if (auto st = builder.Append(); !st.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to allocate table: {}", st);
     }
     for (int f = 0, n = scalar.value.size(); f < n; ++f) {
-      AppendScalarToBuilder visitor(builder->field_builder(f));
+      AppendScalarToBuilder visitor(builder.field_builder(f));
       if (auto res = VisitArrow(scalar.value.at(f), visitor); !res) {
         return res.error();
       }

--- a/tools/graph-convert/TimeParser.h
+++ b/tools/graph-convert/TimeParser.h
@@ -117,18 +117,17 @@ template <class ArrowDateTimeType, typename Duration>
 void
 katana::TimeParser<ArrowDateTimeType, Duration>::ParseInto(
     const arrow::StringArray& strings, arrow::ArrayBuilder* untyped_builder) {
-  BuilderType* builder = dynamic_cast<BuilderType*>(untyped_builder);
-  KATANA_LOG_DEBUG_ASSERT(builder);
-  if (auto st = builder->Reserve(strings.length()); !st.ok()) {
+  BuilderType& builder = dynamic_cast<BuilderType&>(*untyped_builder);
+  if (auto st = builder.Reserve(strings.length()); !st.ok()) {
     KATANA_LOG_FATAL("builder failed to reserve space");
   }
   for (size_t i = 0, n = strings.length(); i < n; ++i) {
     std::string str = strings.GetString(i);
     auto r = Parse(str);
     if (r) {
-      builder->UnsafeAppend(*r);
+      builder.UnsafeAppend(*r);
     } else {
-      builder->UnsafeAppendNull();
+      builder.UnsafeAppendNull();
     }
   }
 }


### PR DESCRIPTION
```
Break the use of dynamic_cast into cases and apply them consistently.

If the cast is assumed to succeed, use either

  auto& ret = dynamic_cast<T&>(item)

or

  auto* ret = dynamic_cast<T*>(item); KATANA_LOG_ASSERT(ret)

In both cases, the program will crash if the assumption does not hold.
This is preferable to memory corruption.

If the cast could fail, use

  auto* ret = dynamic_cast<T*>(item)

And if the cast involves a shared_ptr, use

  auto ret = std::dynamic_pointer_cast<T>(item)

unless the lifetime of item can be guaranteed and the situation requires
extreme performance tuning. dynamic_pointer_cast makes sure that the
lifetime of item and ret are linked and avoids dangling pointers. This
is preferable to memory corruption or a slight performance penalty.
```