### PR TITLE
[KAT-1779] Progress on running tests with NUMBA_DISABLE_JIT

### DIFF
--- a/python/katana/_loops.pyx.jinja
+++ b/python/katana/_loops.pyx.jinja
@@ -326,7 +326,7 @@ elif isinstance(func, katana.native_interfacing.closure.Closure):
     cb_{{loop_variable_type}} = <{{loop_type}}_operator_type_{{loop_variable_type}}><unsigned long int>(func.__function_address__)
     userdata = <void*><unsigned long int>(func.__userdata_address__)
 elif callable(func):
-    _logger.info("PERFORMANCE WARNING: Using Python callable in Galois loop: %s", getattr(func, "__name__", "<unknown function>"))
+    _logger.info("PERFORMANCE WARNING: Using Python callable in Katana loop: %s", getattr(func, "__name__", "<unknown function>"))
     cb_{{loop_variable_type}} = <{{loop_type}}_operator_type_{{loop_variable_type}}>&wrap_python_callable_{{loop_type}}_operator_{{loop_variable_type}}
     function_and_dtype = FunctionAndDtype(func, dtype)
     userdata = <void*>function_and_dtype

--- a/python/katana/local/datastructures.pyx.jinja
+++ b/python/katana/local/datastructures.pyx.jinja
@@ -195,7 +195,7 @@ cdef class {{class_name}}:
             else:
                 raise TypeError("Policy must be an AllocationPolicy")
 
-    def __setitem__(self, uint64_t i,  v):
+    def __setitem__(self, uint64_t i, v):
         """
         `self[i] = v`
 
@@ -225,6 +225,12 @@ cdef class {{class_name}}:
         {% else %}
         return v
         {% endif %}
+
+    def get(self, i):
+        return self[i]
+
+    def set(self, i, v):
+        self[i] = v
 
     def __len__(self):
         """
@@ -292,9 +298,11 @@ cdef class {{class_name}}:
 
         Return a numpy array that is a view on self.
         """
-        return np.lib.stride_tricks.as_strided(np.frombuffer(self, dtype=self.dtype),
-                                               shape=(len(self),),
-                                               strides=(sizeof({{inst.element_c_type}}),))
+        return np.rec.array(
+                    np.lib.stride_tricks.as_strided(np.frombuffer(self, dtype=self.dtype),
+                                                    shape=(len(self),),
+                                                    strides=(sizeof({{inst.element_c_type}}),)),
+                    copy=False)
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         self._check_allocated()

--- a/python/katana/native_interfacing/katana_compiler.py
+++ b/python/katana/native_interfacing/katana_compiler.py
@@ -57,30 +57,3 @@ def constant_function_pointer(context, builder: ir.IRBuilder, ty, pyval):
         return ir.Constant(ir.types.IntType(64), ty.get_pointer(pyval)).inttoptr(ptrty)
     # If we are not in an operator context (as defined by OperatorCompiler use) then call the numba implementation
     return numba.cpython.builtins.constant_function_pointer(context, builder, ty, pyval)
-
-
-# TODO: This is duplicated from numba to allow pipeline_class to be passed through. This should be merged upstream.
-def cfunc(sig, local_vars=None, cache=False, pipeline_class=compiler.Compiler, **options):
-    """
-    This decorator is used to compile a Python function into a C callback
-    usable with foreign C libraries.
-
-    Usage::
-        @cfunc("float64(float64, float64)", nopython=True, cache=True)
-        def add(a, b):
-            return a + b
-
-    """
-    sig = sigutils.normalize_signature(sig)
-    local_vars = local_vars or {}
-
-    def wrapper(func):
-        from numba.core.ccallback import CFunc
-
-        res = CFunc(func, sig, locals=local_vars, options=options, pipeline_class=pipeline_class)
-        if cache:
-            res.enable_caching()
-        res.compile()
-        return res
-
-    return wrapper

--- a/python/test/test_datastructures.py
+++ b/python/test/test_datastructures.py
@@ -179,8 +179,6 @@ def test_NUMAArray_numpy(typ):
     arr[1:4] = 1
     assert list(arr) == [10, 1, 1, 1, 10]
     assert list(larr) == [10, 1, 1, 1, 10]
-    # TODO: Ideally one level of .base would get us there, but it doesn't really matter
-    assert arr.base.base.base is larr
     assert arr.shape == (5,)
     with pytest.raises(IndexError):
         arr[10] = 0
@@ -199,6 +197,24 @@ def test_NUMAArray_numpy_parallel(typ):
 
     do_all(range(1000), f(arr.as_numpy()), steal=False)
     assert list(arr) == list(range(1, 1001))
+
+
+def test_NUMAArray_numpy_opaque():
+    dt = np.dtype([("x", np.float32), ("y", np.int16)], align=True)
+    T = NUMAArray[dt]
+    arr = T()
+    arr.allocateInterleaved(1000)
+
+    arr[0].x = -1
+    arr[0].y = -1
+    nparr = arr.as_numpy()
+    assert nparr[0].x == -1
+    assert nparr[0].y == -1
+
+    nparr[0].x = -2
+    nparr[0].y = -2
+    assert arr[0].x == -2
+    assert arr[0].y == -2
 
 
 def test_NUMAArray_numpy_parallel_opaque():

--- a/python/test/test_loops.py
+++ b/python/test/test_loops.py
@@ -143,6 +143,8 @@ def test_do_all_specific_type(modes, typ):
     assert np.allclose(out, np.array(range(1000)))
     if not numba.config.DISABLE_JIT:
         # Check that the operator was actually compiled for the correct type
+        # [0][1][0] = [first overload][second argument][first possible type]
+        # I'm not sure why the last indexing is used. It always seems to be a 1-tuple, but numba makes it. *shrug*
         assert list(f.inspect_llvm().keys())[0][1][0] == from_dtype(np.dtype(typ))
 
 


### PR DESCRIPTION
This makes it so the core library works correctly when the Numba JIT is disabled. However, tests will fail because the APIs of some types is different in JIT and non-JIT mode. Which was a big mistake on my part. :-/

The goal of this is to eventually enable better coverage, which is important, but not critical, so I'm going to commit this and stop trying to make it better. We can finish it later.

JIRA: KAT-1779