### PR TITLE
tsuba: RDG manifest file names need to include full view

### DIFF
--- a/libtsuba/src/RDGManifest.h
+++ b/libtsuba/src/RDGManifest.h
@@ -62,12 +62,6 @@ class KATANA_EXPORT RDGManifest {
   static std::string PartitionFileName(
       const std::string& view_type, uint32_t node_id, uint64_t version);
 
-  std::string view_specifier() const {
-    if (view_args_.size())
-      return fmt::format("{}-{}", view_type_, fmt::join(view_args_, "-"));
-    return view_type_;
-  }
-
 public:
   RDGManifest() = default;
 
@@ -121,9 +115,15 @@ public:
     previous_version_ = prev_version;
   }
 
+  std::string view_specifier() const {
+    if (view_args_.size())
+      return fmt::format("{}-{}", view_type_, fmt::join(view_args_, "-"));
+    return view_type_;
+  }
+
   katana::Uri PartitionFileName(uint32_t host_id) const;
 
-  katana::Uri FileName() { return FileName(dir_, view_type_, version_); }
+  katana::Uri FileName() { return FileName(dir_, view_specifier(), version_); }
 
   // Canonical naming
   static katana::Uri FileName(

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -247,7 +247,8 @@ tsuba::CreateSrcDestFromViewsForCopy(
                 src_file_uri.BaseName()));
         auto dst_dir_uri = KATANA_CHECKED(katana::Uri::Make(dst_dir));
         dst_file_uri = tsuba::RDGManifest::PartitionFileName(
-            rdg_manifest.view_type(), dst_dir_uri, host_id, 1 /* version */);
+            rdg_manifest.view_specifier(), dst_dir_uri, host_id,
+            1 /* version */);
       } else {
         auto dst_file_path = katana::Uri::JoinPath(dst_dir, fname);
         dst_file_uri = KATANA_CHECKED(katana::Uri::Make(dst_file_path));

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -215,12 +215,12 @@ tsuba::CreateSrcDestFromViewsForCopy(
   // List out all the files in a given view
   auto rdg_views = KATANA_CHECKED(tsuba::ListAvailableViews(src_dir, version));
   for (const auto& rdg_view : rdg_views.second) {
-    auto uri = KATANA_CHECKED(katana::Uri::Make(src_dir));
-
-    auto rdg_manifest_res =
-        tsuba::RDGManifest::Make(uri, rdg_view.view_type, version);
+    auto rdg_view_uri = KATANA_CHECKED(katana::Uri::Make(rdg_view.view_path));
+    auto rdg_manifest_res = tsuba::RDGManifest::Make(rdg_view_uri);
     if (!rdg_manifest_res) {
-      KATANA_LOG_WARN("not a valid manifest file, uri: {}", uri.string());
+      KATANA_LOG_WARN(
+          "not a valid manifest file: {}, {}", rdg_view_uri.string(),
+          rdg_manifest_res.error());
       continue;
     }
 


### PR DESCRIPTION
This PR fixes an edge case when the latest RDG manifest view has view_args in its file name. For example instead of just `katana_vers00000000000000000002_rdg`, we can also have `katana_vers00000000000000000002_rdg-retained-oec-part2`. CopyRDG executed a code path that did not create the filename appropriately, so files were not being copied over in certain scenarios. 

This PR fixes that issue and also makes `view_specifier()` public since it may be needed in certain situations. While this is not in the scope of the PR, it's becoming clearer that certain functions in RDGManifest are slightly misleading since a few of them depend purely on `view_type`. 