### PR TITLE
graphml: expose interface that allows for in-memory data

### DIFF
--- a/libgalois/include/katana/GraphML.h
+++ b/libgalois/include/katana/GraphML.h
@@ -1,6 +1,8 @@
 #ifndef KATANA_LIBGALOIS_KATANA_GRAPHML_H_
 #define KATANA_LIBGALOIS_KATANA_GRAPHML_H_
 
+#include <libxml/xmlreader.h>
+
 #include "katana/BuildGraph.h"
 
 namespace katana {
@@ -18,6 +20,19 @@ namespace katana {
 KATANA_EXPORT katana::Result<katana::GraphComponents> ConvertGraphML(
     const std::string& infilename, size_t chunk_size = 25000,
     bool verbose = false);
+
+/// ConvertGraphML converts a GraphML file into katana form
+///
+/// \param reader xml text reader object for the document
+/// \param chunk_size Chunk size for in memory representations during conversion.
+///     Generally this term can be ignored, but it can be decreased to reduce
+///     memory usage when converting large inputs
+/// \param verbose If true, print graph data to the standard out while
+///     converting.
+/// \returns A collection of Arrow tables of node properties/labels, edge
+///     properties/types, and CSR topology
+KATANA_EXPORT katana::Result<katana::GraphComponents> ConvertGraphML(
+    xmlTextReaderPtr reader, size_t chunk_size = 25000, bool verbose = false);
 
 }  // end namespace katana
 

--- a/libgalois/include/katana/GraphTopology.h
+++ b/libgalois/include/katana/GraphTopology.h
@@ -1537,7 +1537,7 @@ private:
       const std::vector<std::string>& edge_properties) noexcept;
 };
 
-/// Creates a uniform-random CSR GrpahTopology instance, where each node as
+/// Creates a uniform-random CSR GraphTopology instance, where each node as
 ///'edges_per_node' neighbors, chosen randomly
 /// \p num_nodes number of nodes
 /// \p edges_per_node number of out-going edges of each node

--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -174,6 +174,9 @@ public:
         const std::shared_ptr<arrow::Table>& props);
     Result<void> (PropertyGraph::*remove_property_int)(int i);
     Result<void> (PropertyGraph::*remove_property_str)(const std::string& str);
+    Result<void> (PropertyGraph::*ensure_loaded_property_fn)(
+        const std::string& str);
+    Result<void> (PropertyGraph::*unload_property_fn)(const std::string& str);
 
     std::shared_ptr<arrow::Schema> loaded_schema() const {
       return ropv.loaded_schema();
@@ -210,6 +213,14 @@ public:
     }
     Result<void> RemoveProperty(const std::string& str) const {
       return (g->*remove_property_str)(str);
+    }
+
+    Result<void> EnsurePropertyLoaded(const std::string& str) const {
+      return (g->*ensure_loaded_property_fn)(str);
+    }
+
+    Result<void> UnloadProperty(const std::string& str) const {
+      return (g->*unload_property_fn)(str);
     }
   };
 
@@ -712,6 +723,8 @@ public:
         .upsert_properties_fn = &PropertyGraph::UpsertNodeProperties,
         .remove_property_int = &PropertyGraph::RemoveNodeProperty,
         .remove_property_str = &PropertyGraph::RemoveNodeProperty,
+        .ensure_loaded_property_fn = &PropertyGraph::EnsureNodePropertyLoaded,
+        .unload_property_fn = &PropertyGraph::UnloadNodeProperty,
     };
   }
   ReadOnlyPropertyView NodeReadOnlyPropertyView() const {
@@ -741,6 +754,8 @@ public:
         .upsert_properties_fn = &PropertyGraph::UpsertEdgeProperties,
         .remove_property_int = &PropertyGraph::RemoveEdgeProperty,
         .remove_property_str = &PropertyGraph::RemoveEdgeProperty,
+        .ensure_loaded_property_fn = &PropertyGraph::EnsureEdgePropertyLoaded,
+        .unload_property_fn = &PropertyGraph::UnloadEdgeProperty,
     };
   }
   ReadOnlyPropertyView EdgeReadOnlyPropertyView() const {


### PR DESCRIPTION
The above eases testing.

Also: expose property management functions in the view structs of
PropertyGrpah.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>

JIRA: KAT-1823