### PR TITLE
Force safe uses of fmt

### DIFF
--- a/libsupport/include/katana/Logging.h
+++ b/libsupport/include/katana/Logging.h
@@ -121,7 +121,7 @@ KATANA_EXPORT void AbortApplication [[noreturn]] ();
     if (!(cond)) {                                                             \
       ::katana::LogLine(                                                       \
           ::katana::LogLevel::Error, __FILE__, __LINE__,                       \
-          "assertion not true: {}", #cond);                                    \
+          FMT_STRING("assertion not true: {}"), #cond);                        \
       ::katana::AbortApplication();                                            \
     }                                                                          \
   } while (0)

--- a/libsupport/include/katana/Logging.h
+++ b/libsupport/include/katana/Logging.h
@@ -121,7 +121,7 @@ KATANA_EXPORT void AbortApplication [[noreturn]] ();
     if (!(cond)) {                                                             \
       ::katana::LogLine(                                                       \
           ::katana::LogLevel::Error, __FILE__, __LINE__,                       \
-          FMT_STRING("assertion not true: {}"), #cond);                        \
+          "assertion not true: {}", #cond);                                    \
       ::katana::AbortApplication();                                            \
     }                                                                          \
   } while (0)


### PR DESCRIPTION
With: https://github.com/KatanaGraph/katana-enterprise/pull/2277

This forces the use of `FMT_STRING` in all uses of `KATANA_CHECKED`. There is a catch: `KATANA_CHECKED` was effectively overloaded since the function it called with `__VA_ARGS__` is overloaded (`WithContext`). Because of this, safety forced me to add a new macro `KATANA_CHECKED_ERROR_CODE` which handles the overload where the error code is replaced. This macro is not used in the open repo, but is used in enterprise (in libquery).