### PR TITLE
add arrow::DataType to the available overloads for VisitArrow

### DIFF
--- a/libsupport/include/katana/ArrowVisitor.h
+++ b/libsupport/include/katana/ArrowVisitor.h
@@ -83,6 +83,17 @@ VisitArrowCast(arrow::ArrayBuilder* builder) {
   return static_cast<ResultType>(builder);
 }
 
+inline arrow::Type::type
+GetArrowTypeID(const arrow::DataType& type) {
+  return type.id();
+}
+
+template <typename T>
+constexpr decltype(auto)
+VisitArrowCast(const arrow::DataType& type) {
+  return static_cast<const T&>(type);
+}
+
 /// Concept for visitors for VisitArrow.
 ///
 /// A visitor for VisitArrow should model the following behavior.
@@ -312,6 +323,8 @@ using tuple_cat_t = decltype(std::tuple_cat(std::declval<Args>()...));
 
 // TODO(ddn): Move visitor to a function, callers should not need to see this
 // definition directly
+// TODO(daniel): Direct usage is Deprecated, interface will migrate to
+// AppendToBuilder below
 class AppendScalarToBuilder : public ArrowVisitor {
 public:
   using ResultType = Result<void>;
@@ -424,6 +437,9 @@ public:
 private:
   arrow::ArrayBuilder* builder_;
 };
+
+KATANA_EXPORT Result<void> AppendToBuilder(
+    const arrow::Scalar& scalar, arrow::ArrayBuilder* builder);
 
 /// Take a vector of scalars of type data_type and return an Array
 /// scalars vector can contain nullptr entries

--- a/libsupport/src/ArrowVisitor.cpp
+++ b/libsupport/src/ArrowVisitor.cpp
@@ -5,6 +5,8 @@
 
 #include "katana/Logging.h"
 
+namespace {
+
 struct ToArrayVisitor : public katana::ArrowVisitor {
   // Internal data and constructor
   const std::vector<std::shared_ptr<arrow::Scalar>>& scalars;
@@ -94,6 +96,15 @@ struct ToArrayVisitor : public katana::ArrowVisitor {
         builder->type()->name());
   }
 };
+
+}  // namespace
+
+katana::Result<void>
+katana::AppendToBuilder(
+    const arrow::Scalar& scalar, arrow::ArrayBuilder* builder) {
+  katana::AppendScalarToBuilder visitor(builder);
+  return katana::VisitArrow(visitor, scalar);
+}
 
 katana::Result<std::shared_ptr<arrow::Array>>
 katana::ArrayFromScalars(


### PR DESCRIPTION
deprecate direct usage of AppendScalarToBuilder