### PR TITLE
tsuba: let libarrow handle string/largestring conversion

### DIFF
--- a/libtsuba/test/CMakeLists.txt
+++ b/libtsuba/test/CMakeLists.txt
@@ -10,4 +10,10 @@ add_test(NAME file-view COMMAND file-view-test "${CMAKE_CURRENT_BINARY_DIR}/file
 set_tests_properties(file-view PROPERTIES FIXTURES_REQUIRED file-view-ready LABELS quick)
 add_test(NAME clean-file-view COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/file-view-test-wd")
 set_tests_properties(clean-file-view PROPERTIES FIXTURES_SETUP file-view-ready LABELS quick)
-set_property(TEST manifest APPEND PROPERTY LABELS quick)
+
+add_executable(parquet-test parquet.cpp)
+target_link_libraries(parquet-test tsuba)
+add_test(NAME parquet COMMAND parquet-test "${CMAKE_CURRENT_BINARY_DIR}/parquet-test-wd")
+set_tests_properties(parquet PROPERTIES FIXTURES_REQUIRED parquet-ready LABELS quick)
+add_test(NAME clean-parquet COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/parquet-test-wd")
+set_tests_properties(clean-parquet PROPERTIES FIXTURES_SETUP parquet-ready LABELS quick)

--- a/libtsuba/test/parquet.cpp
+++ b/libtsuba/test/parquet.cpp
@@ -1,0 +1,69 @@
+#include <arrow/chunked_array.h>
+#include <arrow/type_fwd.h>
+
+#include "katana/Result.h"
+#include "tsuba/ParquetReader.h"
+#include "tsuba/ParquetWriter.h"
+#include "tsuba/tsuba.h"
+
+katana::Result<std::shared_ptr<arrow::ChunkedArray>>
+MakeArrayOfStrings() {
+  arrow::LargeStringBuilder builder;
+  for (int i = 0; i < 100; ++i) {
+    KATANA_CHECKED(builder.Append(fmt::format("test-string-row-{}", i)));
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  KATANA_CHECKED(builder.Finish(&array));
+  return std::make_shared<arrow::ChunkedArray>(array);
+}
+
+katana::Result<void>
+TestLargeStringRoundTrip(const std::string& dir) {
+  auto uri =
+      KATANA_CHECKED(katana::Uri::Make(dir)).Join("large_string.parquet");
+
+  auto string_array = KATANA_CHECKED(MakeArrayOfStrings());
+  auto writer =
+      KATANA_CHECKED(tsuba::ParquetWriter::Make(string_array, "test-array"));
+
+  KATANA_CHECKED(writer->WriteToUri(uri));
+
+  auto reader = KATANA_CHECKED(tsuba::ParquetReader::Make());
+  auto table = KATANA_CHECKED(reader->ReadTable(uri));
+
+  KATANA_LOG_ASSERT(table->num_columns() == 1);
+  KATANA_LOG_ASSERT(table->columns()[0]->type()->Equals(arrow::large_utf8()));
+
+  return katana::ResultSuccess();
+}
+
+katana::Result<void>
+TestAll(const std::string& dir) {
+  KATANA_CHECKED_CONTEXT(
+      TestLargeStringRoundTrip(dir), "TestLargeStringRoundTrip");
+
+  return katana::ResultSuccess();
+}
+
+int
+main(int argc, char* argv[]) {
+  if (auto init_good = tsuba::Init(); !init_good) {
+    KATANA_LOG_FATAL("tsuba::Init: {}", init_good.error());
+  }
+
+  if (argc <= 1) {
+    KATANA_LOG_FATAL("{} <empty dir>", argv[0]);
+  }
+
+  auto res = TestAll(argv[1]);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  if (auto fini_good = tsuba::Fini(); !fini_good) {
+    KATANA_LOG_FATAL("tsuba::Fini: {}", fini_good.error());
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Version 4 correctly handles large strings when writing parquet, and
has a builtin conversion function from string to large string.

Avoiding our naive manual translation should save memory when we write
Parquet and be no worse (but probably better) on read.

closes #62

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>