### PR TITLE
print error classes

### DIFF
--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -267,14 +267,16 @@ public:
     fmt::format_to(std::back_inserter(out), " ({}:{})", base_name, line_no);
 
     std::string code = ec.message();
-    std::string msg(out.data());
+    char* data = out.data();
+    data[out.size()] = '\0';
+
+    std::string msg(data);
 
     std::string combined = "\n" + code + "\n" + msg;
     const char* output = combined.c_str();
 
     ErrorInfo ei(ec);
-    // TODO(micah) sometimes random characters get printed at the end.
-    ei.Prepend(output, output + combined.length());
+    ei.Prepend(output, output + combined.length() + 1);
 
     return ei;
   }

--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -266,8 +266,15 @@ public:
 
     fmt::format_to(std::back_inserter(out), " ({}:{})", base_name, line_no);
 
+    std::string code = ec.message();
+    std::string msg(out.data());
+
+    std::string combined = "\n" + code + "\n" + msg;
+    const char* output = combined.c_str();
+
     ErrorInfo ei(ec);
-    ei.Prepend(out.data(), out.data() + out.size());
+    // TODO(micah) sometimes random characters get printed at the end.
+    ei.Prepend(output, output + combined.length());
 
     return ei;
   }


### PR DESCRIPTION
The `ErrorInfo` class now prints the error message supplied from the error category along with the error message supplied by the code.