### PR TITLE
Persist node and edge indexes in partition header

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -74,6 +74,9 @@ private:
   Result<void> WriteView(
       const std::string& uri, const std::string& command_line);
 
+  // Recreate indexes from json
+  katana::Result<void> RecreatePropertyIndexes();
+
   tsuba::RDG rdg_;
   std::unique_ptr<tsuba::RDGFile> file_;
   GraphTopology topology_;
@@ -91,42 +94,14 @@ private:
   // List of node indexes on this graph.
   std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Node>>>
       node_indexes_;
-  //And the columns that created them to persist in json
-  std::vector<std::string> node_property_indexes_column_name_;
 
   // List of edge indexes on this graph.
   std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Edge>>>
       edge_indexes_;
-  //And the columns that created them to persist in json
-  std::vector<std::string> edge_property_indexes_column_name_;
 
   PGViewCache pg_view_cache_;
 
   friend class PropertyGraphRetractor;
-
-  // recreate indexes from json
-  katana::Result<void> recreate_node_property_indexes() {
-    node_property_indexes_column_name_ =
-        rdg_.node_property_indexes_column_name();
-    for (const std::string& column_name : node_property_indexes_column_name_) {
-      auto result = MakeNodeIndex(column_name);
-      if (!result) {
-        return result.error();
-      }
-    }
-    return katana::ResultSuccess();
-  }
-  katana::Result<void> recreate_edge_property_indexes() {
-    edge_property_indexes_column_name_ =
-        rdg_.edge_property_indexes_column_name();
-    for (const std::string& column_name : edge_property_indexes_column_name_) {
-      auto result = MakeEdgeIndex(column_name);
-      if (!result) {
-        return result.error();
-      }
-    }
-    return katana::ResultSuccess();
-  }
 
 public:
   /// PropertyView provides a uniform interface when you don't need to

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -74,7 +74,7 @@ private:
   Result<void> WriteView(
       const std::string& uri, const std::string& command_line);
 
-  // Recreate indexes from json
+  /// Recreate indexes listed in RDG metadata.
   katana::Result<void> RecreatePropertyIndexes();
 
   tsuba::RDG rdg_;
@@ -91,11 +91,11 @@ private:
   /// The edge EntityTypeID for each edge's most specific type
   EntityTypeIDArray edge_entity_type_ids_;
 
-  // List of node indexes on this graph.
+  /// List of node indexes on this graph.
   std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Node>>>
       node_indexes_;
 
-  // List of edge indexes on this graph.
+  /// List of edge indexes on this graph.
   std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Edge>>>
       edge_indexes_;
 

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -88,15 +88,45 @@ private:
   /// The edge EntityTypeID for each edge's most specific type
   EntityTypeIDArray edge_entity_type_ids_;
 
-  // List of node and edge indexes on this graph.
+  // List of node indexes on this graph.
   std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Node>>>
       node_indexes_;
+  //And the columns that created them to persist in json
+  std::vector<std::string> node_property_indexes_column_name_;
+
+  // List of edge indexes on this graph.
   std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Edge>>>
       edge_indexes_;
+  //And the columns that created them to persist in json
+  std::vector<std::string> edge_property_indexes_column_name_;
 
   PGViewCache pg_view_cache_;
 
   friend class PropertyGraphRetractor;
+
+  // recreate indexes from json
+  katana::Result<void> recreate_node_property_indexes() {
+    node_property_indexes_column_name_ =
+        rdg_.node_property_indexes_column_name();
+    for (const std::string& column_name : node_property_indexes_column_name_) {
+      auto result = MakeNodeIndex(column_name);
+      if (!result) {
+        return result.error();
+      }
+    }
+    return katana::ResultSuccess();
+  }
+  katana::Result<void> recreate_edge_property_indexes() {
+    edge_property_indexes_column_name_ =
+        rdg_.edge_property_indexes_column_name();
+    for (const std::string& column_name : edge_property_indexes_column_name_) {
+      auto result = MakeEdgeIndex(column_name);
+      if (!result) {
+        return result.error();
+      }
+    }
+    return katana::ResultSuccess();
+  }
 
 public:
   /// PropertyView provides a uniform interface when you don't need to

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -74,7 +74,7 @@ private:
   Result<void> WriteView(
       const std::string& uri, const std::string& command_line);
 
-  /// Recreate indexes listed in RDG metadata.
+  /// Recreate indexes from column names in RDG metadata.
   katana::Result<void> RecreatePropertyIndexes();
 
   tsuba::RDG rdg_;

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -1310,17 +1310,11 @@ katana::PropertyGraph::GetNodePropertyIndex(
 katana::Result<void>
 katana::PropertyGraph::RecreatePropertyIndexes() {
   for (const std::string& column_name : rdg_.node_property_index_columns()) {
-    auto result = MakeNodeIndex(column_name);
-    if (!result) {
-      return result.error();
-    }
+    KATANA_CHECKED(MakeNodeIndex(column_name));
   }
 
   for (const std::string& column_name : rdg_.edge_property_index_columns()) {
-    auto result = MakeEdgeIndex(column_name);
-    if (!result) {
-      return result.error();
-    }
+    KATANA_CHECKED(MakeEdgeIndex(column_name));
   }
 
   return katana::ResultSuccess();

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -1310,11 +1310,15 @@ katana::PropertyGraph::GetNodePropertyIndex(
 katana::Result<void>
 katana::PropertyGraph::RecreatePropertyIndexes() {
   for (const std::string& column_name : rdg_.node_property_index_columns()) {
-    KATANA_CHECKED(MakeNodeIndex(column_name));
+    if (HasNodeProperty(column_name)) {
+      KATANA_CHECKED(MakeNodeIndex(column_name));
+    }
   }
 
   for (const std::string& column_name : rdg_.edge_property_index_columns()) {
-    KATANA_CHECKED(MakeEdgeIndex(column_name));
+    if (HasEdgeProperty(column_name)) {
+      KATANA_CHECKED(MakeEdgeIndex(column_name));
+    }
   }
 
   return katana::ResultSuccess();

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -219,6 +219,8 @@ katana::PropertyGraph::Make(
   katana::GraphTopology topo =
       KATANA_CHECKED(MapTopology(rdg.topology_file_storage()));
 
+  std::unique_ptr<katana::PropertyGraph> property_graph;
+
   if (rdg.IsEntityTypeIDsOutsideProperties()) {
     KATANA_LOG_DEBUG("loading EntityType data from outside properties");
 
@@ -236,7 +238,7 @@ katana::PropertyGraph::Make(
     EntityTypeManager edge_type_manager =
         KATANA_CHECKED(rdg.edge_entity_type_manager());
 
-    return std::make_unique<PropertyGraph>(
+    property_graph = std::make_unique<PropertyGraph>(
         std::move(rdg_file), std::move(rdg), std::move(topo),
         std::move(node_type_ids), std::move(edge_type_ids),
         std::move(node_type_manager), std::move(edge_type_manager));
@@ -244,16 +246,26 @@ katana::PropertyGraph::Make(
   } else {
     // we must construct id_arrays and managers from properties
 
-    auto pg = std::make_unique<PropertyGraph>(
+    property_graph = std::make_unique<PropertyGraph>(
         std::move(rdg_file), std::move(rdg), std::move(topo),
         MakeDefaultEntityTypeIDArray(topo.num_nodes()),
         MakeDefaultEntityTypeIDArray(topo.num_edges()), EntityTypeManager{},
         EntityTypeManager{});
 
-    KATANA_CHECKED(pg->ConstructEntityTypeIDs());
-
-    return MakeResult(std::move(pg));
+    KATANA_CHECKED(property_graph->ConstructEntityTypeIDs());
   }
+
+  auto res = property_graph->recreate_node_property_indexes();
+  if (!res) {
+    return res.error();
+  }
+
+  res = property_graph->recreate_edge_property_indexes();
+  if (!res) {
+    return res.error();
+  }
+
+  return MakeResult(std::move(property_graph));
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
@@ -952,6 +964,13 @@ katana::PropertyGraph::MakeNodeIndex(const std::string& column_name) {
 
   node_indexes_.push_back(std::move(index));
 
+  //save the column name the index was created from for easy assess dudring json load/store
+  node_property_indexes_column_name_.push_back(column_name);
+
+  //persist column names to json, index can now can be recreated using recreate_node_property_indexes()
+  rdg_.set_node_property_indexes_column_name(
+      node_property_indexes_column_name_);
+
   return katana::ResultSuccess();
 }
 
@@ -980,6 +999,13 @@ katana::PropertyGraph::MakeEdgeIndex(const std::string& column_name) {
   KATANA_CHECKED(index->BuildFromProperty());
 
   edge_indexes_.push_back(std::move(index));
+
+  //save the column name the index was created from for easy assess dudring json load/store
+  edge_property_indexes_column_name_.push_back(column_name);
+
+  //persist column names to json, index can now can be recreated using recreate_edge_property_indexes()
+  rdg_.set_edge_property_indexes_column_name(
+      edge_property_indexes_column_name_);
 
   return katana::ResultSuccess();
 }

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -477,13 +477,13 @@ katana::PropertyGraph::DoWrite(
   std::transform(
       node_indexes_.begin(), node_indexes_.end(), node_index_columns.begin(),
       [](const auto& index) { return index->column_name(); });
-  rdg_.set_node_property_index_columns(std::move(node_index_columns));
+  rdg_.set_node_property_index_columns(node_index_columns);
 
   std::vector<std::string> edge_index_columns(edge_indexes_.size());
   std::transform(
       edge_indexes_.begin(), edge_indexes_.end(), edge_index_columns.begin(),
       [](const auto& index) { return index->column_name(); });
-  rdg_.set_edge_property_index_columns(std::move(edge_index_columns));
+  rdg_.set_edge_property_index_columns(edge_index_columns);
 
   return rdg_.Store(
       handle, command_line, versioning_action, std::move(topology_res),

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -230,8 +230,8 @@ public:
   /// Remove all edge properties
   void DropEdgeProperties();
 
-  // Write the list of node and edge column names persisted to json. Consumes
-  // the provided parameters.
+  // Set the list of node and edge column names to persist. Consumes the
+  // provided parameters.
   void set_node_property_index_columns(
       std::vector<std::string>&& node_property_index_columns);
   void set_edge_property_index_columns(

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -233,9 +233,9 @@ public:
   // Set the list of node and edge column names to persist. Consumes the
   // provided parameters.
   void set_node_property_index_columns(
-      std::vector<std::string>&& node_property_index_columns);
+      const std::vector<std::string>& node_property_index_columns);
   void set_edge_property_index_columns(
-      std::vector<std::string>&& edge_property_index_columns);
+      const std::vector<std::string>& edge_property_index_columns);
 
   // Return the list of node and edge column names.
   const std::vector<std::string>& node_property_index_columns();

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -230,15 +230,16 @@ public:
   /// Remove all edge properties
   void DropEdgeProperties();
 
-  // write the list of node and edge column names persisted to json, private as it is called only when the node and edge property index vectors are pushed back
-  void set_node_property_indexes_column_name(
-      std::vector<std::string>& node_property_indexes_column_name);
-  void set_edge_property_indexes_column_name(
-      std::vector<std::string>& edge_property_indexes_column_name);
+  // Write the list of node and edge column names persisted to json. Consumes
+  // the provided parameters.
+  void set_node_property_index_columns(
+      std::vector<std::string>&& node_property_index_columns);
+  void set_edge_property_index_columns(
+      std::vector<std::string>&& edge_property_index_columns);
 
-  // read the same as above and recreate indexes
-  std::vector<std::string>& node_property_indexes_column_name();
-  std::vector<std::string>& edge_property_indexes_column_name();
+  // Return the list of node and edge column names.
+  const std::vector<std::string>& node_property_index_columns();
+  const std::vector<std::string>& edge_property_index_columns();
 
   /// Remove topology data
   katana::Result<void> DropTopology();

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -230,6 +230,16 @@ public:
   /// Remove all edge properties
   void DropEdgeProperties();
 
+  // write the list of node and edge column names persisted to json, private as it is called only when the node and edge property index vectors are pushed back
+  void set_node_property_indexes_column_name(
+      std::vector<std::string>& node_property_indexes_column_name);
+  void set_edge_property_indexes_column_name(
+      std::vector<std::string>& edge_property_indexes_column_name);
+
+  // read the same as above and recreate indexes
+  std::vector<std::string>& node_property_indexes_column_name();
+  std::vector<std::string>& edge_property_indexes_column_name();
+
   /// Remove topology data
   katana::Result<void> DropTopology();
 

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -217,16 +217,16 @@ tsuba::RDG::WritePartArrays(const katana::Uri& dir, tsuba::WriteGroup* desc) {
 
 void
 tsuba::RDG::set_node_property_index_columns(
-    std::vector<std::string>&& node_property_index_columns) {
+    const std::vector<std::string>& node_property_index_columns) {
   core_->part_header().set_node_property_index_columns(
-      std::move(node_property_index_columns));
+      node_property_index_columns);
 }
 
 void
 tsuba::RDG::set_edge_property_index_columns(
-    std::vector<std::string>&& edge_property_index_columns) {
+    const std::vector<std::string>& edge_property_index_columns) {
   core_->part_header().set_edge_property_index_columns(
-      std::move(edge_property_index_columns));
+      edge_property_index_columns);
 }
 
 const std::vector<std::string>&

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -215,6 +215,29 @@ tsuba::RDG::WritePartArrays(const katana::Uri& dir, tsuba::WriteGroup* desc) {
   return next_properties;
 }
 
+//write the list of node and edge column names persisted to json, private as it is called only when the node and edge property index vectors are pushed back
+void
+tsuba::RDG::set_node_property_indexes_column_name(
+    std::vector<std::string>& node_property_indexes_column_name) {
+  core_->part_header().set_node_property_indexes_column_name(
+      node_property_indexes_column_name);
+}
+void
+tsuba::RDG::set_edge_property_indexes_column_name(
+    std::vector<std::string>& edge_property_indexes_column_name) {
+  core_->part_header().set_edge_property_indexes_column_name(
+      edge_property_indexes_column_name);
+}
+// read the same as above and recreate indexes
+std::vector<std::string>&
+tsuba::RDG::node_property_indexes_column_name() {
+  return core_->part_header().node_property_indexes_column_name();
+}
+std::vector<std::string>&
+tsuba::RDG::edge_property_indexes_column_name() {
+  return core_->part_header().edge_property_indexes_column_name();
+}
+
 katana::Result<void>
 tsuba::RDG::DoStoreTopology(
     RDGHandle handle, std::unique_ptr<FileFrame> topology_ff,

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -215,27 +215,28 @@ tsuba::RDG::WritePartArrays(const katana::Uri& dir, tsuba::WriteGroup* desc) {
   return next_properties;
 }
 
-//write the list of node and edge column names persisted to json, private as it is called only when the node and edge property index vectors are pushed back
 void
-tsuba::RDG::set_node_property_indexes_column_name(
-    std::vector<std::string>& node_property_indexes_column_name) {
-  core_->part_header().set_node_property_indexes_column_name(
-      node_property_indexes_column_name);
+tsuba::RDG::set_node_property_index_columns(
+    std::vector<std::string>&& node_property_index_columns) {
+  core_->part_header().set_node_property_index_columns(
+      std::move(node_property_index_columns));
 }
+
 void
-tsuba::RDG::set_edge_property_indexes_column_name(
-    std::vector<std::string>& edge_property_indexes_column_name) {
-  core_->part_header().set_edge_property_indexes_column_name(
-      edge_property_indexes_column_name);
+tsuba::RDG::set_edge_property_index_columns(
+    std::vector<std::string>&& edge_property_index_columns) {
+  core_->part_header().set_edge_property_index_columns(
+      std::move(edge_property_index_columns));
 }
-// read the same as above and recreate indexes
-std::vector<std::string>&
-tsuba::RDG::node_property_indexes_column_name() {
-  return core_->part_header().node_property_indexes_column_name();
+
+const std::vector<std::string>&
+tsuba::RDG::node_property_index_columns() {
+  return core_->part_header().node_property_index_columns();
 }
-std::vector<std::string>&
-tsuba::RDG::edge_property_indexes_column_name() {
-  return core_->part_header().edge_property_indexes_column_name();
+
+const std::vector<std::string>&
+tsuba::RDG::edge_property_index_columns() {
+  return core_->part_header().edge_property_index_columns();
 }
 
 katana::Result<void>

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -33,6 +33,9 @@ const char* kEdgeEntityTypeIDDictionaryKey =
 const char* kNodeEntityTypeIDNameKey = "kg.v1.node_entity_type_id_name";
 // Name maps from Atomic Edge Entity Type ID to set of string names for the Edge Entity Type ID
 const char* kEdgeEntityTypeIDNameKey = "kg.v1.edge_entity_type_id_name";
+// List of node and edge indexed columns
+const char* kNodePropertyIndexColumnsKey = "kg.v1.node_property_index_columns";
+const char* kEdgePropertyIndexColumnsKey = "kg.v1.edge_property_index_columns";
 
 //
 //constexpr std::string_view  mirror_nodes_prop_name = "mirror_nodes";
@@ -288,6 +291,8 @@ tsuba::to_json(json& j, const tsuba::RDGPartHeader& header) {
       {kEdgeEntityTypeIDDictionaryKey, header.edge_entity_type_id_dictionary_},
       {kNodeEntityTypeIDNameKey, header.node_entity_type_id_name_},
       {kEdgeEntityTypeIDNameKey, header.edge_entity_type_id_name_},
+      {kNodePropertyIndexColumnsKey, header.node_property_index_columns_},
+      {kEdgePropertyIndexColumnsKey, header.edge_property_index_columns_},
   };
 }
 
@@ -318,6 +323,16 @@ tsuba::from_json(const json& j, tsuba::RDGPartHeader& header) {
         .get_to(header.edge_entity_type_id_dictionary_);
     j.at(kNodeEntityTypeIDNameKey).get_to(header.node_entity_type_id_name_);
     j.at(kEdgeEntityTypeIDNameKey).get_to(header.edge_entity_type_id_name_);
+  }
+
+  header.node_property_index_columns_ = {};
+  if (auto it = j.find(kNodePropertyIndexColumnsKey); it != j.end()) {
+    it->get_to(header.node_property_index_columns_);
+  }
+
+  header.edge_property_index_columns_ = {};
+  if (auto it = j.find(kEdgePropertyIndexColumnsKey); it != j.end()) {
+    it->get_to(header.edge_property_index_columns_);
   }
 }
 

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -278,28 +278,22 @@ public:
     part_prop_info_list_ = std::move(part_prop_info_list);
   }
 
-  const std::vector<std::string>& node_property_indexes_column_name() const {
-    return node_property_indexes_column_name_;
-  }
-  std::vector<std::string>& node_property_indexes_column_name() {
-    return node_property_indexes_column_name_;
-  }
-  void set_node_property_indexes_column_name(
-      std::vector<std::string>& node_property_indexes_column_name) {
-    node_property_indexes_column_name_ =
-        std::move(node_property_indexes_column_name);
+  const std::vector<std::string>& node_property_index_columns() const {
+    return node_property_index_columns_;
   }
 
-  const std::vector<std::string>& edge_property_indexes_column_name() const {
-    return edge_property_indexes_column_name_;
+  void set_node_property_index_columns(
+      std::vector<std::string>&& node_property_index_columns) {
+    node_property_index_columns_ = std::move(node_property_index_columns);
   }
-  std::vector<std::string>& edge_property_indexes_column_name() {
-    return edge_property_indexes_column_name_;
+
+  const std::vector<std::string>& edge_property_index_columns() const {
+    return edge_property_index_columns_;
   }
-  void set_edge_property_indexes_column_name(
-      std::vector<std::string>& edge_property_indexes_column_name) {
-    edge_property_indexes_column_name_ =
-        std::move(edge_property_indexes_column_name);
+
+  void set_edge_property_index_columns(
+      std::vector<std::string>&& edge_property_index_columns) {
+    edge_property_index_columns_ = std::move(edge_property_index_columns);
   }
 
   const PartitionMetadata& metadata() const { return metadata_; }
@@ -525,11 +519,9 @@ private:
   std::vector<PropStorageInfo> node_prop_info_list_;
   std::vector<PropStorageInfo> edge_prop_info_list_;
 
-  /// Column Names to create property index from on startup
-  std::vector<std::string>
-      node_property_indexes_column_name_;  //nhomann serializes this automagically. to/from json required if column name type is (in the future) changed from string to a custom one
-  std::vector<std::string>
-      edge_property_indexes_column_name_;  //nhomann serializes this automagically. to/from json required if column name type is (in the future) changed from string to a custom one
+  /// Column names to create property index from on startup
+  std::vector<std::string> node_property_index_columns_;
+  std::vector<std::string> edge_property_index_columns_;
 
   /// Metadata filled in by CuSP, or from storage (meta partition file)
   PartitionMetadata metadata_;

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -283,8 +283,8 @@ public:
   }
 
   void set_node_property_index_columns(
-      std::vector<std::string>&& node_property_index_columns) {
-    node_property_index_columns_ = std::move(node_property_index_columns);
+      const std::vector<std::string>& node_property_index_columns) {
+    node_property_index_columns_ = node_property_index_columns;
   }
 
   const std::vector<std::string>& edge_property_index_columns() const {
@@ -292,8 +292,8 @@ public:
   }
 
   void set_edge_property_index_columns(
-      std::vector<std::string>&& edge_property_index_columns) {
-    edge_property_index_columns_ = std::move(edge_property_index_columns);
+      const std::vector<std::string>& edge_property_index_columns) {
+    edge_property_index_columns_ = edge_property_index_columns;
   }
 
   const PartitionMetadata& metadata() const { return metadata_; }

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -278,6 +278,30 @@ public:
     part_prop_info_list_ = std::move(part_prop_info_list);
   }
 
+  const std::vector<std::string>& node_property_indexes_column_name() const {
+    return node_property_indexes_column_name_;
+  }
+  std::vector<std::string>& node_property_indexes_column_name() {
+    return node_property_indexes_column_name_;
+  }
+  void set_node_property_indexes_column_name(
+      std::vector<std::string>& node_property_indexes_column_name) {
+    node_property_indexes_column_name_ =
+        std::move(node_property_indexes_column_name);
+  }
+
+  const std::vector<std::string>& edge_property_indexes_column_name() const {
+    return edge_property_indexes_column_name_;
+  }
+  std::vector<std::string>& edge_property_indexes_column_name() {
+    return edge_property_indexes_column_name_;
+  }
+  void set_edge_property_indexes_column_name(
+      std::vector<std::string>& edge_property_indexes_column_name) {
+    edge_property_indexes_column_name_ =
+        std::move(edge_property_indexes_column_name);
+  }
+
   const PartitionMetadata& metadata() const { return metadata_; }
   void set_metadata(const PartitionMetadata& metadata) { metadata_ = metadata; }
 
@@ -500,6 +524,12 @@ private:
   std::vector<PropStorageInfo> part_prop_info_list_;
   std::vector<PropStorageInfo> node_prop_info_list_;
   std::vector<PropStorageInfo> edge_prop_info_list_;
+
+  /// Column Names to create property index from on startup
+  std::vector<std::string>
+      node_property_indexes_column_name_;  //nhomann serializes this automagically. to/from json required if column name type is (in the future) changed from string to a custom one
+  std::vector<std::string>
+      edge_property_indexes_column_name_;  //nhomann serializes this automagically. to/from json required if column name type is (in the future) changed from string to a custom one
 
   /// Metadata filled in by CuSP, or from storage (meta partition file)
   PartitionMetadata metadata_;


### PR DESCRIPTION
This takes Nirhjar's work to add index persistence to RDGPartHeader and:
- Rebase and resolve conflicts on current head
- Tweaks for some shorter names, better types (don't return or pass non-const references), and data flow
- Adds what I believe are the necessary bits to to_json/from_json to actually persist the index list