### PR TITLE
make projected topology copyable

### DIFF
--- a/libgalois/include/katana/GraphTopology.h
+++ b/libgalois/include/katana/GraphTopology.h
@@ -666,7 +666,6 @@ public:
   ProjectedTopology(ProjectedTopology&&) = default;
   ProjectedTopology& operator=(ProjectedTopology&&) = default;
 
-  ProjectedTopology(const ProjectedTopology&) = delete;
   ProjectedTopology& operator=(const ProjectedTopology&) = delete;
 
   uint64_t num_nodes() const noexcept { return adj_indices_.size(); }


### PR DESCRIPTION
This PR makes the projected topolgy copyable. This is required for distributed graph views.