### PR TITLE
Printing and testing for EntityTypeManager

### DIFF
--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -5,7 +5,6 @@
 #include <set>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 #include <arrow/array/array_primitive.h>
@@ -388,6 +387,9 @@ public:
   /// std::string ReportDiff() IS A TESTING ONLY FUNCTION, DO NOT EXPOSE THIS TO THE USER
   std::string ReportDiff(const EntityTypeManager& other) const;
 
+  /// std::string PrintTypes() IS A TESTING ONLY FUNCTION, DO NOT EXPOSE THIS TO THE USER
+  std::string PrintEntityTypes() const;
+
 private:
   // Used by AssignEntityTypeIDsFromProperties()
   template <typename ArrowType>
@@ -444,3 +446,13 @@ private:
 };
 
 }  // namespace katana
+
+// Allow TypeNameSet foo; fmt::print("{}\n", foo);
+template <>
+struct KATANA_EXPORT fmt::formatter<katana::TypeNameSet>
+    : formatter<std::string> {
+  template <typename FormatContext>
+  auto format(const katana::TypeNameSet& tns, FormatContext& ctx) {
+    return format_to(ctx.out(), "{}", fmt::join(tns, ", "));
+  }
+};

--- a/libsupport/src/EntityTypeManager.cpp
+++ b/libsupport/src/EntityTypeManager.cpp
@@ -261,6 +261,22 @@ katana::EntityTypeManager::ReportDiff(
   return std::string(buf.begin(), buf.end());
 }
 
+std::string
+katana::EntityTypeManager::PrintEntityTypes() const {
+  fmt::memory_buffer buf;
+  auto end = GetNumEntityTypes();
+  for (size_t i = 0; i < end; ++i) {
+    auto res = EntityTypeToTypeNameSet(i);
+    if (res) {
+      fmt::format_to(std::back_inserter(buf), "{:2} {}\n", i, res.value());
+    } else {
+      fmt::format_to(
+          std::back_inserter(buf), "{:2} **error**: {}\n", i, res.error());
+    }
+  }
+  return std::string(buf.begin(), buf.end());
+}
+
 bool
 katana::EntityTypeManager::Equals(
     const katana::EntityTypeManager& other) const {

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_unit_test(result)
 add_unit_test(signals)
 add_unit_test(strings)
 add_unit_test(tracing)
+add_unit_test(type-manager)
 add_unit_test(uri)
 add_unit_test(zip_iterator)
 

--- a/libsupport/test/type-manager.cpp
+++ b/libsupport/test/type-manager.cpp
@@ -1,0 +1,35 @@
+#include "katana/EntityTypeManager.h"
+#include "katana/Logging.h"
+
+int
+main() {
+  std::vector<katana::TypeNameSet> tnss = {
+      {"alice"},
+      {"baker"},
+      {"alice", "baker"},
+      {"charlie"},
+      {"david", "eleanor"}};
+  std::vector<katana::TypeNameSet> check = {
+      {},          {"alice"}, {"baker"},   {"alice", "baker"},
+      {"charlie"}, {"david"}, {"eleanor"}, {"david", "eleanor"}};
+  katana::EntityTypeManager mgr;
+  for (const auto& tns : tnss) {
+    auto res = mgr.GetOrAddNonAtomicEntityTypeFromStrings(tns);
+    KATANA_LOG_ASSERT(res);
+  }
+  auto num_entities = mgr.GetNumEntityTypes();
+  for (size_t i = 0; i < mgr.GetNumEntityTypes(); ++i) {
+    auto res = mgr.EntityTypeToTypeNameSet(i);
+    KATANA_LOG_ASSERT(res);
+    auto tns = res.value();
+    std::string empty = "**empty**";
+    KATANA_LOG_VASSERT(
+        tns == check[i], "i={} tns[i] ({}) check[i] ({})", i, tns, check[i]);
+  }
+  katana::TypeNameSet new_tns({"new", "one"});
+  auto res = mgr.GetOrAddNonAtomicEntityTypeFromStrings(new_tns);
+  KATANA_LOG_ASSERT(res);
+  KATANA_LOG_ASSERT(res.value() >= num_entities);
+
+  fmt::print("{}", mgr.PrintEntityTypes());
+}


### PR DESCRIPTION
This PR is mostly in support of having graph update use the EntityTypeManager (enterprise PR #2049).  It does the following.

- Adds debugging routine to print the types within a manager.
- Adds a rudimentary test that also acts as documentation for how the type manager works.