### PR TITLE
Do not treat kUnknownEntityType as an atomic type

### DIFF
--- a/libgalois/test/property-file-graph.cpp
+++ b/libgalois/test/property-file-graph.cpp
@@ -28,7 +28,7 @@ void
 TestTypesFromPropertiesCompareTypesFromStorage() {
   /*
   Scenario 1:
-  1. create a graph in memory with a couple of bool and uint8 properties
+  1. create a graph in memory with a couple of uint8 properties
   2. Construct types from properties
   3. Commit to storage
   4. Load the graph and compare the type info from step 2 above
@@ -83,9 +83,12 @@ TestTypesFromPropertiesCompareTypesFromStorage() {
       g->GetEdgeEntityTypeID("edge-name"));
 
   KATANA_LOG_VASSERT(
-      g->GetNumNodeEntityTypes() == 2, "found {} entity types.",
+      g->GetNumNodeEntityTypes() == 2, "found {} node entity types.",
       g->GetNumNodeEntityTypes());
-  KATANA_LOG_ASSERT(g->GetNumEdgeEntityTypes() == 2);
+
+  KATANA_LOG_VASSERT(
+      g->GetNumEdgeEntityTypes() == 2, "found {} edge entity types.",
+      g->GetNumEdgeEntityTypes());
 
   auto write_result = g->Write(rdg_dir, command_line);
 
@@ -122,7 +125,7 @@ void
 TestCompositeTypesFromPropertiesCompareCompositeTypesFromStorage() {
   /*
   Scenario 2:
-  1. create a graph in memory with a couple of bool and uint8 properties
+  1. create a graph in memory with a couple of uint8 properties
   2. Construct composite types from properties
   3. Commit to storage
   4. Load the graph and compare the type info from step 2 above

--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -22,7 +22,6 @@ namespace katana {
 /// EntityTypeID is represented using 8 bits
 using EntityTypeID = uint8_t;
 static constexpr EntityTypeID kUnknownEntityType = EntityTypeID{0};
-static constexpr std::string_view kUnknownEntityTypeName = "kUnknownName";
 static constexpr EntityTypeID kInvalidEntityType =
     std::numeric_limits<EntityTypeID>::max();
 /// A set of EntityTypeIDs
@@ -414,9 +413,9 @@ private:
   void Init() {
     // assume kUnknownEntityType is 0
     static_assert(kUnknownEntityType == 0);
-    static_assert(kUnknownEntityTypeName == std::string_view("kUnknownName"));
-    // add kUnknownEntityType
-    auto id = AddAtomicEntityType(std::string(kUnknownEntityTypeName));
+    // add kUnknownEntityType: do not treat it as an atomic type;
+    // treat it as an entity type that does not have any atomic subtypes
+    auto id = AddNonAtomicEntityType(SetOfEntityTypeIDs());
     KATANA_LOG_ASSERT(id.value() == kUnknownEntityType);
   }
 

--- a/libsupport/src/EntityTypeManager.cpp
+++ b/libsupport/src/EntityTypeManager.cpp
@@ -25,7 +25,6 @@ katana::EntityTypeManager::DoAssignEntityTypeIDsFromProperties(
     const std::shared_ptr<arrow::Field>& current_field = schema->field(i);
 
     // a uint8 property is (always) considered a type
-    // TODO(roshan) make this customizable by the user
     if (current_field->type()->Equals(arrow::uint8())) {
       type_field_indices.push_back(i);
       KATANA_LOG_DEBUG_ASSERT(properties->column(i)->num_chunks() == 1);

--- a/python/test/test_entity_type_manager.py
+++ b/python/test/test_entity_type_manager.py
@@ -4,7 +4,6 @@ import pytest
 def test_node_types(graph):
     types = graph.node_types
     assert {str(t) for t in types} == {
-        "kUnknownName",
         "Comment",
         "Tag",
         "City",


### PR DESCRIPTION
We should not return kUnknownEntityTypeName as an
atomic type name.

Do not treat kUnknownEntityType as an atomic type,
even internally within the class. Treat it as an entity type
that does not have any atomic subtypes.