### PR TITLE
Add (abstract) methods for global degrees to Python Graph

### DIFF
--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -23,6 +23,8 @@ from libcpp.vector cimport vector
 from ..native_interfacing.buffer_access cimport to_pyarrow
 from .entity_type cimport EntityType
 
+from abc import abstractmethod
+
 __all__ = ["GraphBase", "Graph"]
 
 
@@ -301,6 +303,14 @@ cdef class GraphBase:
         types = manager.GetAtomicEntityTypeIDs()
         return [EntityType.make(manager, typeid) for typeid in types]
 
+    @abstractmethod
+    def global_out_degree(self, uint64_t node):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def global_in_degree(self, uint64_t node):
+        raise NotImplementedError()
+
 cdef class Graph(GraphBase):
     """
     A property graph loaded into memory.
@@ -355,3 +365,10 @@ cdef class Graph(GraphBase):
         Internal.
         """
         return <uint64_t>self.underlying_property_graph()
+
+    def global_out_degree(self, uint64_t node):
+        return len(self.edges(node))
+
+    def global_in_degree(self, uint64_t node):
+        # TODO(loc) needs shared-memory bi-directional view
+        raise NotImplementedError()


### PR DESCRIPTION
This commit adds global degree methods to the Python graph object. For a
single host, global degree is equivalent to normal degree, but for
distributed execution, global degree allows a user to get the degree of
a node even if the host does not own all of the edges.

The overarching design goal behind this commit is that views that add on
to the base graph (like a bidirectional view) will be generated on
demand whenever a function is called (like global degree) which requires
a view to be built.