### PR TITLE
Fix: RDGSlice accounts for header in entity type storage

### DIFF
--- a/libtsuba/include/tsuba/RDGPrefix.h
+++ b/libtsuba/include/tsuba/RDGPrefix.h
@@ -52,6 +52,15 @@ private:
   static katana::Result<RDGPrefix> DoMakePrefix(const RDGManifest& manifest);
 };
 
+/// EntityTypeIDArrayHeader describes the header in the on disk representation
+/// of EntityTypeID arrays, it could be probably be rolled into RDGPrefix but it
+/// has slightly different uses so for now it is separate
+struct EntityTypeIDArrayHeader {
+  // NB: we could add __attribute__((packed)) or similar, but with only one
+  // member it should be fine for now
+  uint64_t size;
+};
+
 }  // namespace tsuba
 
 #endif


### PR DESCRIPTION
RDGSlice treats the entity type id array storage as a binary array on
disk (i.e. mmap file, cast to pointer, now you have an array). In fact,
the on disk format contains a 8 byte header that contains the size
of the array that follows (i.e. mmap file, offset by 8, cast to pointer,
now you have an array of length <first 8 bytes of file interpreted as
uint64_t>). Modify RDGSlice to ignore that header and offset all of its
math by 8 bytes.

It would be nice to have a more consistent treatment of this offset than
the hard-coded one-off ignoring in this commit. But RDG doesn't
do any accounting for the header and PropertyGraph does, so it isn't
clear where we could centralize our handling.

JIRA: KAT-2029