### PR TITLE
Missing command is not an error for capture_command

### DIFF
--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -116,8 +116,14 @@ def _capture_build(zipout: zipfile.ZipFile):
 def capture_command(*args, **kwargs) -> str:
     # pylint: disable=subprocess-run-check
     # Not using check=True because I want to capture both success and failure the same way.
-    res = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
-    out = res.stdout.decode("utf-8").strip("\n")
+    out = ""
+
+    try:
+        res = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
+        out = res.stdout.decode("utf-8").strip("\n")
+    except OSError as err:
+        out = f"errno: {err.errno}, filename: {err.filename}, strerror: {err.strerror}"
+
     return out
 
 

--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -61,21 +61,21 @@ def _capture_system(zipout: zipfile.ZipFile):
     )
 
     capture_string(zipout, "env.txt", "\n".join(f"{k}={v}" for k, v in get_filtered_environ().items()))
-
+    conda_exist = "CONDA_EXE" in os.environ
     capture_string(
         zipout,
         "conda.txt",
         f"""
             CONDA_PREFIX: {os.environ.get('CONDA_PREFIX', '')}
 
-            {os.environ.get('CONDA_EXE', 'no CONDA_EXE env var')}:
-            {capture_command(os.environ['CONDA_EXE'], 'info')}
-            {capture_command(os.environ['CONDA_EXE'], 'list')}
+            {os.environ['CONDA_EXE'] if conda_exist else 'no CONDA_EXE env var'}:
+            {capture_command(os.environ['CONDA_EXE'], 'info') if conda_exist else ''}
+            {capture_command(os.environ['CONDA_EXE'], 'list') if conda_exist else ''}
 
             {capture_command('which', 'conda')}:
             {capture_command('conda', 'info')}
             {capture_command('conda', 'list')}
-            """,
+        """,
     )
 
     capture_string(

--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -122,7 +122,7 @@ def capture_command(*args, **kwargs) -> str:
         res = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
         out = res.stdout.decode("utf-8").strip("\n")
     except OSError as err:
-        out = f"errno: {err.errno}, filename: {err.filename}, strerror: {err.strerror}"
+        out = f"error executing {args}: {err}"
 
     return out
 

--- a/python/test/test_bug.py
+++ b/python/test/test_bug.py
@@ -16,9 +16,10 @@ def test_bug_capture_environment():
             for fn in ["info/os.txt", "info/python.txt", "info/conda.txt", "info/cmake.txt", "etc/ld.so.conf"]:
                 assert fn in files
 
+
 def test_bug_capture_command_pass_invalid_command():
     from katana.bug.environment import capture_command
 
     # Make sure it doesn't fail for non existent command
-    result = capture_command('notreal', 'xyz')
+    result = capture_command("notreal", "xyz")
     assert isinstance(result) == str

--- a/python/test/test_bug.py
+++ b/python/test/test_bug.py
@@ -1,6 +1,8 @@
 import zipfile
 from tempfile import NamedTemporaryFile
 
+from pandas.core.algorithms import isin
+
 
 def test_bug_capture_environment():
     import katana.bug
@@ -13,3 +15,10 @@ def test_bug_capture_environment():
             files = {f.filename for f in zipin.filelist}
             for fn in ["info/os.txt", "info/python.txt", "info/conda.txt", "info/cmake.txt", "etc/ld.so.conf"]:
                 assert fn in files
+
+def test_bug_capture_command_pass_invalid_command():
+    from katana.bug.environment import capture_command
+
+    # Make sure it doesn't fail for non existent command
+    result = capture_command('notreal', 'xyz')
+    assert isinstance(result) == str

--- a/python/test/test_bug.py
+++ b/python/test/test_bug.py
@@ -20,4 +20,4 @@ def test_bug_capture_command_pass_invalid_command():
 
     # Make sure it doesn't fail for non existent command
     result = capture_command("non-existent-executable", "xyz")
-    assert isinstance(result) == str
+    assert isinstance(result, str)

--- a/python/test/test_bug.py
+++ b/python/test/test_bug.py
@@ -1,8 +1,6 @@
 import zipfile
 from tempfile import NamedTemporaryFile
 
-from pandas.core.algorithms import isin
-
 
 def test_bug_capture_environment():
     import katana.bug
@@ -21,5 +19,5 @@ def test_bug_capture_command_pass_invalid_command():
     from katana.bug.environment import capture_command
 
     # Make sure it doesn't fail for non existent command
-    result = capture_command("notreal", "xyz")
+    result = capture_command("non-existent-executable", "xyz")
     assert isinstance(result) == str


### PR DESCRIPTION
Missing command is not an error for capture_command

capture_command is to aid debugging possibly broken build environments so it should complete executing even if the build environment is missing expected programs.

jira: KAT-1651