### PR TITLE
ToArrayVisitor: fix null bug

### DIFF
--- a/libsupport/src/ArrowVisitor.cpp
+++ b/libsupport/src/ArrowVisitor.cpp
@@ -152,6 +152,7 @@ struct ToArrayVisitor : public katana::ArrowVisitor {
 
   template <typename ArrowType, typename BuilderType>
   arrow::enable_if_null<ArrowType, ResultType> Call(BuilderType* builder) {
+    KATANA_CHECKED(builder->AppendNulls(scalars.size()));
     return KATANA_CHECKED(builder->Finish());
   }
 

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -17,6 +17,7 @@ function(add_unit_test name)
 endfunction()
 
 add_unit_test(arrow)
+add_unit_test(array-from-scalars)
 add_unit_test(bitmath)
 add_unit_test(cache)
 add_unit_test(env)

--- a/libsupport/test/array-from-scalars.cpp
+++ b/libsupport/test/array-from-scalars.cpp
@@ -1,0 +1,37 @@
+#include <arrow/type_fwd.h>
+
+#include "katana/ArrowVisitor.h"
+#include "katana/Result.h"
+
+namespace {
+
+constexpr int NUM_ENTRIES = 10;
+
+katana::Result<void>
+TestNulls() {
+  std::vector<std::shared_ptr<arrow::Scalar>> scalars(NUM_ENTRIES);
+  std::shared_ptr<arrow::Array> array =
+      KATANA_CHECKED(katana::ArrayFromScalars(scalars, arrow::null()));
+  // NB: length() is signed, size() is not - but they should both have small
+  // enough values that it doesn't matter
+  KATANA_LOG_VASSERT(
+      static_cast<size_t>(array->length()) == scalars.size(),
+      "array length: {}, vector size: {}", array->length(), scalars.size());
+  KATANA_LOG_ASSERT(array->length() == array->null_count());
+  KATANA_LOG_ASSERT(array->null_count() == NUM_ENTRIES);
+  return katana::ResultSuccess();
+}
+
+katana::Result<void>
+TestAll() {
+  KATANA_CHECKED(TestNulls());
+  return katana::ResultSuccess();
+}
+
+}  // namespace
+
+int
+main() {
+  KATANA_LOG_ASSERT(TestAll());
+  return 0;
+}


### PR DESCRIPTION
If the DataType passed to ToArrayVisitor is null, it
finishes the empty array builder and returns. It should first append the
correct number of nulls because part of its contract is that the output
array will have the same length as the input vector.