### PR TITLE
Balance block_range

### DIFF
--- a/libgalois/include/katana/ParallelSTL.h
+++ b/libgalois/include/katana/ParallelSTL.h
@@ -311,14 +311,14 @@ map_reduce(
 }
 
 template <typename I>
-std::enable_if_t<!std::is_scalar<internal::Val_ty<I>>::value>
+std::enable_if_t<!std::is_scalar<internal::IteratorValueType<I>>::value>
 destroy(I first, I last) {
-  using T = internal::Val_ty<I>;
+  using T = internal::IteratorValueType<I>;
   do_all(iterate(first, last), [=](T& i) { (&i)->~T(); });
 }
 
 template <class I>
-std::enable_if_t<std::is_scalar<internal::Val_ty<I>>::value>
+std::enable_if_t<std::is_scalar<internal::IteratorValueType<I>>::value>
 destroy(I, I) {}
 
 /**

--- a/libgalois/include/katana/StableIterator.h
+++ b/libgalois/include/katana/StableIterator.h
@@ -21,6 +21,7 @@
 #define KATANA_LIBGALOIS_KATANA_STABLEITERATOR_H_
 
 #include "katana/Chunk.h"
+#include "katana/Range.h"
 #include "katana/config.h"
 #include "katana/gstl.h"
 

--- a/libgalois/include/katana/gstl.h
+++ b/libgalois/include/katana/gstl.h
@@ -335,57 +335,6 @@ safe_advance(IterTy b, IterTy e, Distance n) {
   return safe_advance_dispatch(b, e, n, category);
 }
 
-/**
- * Finds the midpoint of a range.  The first half is always be bigger than
- * the second half if the range has an odd length.
- */
-template <typename IterTy>
-IterTy
-split_range(IterTy b, IterTy e) {
-  std::advance(b, (std::distance(b, e) + 1) / 2);
-  return b;
-}
-
-/**
- * Returns a continuous block from the range based on the number of
- * divisions and the id of the block requested
- */
-template <
-    typename IterTy,
-    typename std::enable_if<!std::is_integral<IterTy>::value>::type* = nullptr>
-std::pair<IterTy, IterTy>
-block_range(IterTy b, IterTy e, unsigned id, unsigned num) {
-  size_t dist = std::distance(b, e);
-  size_t numper = std::max((dist + num - 1) / num, (size_t)1);  // round up
-  size_t A = std::min(numper * id, dist);
-  size_t B = std::min(numper * (id + 1), dist);
-  std::advance(b, A);
-
-  if (dist != B) {
-    e = b;
-    std::advance(e, B - A);
-  }
-
-  return std::make_pair(b, e);
-}
-
-template <
-    typename IntTy,
-    typename std::enable_if<std::is_integral<IntTy>::value>::type* = nullptr>
-std::pair<IntTy, IntTy>
-block_range(IntTy b, IntTy e, unsigned id, unsigned num) {
-  IntTy dist = e - b;
-  IntTy numper = std::max((dist + num - 1) / num, (IntTy)1);  // round up
-  IntTy A = std::min(numper * id, dist);
-  IntTy B = std::min(numper * (id + 1), dist);
-  b += A;
-  if (dist != B) {
-    e = b;
-    e += (B - A);
-  }
-  return std::make_pair(b, e);
-}
-
 namespace internal {
 template <typename I>
 using IteratorValueType = typename std::iterator_traits<I>::value_type;

--- a/libgalois/include/katana/gstl.h
+++ b/libgalois/include/katana/gstl.h
@@ -388,20 +388,20 @@ block_range(IntTy b, IntTy e, unsigned id, unsigned num) {
 
 namespace internal {
 template <typename I>
-using Val_ty = typename std::iterator_traits<I>::value_type;
+using IteratorValueType = typename std::iterator_traits<I>::value_type;
 }  // namespace internal
 
 //! Destroy a range
 template <typename I>
-std::enable_if_t<!std::is_scalar<internal::Val_ty<I>>::value>
+std::enable_if_t<!std::is_scalar<internal::IteratorValueType<I>>::value>
 uninitialized_destroy(I first, I last) {
-  using T = internal::Val_ty<I>;
+  using T = internal::IteratorValueType<I>;
   for (; first != last; ++first)
     (&*first)->~T();
 }
 
 template <class I>
-std::enable_if_t<std::is_scalar<internal::Val_ty<I>>::value>
+std::enable_if_t<std::is_scalar<internal::IteratorValueType<I>>::value>
 uninitialized_destroy(I, I) {}
 
 }  // namespace katana


### PR DESCRIPTION
commit 4cc50701c4649fa4b553bc23a2083c26dc83ca78 (HEAD -> feature/block, ddn0/feature/block)
Author: Donald Nguyen <ddn0@users.noreply.github.com>
Date:   Fri Oct 1 13:40:48 2021 -0700

    libgalois: block_range more evenly

    Balance block ranges more evenly. The previous approach of taking the
    ceiling can leave the last block much smaller than all others. This is
    has not been significant in practice but it is easy enough to fix with
    integers by taking the floor and then adding 1 to the first remainder
    blocks.

    Also, move range functions to Range.h.

