### PR TITLE
python: Reset busy wait / burnPower value

### DIFF
--- a/config/sanitizers/ubsan_blacklist.txt.in
+++ b/config/sanitizers/ubsan_blacklist.txt.in
@@ -1,3 +1,10 @@
 [undefined]
 src:*/include/c\+\+/*/chrono
 src:*/include/c\+\+/*/experimental/chrono
+
+# How cython generates vtables results in undefined behavior like:
+#
+#     python/katana/local/_graph.cpp:6830:13: runtime error:
+#       call to function [...] through pointer to incorrect function type [...]
+#
+src:*python/katana/local/*.cpp

--- a/libgalois/include/katana/ThreadPool.h
+++ b/libgalois/include/katana/ThreadPool.h
@@ -52,9 +52,9 @@ struct ExecuteTupleImpl<tpl, s, 0> {
 namespace katana {
 
 class KATANA_EXPORT ThreadPool {
+private:
   friend class SharedMem;
 
-protected:
   struct shutdown_ty {};  //! type for shutting down thread
   struct fastmode_ty {
     bool mode;
@@ -169,8 +169,6 @@ public:
   void burnPower(unsigned num);
   // experimental: leave busy wait
   void beKind();
-
-  bool isRunning() const { return running; }
 
   //! return the number of non-reserved threads in the pool
   unsigned getMaxUsableThreads() const { return mi.maxThreads - reserved; }

--- a/libgalois/src/ThreadPool.cpp
+++ b/libgalois/src/ThreadPool.cpp
@@ -41,7 +41,7 @@ thread_local ThreadPool::per_signal ThreadPool::my_box;
 ThreadPool::ThreadPool()
     : mi(getHWTopo().machineTopoInfo),
       reserved(0),
-      masterFastmode(false),
+      masterFastmode(0),
       running(false) {
   signals.resize(mi.maxThreads);
   initThread(0);
@@ -238,7 +238,9 @@ ThreadPool::runInternal(unsigned num) {
   me.wbegin = 1;
   me.wend = num;
 
-  KATANA_LOG_DEBUG_ASSERT(!masterFastmode || masterFastmode == num);
+  KATANA_LOG_VASSERT(
+      !masterFastmode || masterFastmode == num,
+      "fastmode threads {} != num threads {}", masterFastmode, num);
   // launch threads
   cascade(masterFastmode);
   // Do master thread work

--- a/python/test/benchmarking/bench_python_cpp_algos.py
+++ b/python/test/benchmarking/bench_python_cpp_algos.py
@@ -35,6 +35,15 @@ def time_block(run_name, time_data):
     time_data[run_name] = round(1000 * (timer_algo_end - timer_algo_start))
 
 
+@contextlib.contextmanager
+def busy_wait(enabled):
+    if enabled:
+        katana.set_busy_wait()
+    yield
+    if enabled:
+        katana.set_busy_wait(0)
+
+
 def check_schema(graph: Graph, property_name):
     node_schema: Schema = graph.loaded_node_schema()
     num_node_properties = len(node_schema)
@@ -331,9 +340,12 @@ def tc(graph: Graph, _input_args):
 def run_all_gap(args):
     katana.local.initialize()
     print("Using threads:", katana.set_active_threads(args.threads))
-    if args.thread_spin:
-        katana.set_busy_wait()
 
+    with busy_wait(args.thread_spin):
+        return _run_all_gap(args)
+
+
+def _run_all_gap(args):
     inputs = [
         {
             "name": "GAP-road",
@@ -465,7 +477,6 @@ def run_all_gap(args):
 
 
 def main(parsed_args):
-
     run_all_gap(parsed_args)
 
 

--- a/python/test/test_algo_bench.py
+++ b/python/test/test_algo_bench.py
@@ -5,7 +5,6 @@ import test.benchmarking.bench_python_cpp_algos
 from pytest import approx
 
 from katana.example_data import get_input
-from katana.local import Graph
 
 
 def generate_args(
@@ -177,7 +176,7 @@ def run_single_test(arguments):
     args = generate_args(**arguments)
     ground_truth = test.benchmarking.bench_python_cpp_algos.create_empty_statistics(args)
     output_tuple = test.benchmarking.bench_python_cpp_algos.run_all_gap(args)
-    assert output_tuple.write_success, "Writing JSON statistics to disc failed!"
+    assert output_tuple.write_success, "Writing JSON statistics to disk failed!"
     assert_types_match(ground_truth, output_tuple.time_write_data)
     for subroutine in output_tuple.time_write_data["routines"]:
         assert_routine_output(output_tuple.time_write_data["routines"][subroutine])


### PR DESCRIPTION
Without resetting, the leaked value interferes with manual changes of
the number of active threads, which is quite common in tests. Promote
the debug build assert to an always on assertion as inconsistencies in
the number of threads is dangerous.

Along the way, be aggressive about hiding private state of ThreadPool.

Context: I am running tests with debug and sanitizer on and need fixes like this.