### PR TITLE
Enrich RDGSlice interface

### DIFF
--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -186,43 +186,37 @@ public:
   katana::Result<void> UnbindTopologyFileStorage();
 
   /// Inform this RDG that its topology is in storage at this location
-  /// without loading it into memory. \param new_top must exist and be in
-  /// the correct directory for this RDG
+  /// without loading it into memory.
+  /// \param new_top must exist and be in the correct directory for this RDG but
+  /// it need not be writable
   katana::Result<void> SetTopologyFile(const katana::Uri& new_top);
 
   katana::Result<void> UnbindNodeEntityTypeIDArrayFileStorage();
 
-  /// Inform this RDG that its Node Entity Type ID Array is in storage at this location
-  /// without loading it into memory. \param new_type_id_array must exist and be in
-  /// the correct directory for this RDG
+  /// Inform this RDG that its Node Entity Type ID Array is in storage at this
+  /// location without loading it into memory.
+  /// \param new_type_id_array must exist and be in the correct directory for
+  /// this RDG but it need not be writable
   katana::Result<void> SetNodeEntityTypeIDArrayFile(
       const katana::Uri& new_type_id_array);
 
   katana::Result<void> UnbindEdgeEntityTypeIDArrayFileStorage();
 
-  /// Inform this RDG that its Edge Entity Type ID Array is in storage at this location
-  /// without loading it into memory. \param new_type_id_array must exist and be in
-  /// the correct directory for this RDG
+  /// Inform this RDG that its Edge Entity Type ID Array is in storage at this
+  /// location without loading it into memory.
+  /// \param new_type_id_array must exist and be in the correct directory for
+  /// this RDG but it need not be writable
   katana::Result<void> SetEdgeEntityTypeIDArrayFile(
       const katana::Uri& new_type_id_array);
-
-  void AddMirrorNodes(std::shared_ptr<arrow::ChunkedArray>&& a) {
-    mirror_nodes_.emplace_back(std::move(a));
-  }
-
-  void AddMasterNodes(std::shared_ptr<arrow::ChunkedArray>&& a) {
-    master_nodes_.emplace_back(std::move(a));
-  }
 
   //
   // accessors and mutators
   //
 
-  const katana::Uri& rdg_dir() const { return rdg_dir_; }
-  void set_rdg_dir(const katana::Uri& rdg_dir) { rdg_dir_ = rdg_dir; }
+  const katana::Uri& rdg_dir() const;
+  void set_rdg_dir(const katana::Uri& rdg_dir);
 
-  uint32_t partition_id() const { return partition_id_; }
-  void set_partition_id(uint32_t partition_id) { partition_id_ = partition_id; }
+  uint32_t partition_id() const;
 
   /// The node properties
   const std::shared_ptr<arrow::Table>& node_properties() const;
@@ -243,53 +237,26 @@ public:
 
   std::shared_ptr<arrow::Schema> full_edge_schema() const;
 
-  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
-      const {
-    return master_nodes_;
-  }
-  void set_master_nodes(std::vector<std::shared_ptr<arrow::ChunkedArray>>&& a) {
-    master_nodes_ = std::move(a);
-  }
-
-  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes()
-      const {
-    return mirror_nodes_;
-  }
-  void set_mirror_nodes(std::vector<std::shared_ptr<arrow::ChunkedArray>>&& a) {
-    mirror_nodes_ = std::move(a);
-  }
-
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes() const;
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes() const;
   const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
-      const {
-    return host_to_owned_global_node_ids_;
-  }
-  void set_host_to_owned_global_node_ids(
-      std::shared_ptr<arrow::ChunkedArray>&& a) {
-    host_to_owned_global_node_ids_ = std::move(a);
-  }
-
+      const;
   const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
-      const {
-    return host_to_owned_global_edge_ids_;
-  }
+      const;
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const;
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const;
+  void set_master_nodes(
+      std::vector<std::shared_ptr<arrow::ChunkedArray>>&& master_nodes);
+  void set_mirror_nodes(
+      std::vector<std::shared_ptr<arrow::ChunkedArray>>&& mirror_nodes);
+  void set_host_to_owned_global_node_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& host_to_owned_global_node_ids);
   void set_host_to_owned_global_edge_ids(
-      std::shared_ptr<arrow::ChunkedArray>&& a) {
-    host_to_owned_global_edge_ids_ = std::move(a);
-  }
-
-  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
-    return local_to_user_id_;
-  }
-  void set_local_to_user_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
-    local_to_user_id_ = std::move(a);
-  }
-
-  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const {
-    return local_to_global_id_;
-  }
-  void set_local_to_global_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
-    local_to_global_id_ = std::move(a);
-  }
+      std::shared_ptr<arrow::ChunkedArray>&& host_to_owned_global_edge_ids);
+  void set_local_to_user_id(
+      std::shared_ptr<arrow::ChunkedArray>&& local_to_user_ids);
+  void set_local_to_global_id(
+      std::shared_ptr<arrow::ChunkedArray>&& local_to_global_id);
 
   const PartitionMetadata& part_metadata() const;
   void set_part_metadata(const PartitionMetadata& metadata);
@@ -320,9 +287,6 @@ private:
   static katana::Result<RDG> Make(
       const RDGManifest& manifest, const RDGLoadOptions& opts);
 
-  katana::Result<void> AddPartitionMetadataArray(
-      const std::shared_ptr<arrow::Table>& props);
-
   katana::Result<std::vector<tsuba::PropStorageInfo>> WritePartArrays(
       const katana::Uri& dir, tsuba::WriteGroup* desc);
 
@@ -350,22 +314,6 @@ private:
   std::unique_ptr<RDGCore> core_;
   // Optional property cache
   tsuba::PropertyCache* prop_cache_{nullptr};
-
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
-  // Called while constructing to put these arrays into a usable state for Distribution
-  void InitArrowVectors();
-  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
-  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_edge_ids_;
-  std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
-  std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;
-
-  /// name of the graph that was used to load this RDG
-  katana::Uri rdg_dir_;
-  /// which partition of the graph was loaded
-  uint32_t partition_id_{std::numeric_limits<uint32_t>::max()};
-  // How this graph was derived from the previous version
-  RDGLineage lineage_;
 };
 
 }  // namespace tsuba

--- a/libtsuba/include/tsuba/RDGManifest.h
+++ b/libtsuba/include/tsuba/RDGManifest.h
@@ -72,12 +72,12 @@ public:
         version_ + 1, version_, num_hosts, policy_id, transpose, dir_, lineage);
   }
 
-  // TODO(vkarthik): This should have previous_version_ for the second argument, no?
   RDGManifest SameVersion(
       uint32_t num_hosts, uint32_t policy_id, bool transpose,
       const RDGLineage& lineage) const {
     return RDGManifest(
-        version_, version_, num_hosts, policy_id, transpose, dir_, lineage);
+        version_, previous_version_, num_hosts, policy_id, transpose, dir_,
+        lineage);
   }
 
   bool IsEmptyRDG() const { return num_hosts() == 0; }

--- a/libtsuba/include/tsuba/RDGSlice.h
+++ b/libtsuba/include/tsuba/RDGSlice.h
@@ -10,6 +10,7 @@
 #include "katana/URI.h"
 #include "katana/config.h"
 #include "tsuba/FileView.h"
+#include "tsuba/RDGLineage.h"
 #include "tsuba/tsuba.h"
 
 namespace tsuba {
@@ -17,7 +18,15 @@ namespace tsuba {
 class RDGManifest;
 class RDGCore;
 
-/// A contiguous piece of an RDG
+/// A read-only contiguous piece of a partition.
+///
+/// This class owns a contiguous slice of nodes from the associated default CSR
+/// topology. It also owns the outgoing edges associated with those nodes.
+/// Because of the structure of CSR, those edges form a contiguous slice.
+/// As a result, it also owns a contiguous slice from each of
+/// the node and edge property arrays and the node and edge type id arrays.
+///
+/// A typical use would be loading an unpartitioned graph on multiple hosts.
 class KATANA_EXPORT RDGSlice {
 public:
   RDGSlice(const RDGSlice& no_copy) = delete;
@@ -44,9 +53,47 @@ public:
       const std::optional<std::vector<std::string>>& node_props = std::nullopt,
       const std::optional<std::vector<std::string>>& edge_props = std::nullopt);
 
+  // metadata sorts of things
+  const katana::Uri& rdg_dir() const;
+  uint32_t partition_id() const;
+
+  // properties and friends
+  std::shared_ptr<arrow::Schema> full_node_schema() const;
+  std::shared_ptr<arrow::Schema> full_edge_schema() const;
   const std::shared_ptr<arrow::Table>& node_properties() const;
   const std::shared_ptr<arrow::Table>& edge_properties() const;
+
+  // topology and friends
   const FileView& topology_file_storage() const;
+
+  // optional partition metadata
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
+      const {
+    return master_nodes_;
+  }
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes()
+      const {
+    return mirror_nodes_;
+  }
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
+      const {
+    return host_to_owned_global_node_ids_;
+  }
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
+      const {
+    return host_to_owned_global_edge_ids_;
+  }
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
+    return local_to_user_id_;
+  }
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const {
+    return local_to_global_id_;
+  }
+
+  // type info
+  /// Determine if the EntityTypeIDs are stored in properties, or outside
+  /// in their own dedicated structures
+  bool IsEntityTypeIDsOutsideProperties() const;
   const FileView& node_entity_type_id_array_file_storage() const;
   const FileView& edge_entity_type_id_array_file_storage() const;
   katana::Result<katana::EntityTypeManager> node_entity_type_manager() const;
@@ -69,6 +116,20 @@ private:
   //
 
   std::unique_ptr<RDGCore> core_;
+  // NB: we intentionally do not include a property cache here because that will
+  // complicate the property cache logic; one could be added in the future if it
+  // seems necessary
+
+  void InitArrowVectors();
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
+  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
+  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_edge_ids_;
+  std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
+  std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;
+
+  // How this graph was derived from the previous version
+  RDGLineage lineage_;
 };
 
 }  // namespace tsuba

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -174,7 +174,7 @@ tsuba::AddPropertySlice(
     const std::function<katana::Result<void>(std::shared_ptr<arrow::Table>)>&
         add_fn) {
   uint64_t begin = range.first;
-  uint64_t size = range.second - range.first;
+  uint64_t size = range.second > range.first ? range.second - range.first : 0;
   for (tsuba::PropStorageInfo* prop : properties) {
     if (!prop->IsAbsent()) {
       return KATANA_ERROR(

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -13,10 +13,14 @@ namespace tsuba {
 
 class KATANA_EXPORT RDGCore {
 public:
-  RDGCore() { InitEmptyProperties(); }
+  RDGCore() {
+    InitEmptyProperties();
+    InitArrowVectors();
+  }
 
   RDGCore(RDGPartHeader&& part_header) : part_header_(std::move(part_header)) {
     InitEmptyProperties();
+    InitArrowVectors();
   }
 
   bool Equals(const RDGCore& other) const;
@@ -39,12 +43,44 @@ public:
 
   // type info will be missing for properties that weren't loaded
   // make sure it's not missing
-  katana::Result<void> EnsureNodeTypesLoaded(const katana::Uri& rdg_dir);
-  katana::Result<void> EnsureEdgeTypesLoaded(const katana::Uri& rdg_dir);
+  katana::Result<void> EnsureNodeTypesLoaded();
+  katana::Result<void> EnsureEdgeTypesLoaded();
 
   //
   // Accessors and Mutators
   //
+
+  // special partition property names
+  static const inline std::string kMirrorNodesPropName = "mirror_nodes";
+  static const inline std::string kMasterNodesPropName = "master_nodes";
+  static const inline std::string kHostToOwnedGlobalNodeIDsPropName =
+      "host_to_owned_global_node_ids";
+  static const inline std::string kHostToOwnedGlobalEdgeIDsPropName =
+      "host_to_owned_global_edge_ids";
+  static const inline std::string kLocalToUserIDPropName = "local_to_user_id";
+  static const inline std::string kLocalToGlobalIDPropName =
+      "local_to_global_id";
+  // deprecated; only here to support backward compatibility
+  static const inline std::string kDeprecatedLocalToGlobalIDPropName =
+      "local_to_global_vector";
+  static const inline std::string kDeprecatedHostToOwnedGlobalNodeIDsPropName =
+      "host_to_owned_global_ids";
+
+  static std::string MirrorPropName(unsigned i) {
+    return std::string(kMirrorNodesPropName) + "_" + std::to_string(i);
+  }
+
+  static std::string MasterPropName(unsigned i) {
+    return std::string(kMasterNodesPropName) + "_" + std::to_string(i);
+  }
+  katana::Result<void> AddPartitionMetadataArray(
+      const std::shared_ptr<arrow::Table>& props);
+
+  const katana::Uri& rdg_dir() const { return rdg_dir_; }
+  void set_rdg_dir(const katana::Uri& rdg_dir) { rdg_dir_ = rdg_dir; }
+
+  uint32_t partition_id() const { return partition_id_; }
+  void set_partition_id(uint32_t partition_id) { partition_id_ = partition_id; }
 
   const std::shared_ptr<arrow::Table>& node_properties() const {
     return node_properties_;
@@ -70,6 +106,65 @@ public:
     edge_properties_ = arrow::Table::Make(arrow::schema({}), empty, 0);
     part_header_.set_edge_prop_info_list({});
   }
+
+  void AddMirrorNodes(std::shared_ptr<arrow::ChunkedArray>&& a) {
+    mirror_nodes_.emplace_back(std::move(a));
+  }
+
+  void AddMasterNodes(std::shared_ptr<arrow::ChunkedArray>&& a) {
+    master_nodes_.emplace_back(std::move(a));
+  }
+
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
+      const {
+    return master_nodes_;
+  }
+  void set_master_nodes(std::vector<std::shared_ptr<arrow::ChunkedArray>>&& a) {
+    master_nodes_ = std::move(a);
+  }
+
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes()
+      const {
+    return mirror_nodes_;
+  }
+  void set_mirror_nodes(std::vector<std::shared_ptr<arrow::ChunkedArray>>&& a) {
+    mirror_nodes_ = std::move(a);
+  }
+
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
+      const {
+    return host_to_owned_global_node_ids_;
+  }
+  void set_host_to_owned_global_node_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    host_to_owned_global_node_ids_ = std::move(a);
+  }
+
+  const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
+      const {
+    return host_to_owned_global_edge_ids_;
+  }
+  void set_host_to_owned_global_edge_ids(
+      std::shared_ptr<arrow::ChunkedArray>&& a) {
+    host_to_owned_global_edge_ids_ = std::move(a);
+  }
+
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
+    return local_to_user_id_;
+  }
+  void set_local_to_user_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
+    local_to_user_id_ = std::move(a);
+  }
+
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const {
+    return local_to_global_id_;
+  }
+  void set_local_to_global_id(std::shared_ptr<arrow::ChunkedArray>&& a) {
+    local_to_global_id_ = std::move(a);
+  }
+
+  const RDGLineage& lineage() const { return lineage_; }
+  void set_lineage(RDGLineage&& lineage) { lineage_ = lineage; }
 
   const FileView& topology_file_storage() const {
     return topology_file_storage_;
@@ -130,6 +225,10 @@ public:
     return edge_entity_type_id_array_file_storage_.Unbind();
   }
 
+  void AddCommandLine(const std::string& command_line) {
+    lineage_.AddCommandLine(command_line);
+  }
+
 private:
   void InitEmptyProperties();
 
@@ -146,6 +245,23 @@ private:
   FileView edge_entity_type_id_array_file_storage_;
 
   RDGPartHeader part_header_;
+
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
+  // Called while constructing to put these arrays into a usable state for
+  // Distribution
+  void InitArrowVectors();
+  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
+  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_edge_ids_;
+  std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
+  std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;
+
+  /// name of the graph that was used to load this RDG
+  katana::Uri rdg_dir_;
+  /// which partition of the graph was loaded
+  uint32_t partition_id_{std::numeric_limits<uint32_t>::max()};
+  // How this graph was derived from the previous version
+  RDGLineage lineage_;
 };
 
 }  // namespace tsuba


### PR DESCRIPTION
Currently, RDGSlice supports only a subset of the full RDG interface.

Move more RDG functionality into RDGCore and then expose it from RDGSlice. One distinction that I think is important to make now is that RDGSlice is still read-only, despite providing access to all the same data structures as RDG.

This code is currently untested and unused, but I decided that I had written enough that I should merge what I have before continuing.