### PR TITLE
tsuba: make sure new single-partion rdgs are readable by enterprise

### DIFF
--- a/libtsuba/include/tsuba/FileFrame.h
+++ b/libtsuba/include/tsuba/FileFrame.h
@@ -76,6 +76,11 @@ public:
     return reinterpret_cast<T*>(map_start_); /* NOLINT */
   }
 
+  /// only data up to cursor is written out, flavors of Write
+  /// automatically track this, so SetCursor is only useful when
+  /// treating the FileFrame like a buffer (e.g., using ptr())
+  katana::Result<void> SetCursor(uint64_t new_cursor);
+
   const std::string& path() const { return path_; }
 
   ///// Begin arrow::io::BufferOutputStream methods ///////

--- a/libtsuba/src/FileFrame.cpp
+++ b/libtsuba/src/FileFrame.cpp
@@ -137,6 +137,15 @@ FileFrame::PersistAsync() {
   return tsuba::FileStoreAsync(path_, map_start_, cursor_);
 }
 
+katana::Result<void>
+FileFrame::SetCursor(uint64_t new_cursor) {
+  if (new_cursor > map_size_) {
+    KATANA_CHECKED(GrowBuffer(new_cursor - map_size_));
+  }
+  cursor_ = new_cursor;
+  return katana::ResultSuccess();
+}
+
 /////// Begin arrow::io::BufferOutputStream method definitions //////
 
 arrow::Status

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -205,15 +205,6 @@ RDGCore::EnsureEdgeTypesLoaded() {
 }
 
 void
-tsuba::RDGCore::InitArrowVectors() {
-  // Create an empty array, accessed by Distribution during loading
-  host_to_owned_global_node_ids_ = katana::NullChunkedArray(arrow::uint64(), 0);
-  host_to_owned_global_edge_ids_ = katana::NullChunkedArray(arrow::uint64(), 0);
-  local_to_user_id_ = katana::NullChunkedArray(arrow::uint64(), 0);
-  local_to_global_id_ = katana::NullChunkedArray(arrow::uint64(), 0);
-}
-
-void
 RDGCore::InitEmptyProperties() {
   std::vector<std::shared_ptr<arrow::Array>> empty;
   node_properties_ = arrow::Table::Make(arrow::schema({}), empty, 0);

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -13,14 +13,10 @@ namespace tsuba {
 
 class KATANA_EXPORT RDGCore {
 public:
-  RDGCore() {
-    InitEmptyProperties();
-    InitArrowVectors();
-  }
+  RDGCore() : RDGCore(RDGPartHeader{}) {}
 
   RDGCore(RDGPartHeader&& part_header) : part_header_(std::move(part_header)) {
     InitEmptyProperties();
-    InitArrowVectors();
   }
 
   bool Equals(const RDGCore& other) const;
@@ -206,7 +202,8 @@ public:
 
   katana::Result<void> RegisterTopologyFile(const std::string& new_top) {
     part_header_.set_topology_path(new_top);
-    return topology_file_storage_.Unbind();
+    return topology_file_storage_.Bind(
+        rdg_dir_.Join(new_top).string(), /*resolve =*/false);
   }
 
   katana::Result<void> UnbindTopologyFile() {
@@ -248,9 +245,6 @@ private:
 
   std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
   std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
-  // Called while constructing to put these arrays into a usable state for
-  // Distribution
-  void InitArrowVectors();
   std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
   std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_edge_ids_;
   std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;


### PR DESCRIPTION
Tweaks to tsuba and graph-convert to prove that we can successfully
store a single partition RDG here that is readable when distributed.

This requires tweaks in Enterprise (and there is a test added there to
prove this works/prevent regressions).

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>