### PR TITLE
[KAT-1849] logging: add a method for suppressing logging from unnecessary spans …

### DIFF
--- a/libsupport/include/katana/JSONTracer.h
+++ b/libsupport/include/katana/JSONTracer.h
@@ -31,8 +31,8 @@ private:
       : ProgressTracer(host_id, num_hosts), out_callback_(out_callback) {}
 
   std::shared_ptr<ProgressSpan> StartSpan(
-      const std::string& span_name,
-      std::shared_ptr<ProgressSpan> child_of) override;
+      const std::string& span_name, std::shared_ptr<ProgressSpan> child_of,
+      bool is_suppressed) override;
 
   void Close() override {}
 
@@ -73,16 +73,16 @@ private:
 
   JSONSpan(
       const std::string& span_name, std::shared_ptr<ProgressSpan> parent,
-      OutputCB out_callback);
+      bool is_suppressed, OutputCB out_callback);
   JSONSpan(
       const std::string& span_name, const ProgressContext& parent,
-      OutputCB out_callback);
+      bool is_suppressed, OutputCB out_callback);
   static std::shared_ptr<ProgressSpan> Make(
       const std::string& span_name, std::shared_ptr<ProgressSpan> parent,
-      OutputCB out_callback);
+      bool is_suppressed, OutputCB out_callback);
   static std::shared_ptr<ProgressSpan> Make(
       const std::string& span_name, const ProgressContext& parent,
-      OutputCB out_callback);
+      bool is_suppressed, OutputCB out_callback);
 
   void Close() override;
 

--- a/libsupport/include/katana/TextTracer.h
+++ b/libsupport/include/katana/TextTracer.h
@@ -26,8 +26,8 @@ private:
       : ProgressTracer(host_id, num_hosts) {}
 
   std::shared_ptr<ProgressSpan> StartSpan(
-      const std::string& span_name,
-      std::shared_ptr<ProgressSpan> child_of) override;
+      const std::string& span_name, std::shared_ptr<ProgressSpan> child_of,
+      bool is_suppressed) override;
 
   void Close() override {}
 };
@@ -64,12 +64,18 @@ public:
 private:
   friend TextTracer;
 
-  TextSpan(const std::string& span_name, std::shared_ptr<ProgressSpan> parent);
-  TextSpan(const std::string& span_name, const ProgressContext& parent);
+  TextSpan(
+      const std::string& span_name, std::shared_ptr<ProgressSpan> parent,
+      bool is_suppressed);
+  TextSpan(
+      const std::string& span_name, const ProgressContext& parent,
+      bool is_suppressed);
   static std::shared_ptr<ProgressSpan> Make(
-      const std::string& span_name, std::shared_ptr<ProgressSpan> parent);
+      const std::string& span_name, std::shared_ptr<ProgressSpan> parent,
+      bool is_suppressed);
   static std::shared_ptr<ProgressSpan> Make(
-      const std::string& span_name, const ProgressContext& parent);
+      const std::string& span_name, const ProgressContext& parent,
+      bool is_suppressed);
 
   void Close() override;
 

--- a/libsupport/test/tracing.cpp
+++ b/libsupport/test/tracing.cpp
@@ -9,6 +9,7 @@ CreateError() {
 
 katana::Result<void>
 GetError() {
+  auto suppressor = katana::GetTracer().SuppressTracer();
   auto scope = katana::GetTracer().StartActiveSpan("passing error");
   return CreateError().error().WithContext("passed along by GetError");
 }


### PR DESCRIPTION
…to tracers

This is useful for example in subgraph sampling when this function calls the query engine (which generates a lot of output that is not very important to subgraph sampling) and this becomes an issue if someone wants to call subgraph sampling thousands of times