### PR TITLE
support: add ability to create CopyableErrorInfo with a known message

### DIFF
--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -338,7 +338,8 @@ operator<<(std::ostream& out, const ErrorInfo& ei) {
 /// to store errors, e.g., collecting results across threads.
 class KATANA_EXPORT CopyableErrorInfo {
 public:
-  CopyableErrorInfo(const std::error_code& ec) : error_code_(ec) {}
+  CopyableErrorInfo(const std::error_code& ec, std::string message = "")
+      : error_code_(ec), message_(std::move(message)) {}
 
   CopyableErrorInfo() : CopyableErrorInfo(std::error_code()) {}
 


### PR DESCRIPTION
This was needed to support serializing these objects.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>