### PR TITLE
tsuba: fix missing header

### DIFF
--- a/libtsuba/include/tsuba/PartitionMetadata.h
+++ b/libtsuba/include/tsuba/PartitionMetadata.h
@@ -9,8 +9,8 @@ namespace tsuba {
 struct PartitionMetadata {
   uint32_t policy_id_{0};
   bool transposed_{false};
-  bool is_outgoing_edge_cut_{false};
-  bool is_incoming_edge_cut_{false};
+  bool is_outgoing_edge_cut_{false};  // TODO(thunt) deprecated
+  bool is_incoming_edge_cut_{false};  // TODO(thunt) deprecated
   uint64_t num_global_nodes_{0UL};
   uint64_t max_global_node_id_{0UL};
   uint64_t num_global_edges_{0UL};

--- a/libtsuba/include/tsuba/PropertyCache.h
+++ b/libtsuba/include/tsuba/PropertyCache.h
@@ -1,6 +1,8 @@
 #ifndef KATANA_LIBTSUBA_TSUBA_PROPERTYCACHE_H_
 #define KATANA_LIBTSUBA_TSUBA_PROPERTYCACHE_H_
 
+#include <arrow/api.h>
+
 #include "katana/Cache.h"
 
 namespace tsuba {


### PR DESCRIPTION
When debugging a missing header I found that `PropertyCache` was missing
an arrow inclusion.

Also these fields in PartitionMetadata can be easily inferred from the
policy so mark them as deprecated because I intend to change enterprise
to do that.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>