### PR TITLE
tsuba: Include property split files in RDGManifest::FilesNames()

### DIFF
--- a/libtsuba/include/tsuba/FileView.h
+++ b/libtsuba/include/tsuba/FileView.h
@@ -110,7 +110,7 @@ public:
   }
 
   uint64_t size() const { return file_size_; }
-  std::string filename() const { return filename_; }
+  const std::string& filename() const { return filename_; }
 
   // support iterating through characters
   const char* begin() const { return ptr<char>(); }

--- a/libtsuba/include/tsuba/FileView.h
+++ b/libtsuba/include/tsuba/FileView.h
@@ -110,6 +110,7 @@ public:
   }
 
   uint64_t size() const { return file_size_; }
+  std::string filename() const { return filename_; }
 
   // support iterating through characters
   const char* begin() const { return ptr<char>(); }

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -75,7 +75,10 @@ public:
   /// Get the number of rows for the table stored in a parquet file
   ///   \param uri an identifier for a parquet file
   katana::Result<int64_t> NumRows(const katana::Uri& uri);
-
+  
+  /// Get the number of offset files for the parquet file
+  ///   \param uri an identifier for a parquet file
+  katana::Result<uint64_t> NumOffsetFiles(const katana::Uri& uri);
 private:
   ParquetReader(std::optional<Slice> slice, bool make_cannonical)
       : slice_(slice), make_cannonical_{make_cannonical} {}

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -76,10 +76,9 @@ public:
   ///   \param uri an identifier for a parquet file
   katana::Result<int64_t> NumRows(const katana::Uri& uri);
 
-  /// Get the possible sub files for the logical parquet file, will return
-  /// a original parquet file if there are no sub files
+  /// Get the files for the logical parquet table
   ///   \param uri an identifier for a parquet file
-  katana::Result<std::vector<std::string>> GetSubFiles(const katana::Uri& uri);
+  katana::Result<std::vector<std::string>> GetFiles(const katana::Uri& uri);
 
 private:
   ParquetReader(std::optional<Slice> slice, bool make_cannonical)

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -75,10 +75,11 @@ public:
   /// Get the number of rows for the table stored in a parquet file
   ///   \param uri an identifier for a parquet file
   katana::Result<int64_t> NumRows(const katana::Uri& uri);
-  
-  /// Get the number of offset files for the parquet file
+
+  /// Get the number of files for the logical parquet file
   ///   \param uri an identifier for a parquet file
-  katana::Result<uint64_t> NumOffsetFiles(const katana::Uri& uri);
+  katana::Result<uint64_t> NumFiles(const katana::Uri& uri);
+
 private:
   ParquetReader(std::optional<Slice> slice, bool make_cannonical)
       : slice_(slice), make_cannonical_{make_cannonical} {}

--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -76,9 +76,10 @@ public:
   ///   \param uri an identifier for a parquet file
   katana::Result<int64_t> NumRows(const katana::Uri& uri);
 
-  /// Get the number of files for the logical parquet file
+  /// Get the possible sub files for the logical parquet file, will return
+  /// a original parquet file if there are no sub files
   ///   \param uri an identifier for a parquet file
-  katana::Result<uint64_t> NumFiles(const katana::Uri& uri);
+  katana::Result<std::vector<std::string>> GetSubFiles(const katana::Uri& uri);
 
 private:
   ParquetReader(std::optional<Slice> slice, bool make_cannonical)

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -317,6 +317,10 @@ public:
     return concatenated_table;
   }
 
+  Result<uint64_t> NumOffsetFiles() {
+    return fvs_.size();
+  }
+
 private:
   BlockedParquetReader(
       std::string prefix, std::vector<std::shared_ptr<tsuba::FileView>>&& fvs,
@@ -395,6 +399,11 @@ tsuba::ParquetReader::NumColumns(const katana::Uri& uri) {
 Result<int64_t>
 tsuba::ParquetReader::NumRows(const katana::Uri& uri) {
   return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->NumRows();
+}
+
+Result<uint64_t>
+tsuba::ParquetReader::NumOffsetFiles(const katana::Uri& uri) {
+  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->NumOffsetFiles();
 }
 
 Result<std::shared_ptr<arrow::Schema>>

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -317,9 +317,7 @@ public:
     return concatenated_table;
   }
 
-  Result<uint64_t> NumOffsetFiles() {
-    return fvs_.size();
-  }
+  Result<uint64_t> NumFiles() { return fvs_.size(); }
 
 private:
   BlockedParquetReader(
@@ -402,8 +400,9 @@ tsuba::ParquetReader::NumRows(const katana::Uri& uri) {
 }
 
 Result<uint64_t>
-tsuba::ParquetReader::NumOffsetFiles(const katana::Uri& uri) {
-  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->NumOffsetFiles();
+tsuba::ParquetReader::NumFiles(const katana::Uri& uri) {
+  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))
+      ->NumFiles();
 }
 
 Result<std::shared_ptr<arrow::Schema>>

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -401,8 +401,7 @@ tsuba::ParquetReader::NumRows(const katana::Uri& uri) {
 
 Result<uint64_t>
 tsuba::ParquetReader::NumFiles(const katana::Uri& uri) {
-  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))
-      ->NumFiles();
+  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->NumFiles();
 }
 
 Result<std::shared_ptr<arrow::Schema>>

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -317,7 +317,7 @@ public:
     return concatenated_table;
   }
 
-  Result<std::vector<std::string>> GetSubFiles() {
+  Result<std::vector<std::string>> GetFiles() {
     std::vector<std::string> sub_files;
     sub_files.reserve(fvs_.size());
     // Bind some the file views so we can get the filenames
@@ -325,7 +325,6 @@ public:
       KATANA_CHECKED(EnsureReader(i, false));
     }
     for (const auto& fv : fvs_) {
-      KATANA_LOG_WARN("fv->filename(): {}", fv->filename());
       sub_files.emplace_back(fv->filename());
     }
     return sub_files;
@@ -412,8 +411,8 @@ tsuba::ParquetReader::NumRows(const katana::Uri& uri) {
 }
 
 Result<std::vector<std::string>>
-tsuba::ParquetReader::GetSubFiles(const katana::Uri& uri) {
-  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->GetSubFiles();
+tsuba::ParquetReader::GetFiles(const katana::Uri& uri) {
+  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->GetFiles();
 }
 
 Result<std::shared_ptr<arrow::Schema>>

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -317,7 +317,19 @@ public:
     return concatenated_table;
   }
 
-  Result<uint64_t> NumFiles() { return fvs_.size(); }
+  Result<std::vector<std::string>> GetSubFiles() {
+    std::vector<std::string> sub_files;
+    sub_files.reserve(fvs_.size());
+    // Bind some the file views so we can get the filenames
+    for (size_t i = 0, num_files = readers_.size(); i < num_files; ++i) {
+      KATANA_CHECKED(EnsureReader(i, false));
+    }
+    for (const auto& fv : fvs_) {
+      KATANA_LOG_WARN("fv->filename(): {}", fv->filename());
+      sub_files.emplace_back(fv->filename());
+    }
+    return sub_files;
+  }
 
 private:
   BlockedParquetReader(
@@ -399,9 +411,9 @@ tsuba::ParquetReader::NumRows(const katana::Uri& uri) {
   return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->NumRows();
 }
 
-Result<uint64_t>
-tsuba::ParquetReader::NumFiles(const katana::Uri& uri) {
-  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->NumFiles();
+Result<std::vector<std::string>>
+tsuba::ParquetReader::GetSubFiles(const katana::Uri& uri) {
+  return KATANA_CHECKED(BlockedParquetReader::Make(uri, false))->GetSubFiles();
 }
 
 Result<std::shared_ptr<arrow::Schema>>

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -237,6 +237,17 @@ RDGManifest::FileNames() {
       for (const auto& part_prop : header.part_prop_info_list()) {
         fnames.emplace(part_prop.path());
       }
+      // Some properties may have split files, so we add them to fnames as well
+      // node_prop_offset_files() etc, all return strings instead of objects
+      for (const auto& node_prop : header.node_prop_offset_files()) {
+        fnames.emplace(node_prop);
+      }
+      for (const auto& edge_prop : header.edge_prop_offset_files()) {
+        fnames.emplace(edge_prop);
+      }
+      for (const auto& part_prop : header.part_prop_offset_files()) {
+        fnames.emplace(part_prop);
+      }
       // Duplicates eliminated by set
       fnames.emplace(header.topology_path());
       if (const auto& n = header.node_entity_type_id_array_path(); !n.empty()) {

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -10,6 +10,7 @@
 #include "katana/Result.h"
 #include "tsuba/Errors.h"
 #include "tsuba/FileView.h"
+#include "tsuba/ParquetReader.h"
 #include "tsuba/tsuba.h"
 template <typename T>
 using Result = katana::Result<T>;
@@ -211,7 +212,7 @@ Result<void>
 AddPropertySubFiles(std::set<std::string>& fnames, std::string full_path) {
   auto reader = KATANA_CHECKED(tsuba::ParquetReader::Make());
   auto uri_path = KATANA_CHECKED(katana::Uri::Make(full_path));
-  auto sub_files = KATANA_CHECKED(reader->GetSubFiles(uri_path));
+  auto sub_files = KATANA_CHECKED(reader->GetFiles(uri_path));
   for (const auto& sub_file : sub_files) {
     auto sub_file_uri = KATANA_CHECKED(katana::Uri::Make(sub_file));
     fnames.emplace(

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -223,7 +223,7 @@ RDGManifest::FileNames() {
     auto header_res = RDGPartHeader::Make(header_uri);
 
     if (!header_res) {
-      KATANA_LOG_DEBUG(
+      KATANA_LOG_WARN(
           "problem uri: {} host: {} ver: {} view_name: {}  : {}", header_uri, i,
           version(), view_specifier(), header_res.error());
     } else {

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -101,6 +101,17 @@ RDGPartHeader::Make(const katana::Uri& partition_path) {
   if (!res) {
     return res.error();
   }
+
+  // Iterate over properties and find any potential part files
+  auto node_offset_files = KATANA_CHECKED(GetOffsetFiles(res.value().node_prop_info_list()));
+  res.value().set_node_prop_offset_files(std::move(node_offset_files));
+
+  auto edge_offset_files = KATANA_CHECKED(GetOffsetFiles(res.value().edge_prop_info_list()));
+  res.value().set_edge_prop_offset_files(std::move(edge_offset_files));
+
+  auto part_offset_files = KATANA_CHECKED(GetOffsetFiles(res.value().part_prop_info_list()));
+  res.value().set_part_prop_offset_files(std::move(part_offset_files));
+
   return res;
 }
 

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -98,21 +98,6 @@ RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
 katana::Result<RDGPartHeader>
 RDGPartHeader::Make(const katana::Uri& partition_path) {
   auto part_header = KATANA_CHECKED(MakeJson(partition_path));
-  auto part_dir_name = partition_path.DirName().string();
-
-  // Iterate over properties and find any potential part files
-  auto node_offset_files = KATANA_CHECKED(
-      GetOffsetFiles(part_header.node_prop_info_list(), part_dir_name));
-  part_header.set_node_prop_offset_files(std::move(node_offset_files));
-
-  auto edge_offset_files = KATANA_CHECKED(
-      GetOffsetFiles(part_header.edge_prop_info_list(), part_dir_name));
-  part_header.set_edge_prop_offset_files(std::move(edge_offset_files));
-
-  auto part_offset_files = KATANA_CHECKED(
-      GetOffsetFiles(part_header.part_prop_info_list(), part_dir_name));
-  part_header.set_part_prop_offset_files(std::move(part_offset_files));
-
   return part_header;
 }
 

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -101,16 +101,16 @@ RDGPartHeader::Make(const katana::Uri& partition_path) {
   auto part_dir_name = partition_path.DirName().string();
 
   // Iterate over properties and find any potential part files
-  auto node_offset_files =
-      KATANA_CHECKED(GetOffsetFiles(part_header.node_prop_info_list(), part_dir_name));
+  auto node_offset_files = KATANA_CHECKED(
+      GetOffsetFiles(part_header.node_prop_info_list(), part_dir_name));
   part_header.set_node_prop_offset_files(std::move(node_offset_files));
 
-  auto edge_offset_files =
-      KATANA_CHECKED(GetOffsetFiles(part_header.edge_prop_info_list(), part_dir_name));
+  auto edge_offset_files = KATANA_CHECKED(
+      GetOffsetFiles(part_header.edge_prop_info_list(), part_dir_name));
   part_header.set_edge_prop_offset_files(std::move(edge_offset_files));
 
-  auto part_offset_files =
-      KATANA_CHECKED(GetOffsetFiles(part_header.part_prop_info_list(), part_dir_name));
+  auto part_offset_files = KATANA_CHECKED(
+      GetOffsetFiles(part_header.part_prop_info_list(), part_dir_name));
   part_header.set_part_prop_offset_files(std::move(part_offset_files));
 
   return part_header;

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -97,22 +97,23 @@ RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
 
 katana::Result<RDGPartHeader>
 RDGPartHeader::Make(const katana::Uri& partition_path) {
-  katana::Result<RDGPartHeader> res = MakeJson(partition_path);
-  if (!res) {
-    return res.error();
-  }
+  auto part_header = KATANA_CHECKED(MakeJson(partition_path));
+  auto part_dir_name = partition_path.DirName().string();
 
   // Iterate over properties and find any potential part files
-  auto node_offset_files = KATANA_CHECKED(GetOffsetFiles(res.value().node_prop_info_list()));
-  res.value().set_node_prop_offset_files(std::move(node_offset_files));
+  auto node_offset_files =
+      KATANA_CHECKED(GetOffsetFiles(part_header.node_prop_info_list(), part_dir_name));
+  part_header.set_node_prop_offset_files(std::move(node_offset_files));
 
-  auto edge_offset_files = KATANA_CHECKED(GetOffsetFiles(res.value().edge_prop_info_list()));
-  res.value().set_edge_prop_offset_files(std::move(edge_offset_files));
+  auto edge_offset_files =
+      KATANA_CHECKED(GetOffsetFiles(part_header.edge_prop_info_list(), part_dir_name));
+  part_header.set_edge_prop_offset_files(std::move(edge_offset_files));
 
-  auto part_offset_files = KATANA_CHECKED(GetOffsetFiles(res.value().part_prop_info_list()));
-  res.value().set_part_prop_offset_files(std::move(part_offset_files));
+  auto part_offset_files =
+      KATANA_CHECKED(GetOffsetFiles(part_header.part_prop_info_list(), part_dir_name));
+  part_header.set_part_prop_offset_files(std::move(part_offset_files));
 
-  return res;
+  return part_header;
 }
 
 katana::Result<void>

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -97,8 +97,7 @@ RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
 
 katana::Result<RDGPartHeader>
 RDGPartHeader::Make(const katana::Uri& partition_path) {
-  auto part_header = KATANA_CHECKED(MakeJson(partition_path));
-  return part_header;
+  return KATANA_CHECKED(MakeJson(partition_path));
 }
 
 katana::Result<void>

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -283,21 +283,24 @@ public:
   const std::vector<std::string>& node_prop_offset_files() const {
     return node_prop_offset_files_;
   }
-  void set_node_prop_offset_files(std::vector<std::string>&& node_prop_offset_files) {
+  void set_node_prop_offset_files(
+      std::vector<std::string>&& node_prop_offset_files) {
     node_prop_offset_files_ = std::move(node_prop_offset_files);
   }
 
   const std::vector<std::string>& edge_prop_offset_files() const {
     return edge_prop_offset_files_;
   }
-  void set_edge_prop_offset_files(std::vector<std::string>&& edge_prop_offset_files) {
+  void set_edge_prop_offset_files(
+      std::vector<std::string>&& edge_prop_offset_files) {
     edge_prop_offset_files_ = std::move(edge_prop_offset_files);
   }
-  
+
   const std::vector<std::string>& part_prop_offset_files() const {
     return part_prop_offset_files_;
   }
-  void set_part_prop_offset_files(std::vector<std::string>&& part_prop_offset_files) {
+  void set_part_prop_offset_files(
+      std::vector<std::string>&& part_prop_offset_files) {
     part_prop_offset_files_ = std::move(part_prop_offset_files);
   }
 
@@ -496,15 +499,21 @@ private:
   }
 
   // Some property files are split up, so we make sure to keep track of all offset files
-  static katana::Result<std::vector<std::string>> GetOffsetFiles(const std::vector<PropStorageInfo>& storage_info) {
+  static katana::Result<std::vector<std::string>> GetOffsetFiles(
+      const std::vector<PropStorageInfo>& storage_info, std::string prop_dir_name) {
     std::vector<std::string> prop_offset_files;
     auto reader = KATANA_CHECKED(tsuba::ParquetReader::Make());
     for (const auto& prop : storage_info) {
-      auto uri_path = KATANA_CHECKED(katana::Uri::Make(prop.path()));
-      auto num_files = KATANA_CHECKED(reader->NumOffsetFiles(uri_path));
-      auto base_dir = uri_path.BaseName();
+      auto full_path = katana::Uri::JoinPath(prop_dir_name, prop.path());
+      auto uri_path = KATANA_CHECKED(katana::Uri::Make(full_path));
+      auto num_files = KATANA_CHECKED(reader->NumFiles(uri_path));
+      // num_files can be 1, which means there are no split property files
+      if (num_files == 1) {
+        continue;
+      }
       for (uint64_t i = 0; i < num_files; i++) {
-        auto file_name = katana::Uri::JoinPath(base_dir, fmt::format("{}.part_{:09}", prop.name(), i));
+        auto file_name = fmt::format("{}.part_{:09}", prop.path(), i);
+        // Let's keep things consistent and only keep track of the file name, not full path
         prop_offset_files.push_back(file_name);
       }
     }

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -17,7 +17,6 @@
 #include "katana/Result.h"
 #include "katana/URI.h"
 #include "tsuba/Errors.h"
-#include "tsuba/ParquetReader.h"
 #include "tsuba/PartitionMetadata.h"
 #include "tsuba/RDG.h"
 #include "tsuba/WriteGroup.h"
@@ -141,7 +140,6 @@ public:
 
   katana::Result<void> ValidateEntityTypeIDStructures() const;
   static bool IsPartitionFileUri(const katana::Uri& uri);
-
   // TODO(vkarthik): Move this somewhere else because this depends on the Parse function here. Might
   // need to reorganize all the parsing properly.
   static katana::Result<uint64_t> ParseHostFromPartitionFile(

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -500,7 +500,8 @@ private:
 
   // Some property files are split up, so we make sure to keep track of all offset files
   static katana::Result<std::vector<std::string>> GetOffsetFiles(
-      const std::vector<PropStorageInfo>& storage_info, std::string prop_dir_name) {
+      const std::vector<PropStorageInfo>& storage_info,
+      std::string prop_dir_name) {
     std::vector<std::string> prop_offset_files;
     auto reader = KATANA_CHECKED(tsuba::ParquetReader::Make());
     for (const auto& prop : storage_info) {


### PR DESCRIPTION
This PR fixes the bug where split property files were not being copied over during a `CopyRDGOperation`. This was occurring because the RDGManifest only had information for the property file, but excluded the split property files if they existed. This PR tackles this issue by checking to see whether a given property file contains offset mappings or not and then save those file names to be returned later on. 

JIRA: https://katanagraph.atlassian.net/browse/KAT-1892