### PR TITLE
[KAT-1848] logging: add no-op tracer for benchmarking and use 64bit integers for…

### DIFF
--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -23,6 +23,7 @@ set(sources
         src/JSON.cpp
         src/JSONTracer.cpp
         src/Logging.cpp
+        src/NoopTracer.cpp
         src/Random.cpp
         src/Result.cpp
         src/Plugin.cpp

--- a/libsupport/include/katana/NoopTracer.h
+++ b/libsupport/include/katana/NoopTracer.h
@@ -1,0 +1,78 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_NOOPTRACER_H_
+#define KATANA_LIBSUPPORT_KATANA_NOOPTRACER_H_
+
+#include "katana/ProgressTracer.h"
+
+namespace katana {
+
+class KATANA_EXPORT NoopTracer : public ProgressTracer {
+public:
+  static std::unique_ptr<NoopTracer> Make(
+      uint32_t host_id = 0, uint32_t num_hosts = 1);
+
+  std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name, const ProgressContext& child_of) override;
+
+  std::string Inject([[maybe_unused]] const ProgressContext& ctx) override {
+    return "";
+  }
+  std::unique_ptr<ProgressContext> Extract(const std::string& carrier) override;
+
+private:
+  NoopTracer(uint32_t host_id, uint32_t num_hosts)
+      : ProgressTracer(host_id, num_hosts) {}
+
+  std::shared_ptr<ProgressSpan> StartSpan(
+      const std::string& span_name,
+      std::shared_ptr<ProgressSpan> child_of) override;
+
+  void Close() override {}
+};
+
+class KATANA_EXPORT NoopContext : public ProgressContext {
+public:
+  std::unique_ptr<ProgressContext> Clone() const noexcept override;
+  std::string GetTraceID() const noexcept override { return ""; }
+  std::string GetSpanID() const noexcept override { return ""; }
+
+private:
+  friend class NoopTracer;
+  friend class NoopSpan;
+
+  NoopContext() {}
+};
+
+class KATANA_EXPORT NoopSpan : public ProgressSpan {
+public:
+  ~NoopSpan() override { Finish(); }
+
+  void SetTags([[maybe_unused]] const Tags& tags) override {}
+
+  void Log(
+      [[maybe_unused]] const std::string& message,
+      [[maybe_unused]] const Tags& tags) override {}
+
+  const ProgressContext& GetContext() const noexcept override;
+
+private:
+  friend NoopTracer;
+
+  NoopSpan() : ProgressSpan(nullptr), context_(NoopContext{}) {}
+  NoopSpan(std::shared_ptr<ProgressSpan> parent)
+      : ProgressSpan(std::move(parent)), context_(NoopContext{}) {}
+  static std::shared_ptr<ProgressSpan> Make(
+      std::shared_ptr<ProgressSpan> parent) {
+    return std::shared_ptr<NoopSpan>(new NoopSpan(std::move(parent)));
+  }
+  static std::shared_ptr<ProgressSpan> Make() {
+    return std::shared_ptr<NoopSpan>(new NoopSpan());
+  }
+
+  void Close() override{};
+
+  NoopContext context_;
+};
+
+}  // namespace katana
+
+#endif

--- a/libsupport/src/JSONTracer.cpp
+++ b/libsupport/src/JSONTracer.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <mutex>
 
 #include <arrow/memory_pool.h>
@@ -13,13 +14,13 @@
 
 namespace {
 
-constexpr int kRandomIDLength = 15;
-
 std::mutex output_mutex;
 
 std::string
 GenerateID() {
-  return katana::RandomAlphanumericString(kRandomIDLength);
+  std::uniform_int_distribution<uint64_t> dist(
+      0, std::numeric_limits<uint64_t>::max());
+  return fmt::format("0x{:x}", dist(katana::GetGenerator()));
 }
 
 std::string

--- a/libsupport/src/NoopTracer.cpp
+++ b/libsupport/src/NoopTracer.cpp
@@ -1,0 +1,35 @@
+#include "katana/NoopTracer.h"
+
+std::unique_ptr<katana::NoopTracer>
+katana::NoopTracer::Make(uint32_t host_id, uint32_t num_hosts) {
+  return std::unique_ptr<NoopTracer>(new NoopTracer(host_id, num_hosts));
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::NoopTracer::StartSpan(
+    [[maybe_unused]] const std::string& span_name,
+    [[maybe_unused]] const ProgressContext& child_of) {
+  return NoopSpan::Make();
+}
+
+std::unique_ptr<katana::ProgressContext>
+katana::NoopTracer::Extract([[maybe_unused]] const std::string& carrier) {
+  return std::unique_ptr<NoopContext>(new NoopContext());
+}
+
+std::shared_ptr<katana::ProgressSpan>
+katana::NoopTracer::StartSpan(
+    [[maybe_unused]] const std::string& span_name,
+    std::shared_ptr<ProgressSpan> child_of) {
+  return NoopSpan::Make(std::move(child_of));
+}
+
+std::unique_ptr<katana::ProgressContext>
+katana::NoopContext::Clone() const noexcept {
+  return std::unique_ptr<NoopContext>(new NoopContext());
+}
+
+const katana::ProgressContext&
+katana::NoopSpan::GetContext() const noexcept {
+  return context_;
+}


### PR DESCRIPTION
… ids in json tracer

Add a no-op tracer for benchmarking
Use 64-bit integers for ids for better Jaeger integration and faster generation