### PR TITLE
fix lexing of json in documentation (not supported)

### DIFF
--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -145,7 +145,7 @@ but other pages can still link to it.
 Orphaned notebookes require the following to be added to the notebook's JSON
 metadata:
 
-.. code-block:: json
+.. code-block:: javascript
 
    "nbsphinx": {
       "orphan": true


### PR DESCRIPTION
json is not consistent across Ubuntu versions. Use javascript