### PR TITLE
[KAT-1851] Add nbsphinx to build notebooks as docs again

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -54,8 +54,9 @@ dependencies:
  - jupyter_client<7
  - attrs<21,>=19
  - nbconvert<6
+ - nbsphinx
+ - pandoc
  - pexpect
-
  - python=3.8.* *_cpython
  - setuptools
  - shellcheck

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -18,8 +18,10 @@ requirements:
     - cmake>=3.17
     - cython>=0.29.12
     - doxygen
+    - nbsphinx
     - make
     - packaging
+    - pandoc
     - pyarrow {{ arrow_cpp }}
     - pydata-sphinx-theme>=0.6.3
     - pygithub
@@ -109,6 +111,8 @@ outputs:
         - {{ cdt('numactl-devel') }}
         - breathe>=4.30
         - doxygen
+        - nbsphinx
+        - pandoc
         - pydata-sphinx-theme>=0.6.3
         - sphinx>=3.5.1,<4
         - sphinx-copybutton

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ doxygen_path = os.environ["KATANA_DOXYGEN_PATH"]
 # ones.
 extensions = [
     "breathe",
+    "nbsphinx",
     "sphinx.ext.intersphinx",
     #'sphinx.ext.autosummary',
     "sphinx.ext.autodoc",
@@ -81,3 +82,8 @@ author = "Katana Graph"
 
 # TODO(ddn): Get this from katana.libgalois.version
 copyright = "Katana Graph, Inc. 2021"
+
+# -- Options for extensions --------------------------------------------------
+
+# nbsphinx configuration values
+nbsphinx_execute = "never"

--- a/docs/notebooks/algorithms_in_python.ipynb
+++ b/docs/notebooks/algorithms_in_python.ipynb
@@ -311,6 +311,9 @@
    "diff_ignore": [
     "/metadata/language_info/version"
    ]
+  },
+  "nbsphinx": {
+   "orphan": true
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/hello_world.ipynb
+++ b/docs/notebooks/hello_world.ipynb
@@ -157,6 +157,9 @@
    "diff_ignore": [
     "/metadata/language_info/version"
    ]
+  },
+  "nbsphinx": {
+   "orphan": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In commit dba7ab2d50801aa59b5497d44f45581d2ca2909a, I reverted the addition of nbsphinx because it was not sufficiently tested and it was blocking other commits from being merge. Now, adding nbsphinx because the testing is complete.