### PR TITLE
bump input version to bring in storage_format_v2 graph

### DIFF
--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -10,7 +10,7 @@ You can get them with ``make input``.
 If you need to update the inputs, they are referenced as
 https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-vN.tar.gz
 in ``.github/workflows``, ``inputs/CMakeLists.txt`` and
-``python/katana/exmaple_utils.py``.  ``vN`` is a monotonically increasing
+``python/katana/exmaple_data.py``.  ``vN`` is a monotonically increasing
 version number. You can use a command ``inputs/update_inputs.sh`` to create
 create a new input collection. After creating the tar file, you will need to
 upload the file to the S3 bucket.

--- a/inputs/CMakeLists.txt
+++ b/inputs/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(INPUT_VERSION v25)
+set(INPUT_VERSION v26)
 
 set(INPUT_URL "https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-${INPUT_VERSION}.tar.gz")
 

--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -37,7 +37,7 @@ def get_inputs_directory(*, invalidate=False) -> Path:
             inputs_dir.unlink()
     inputs_dir.mkdir(parents=True, exist_ok=True)
     fn, _headers = urllib.request.urlretrieve(
-        "https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-v25.tar.gz"
+        "https://katana-ci-public.s3.us-east-1.amazonaws.com/inputs/katana-inputs-v26.tar.gz"
     )
     try:
         with tarfile.open(fn) as tar:


### PR DESCRIPTION
to be merged once katana-inputs-v26.tar.gz is uploaded