### PR TITLE
fix contributing documentation with valid json

### DIFF
--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -149,7 +149,7 @@ metadata:
 
    "nbsphinx": {
       "orphan": true
-   },
+   }
 
 API Documentation
 =================


### PR DESCRIPTION
Did not expect different Ubuntu versions would have different sphinx lexing.

@ddn0 this is really weird that this wasn't caught in the open-source CI. Broken ubuntu-20.04