### PR TITLE
Allow any column name in property Parquet files

### DIFF
--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -38,7 +38,8 @@ DoLoadProperties(
   auto renamed = out->RenameColumns({expected_name});
   if (!renamed.ok()) {
     std::shared_ptr<arrow::Schema> schema = out->schema();
-    return KATANA_ERROR(tsuba::ErrorCode::InvalidArgument, "{}", renamed.status().ToString());
+    return KATANA_ERROR(
+        tsuba::ErrorCode::InvalidArgument, "{}", renamed.status().ToString());
   }
   return renamed.ValueOrDie();
 }

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -35,19 +35,12 @@ DoLoadProperties(
 
   std::shared_ptr<arrow::Table> out = std::move(out_res.value());
 
-  std::shared_ptr<arrow::Schema> schema = out->schema();
-  if (schema->num_fields() != 1) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::InvalidArgument, "expected 1 field found {} instead",
-        schema->num_fields());
+  auto renamed = out->RenameColumns({expected_name});
+  if (!renamed.ok()) {
+    std::shared_ptr<arrow::Schema> schema = out->schema();
+    return KATANA_ERROR(tsuba::ErrorCode::InvalidArgument, "{}", renamed.status().ToString());
   }
-
-  if (schema->field(0)->name() != expected_name) {
-    return KATANA_ERROR(
-        tsuba::ErrorCode::InvalidArgument, "expected {} found {} instead",
-        expected_name, schema->field(0)->name());
-  }
-  return out;
+  return renamed.ValueOrDie();
 }
 
 }  // namespace


### PR DESCRIPTION
Hi,
With this change I'm able to use the same Parquet files in a new RDG version under a new name.
I'm not sure about the C++. `ValueOrDie` sounds scary, but it's after the `ok()` check. Is there a better way?