### PR TITLE
Fix potential overflow in RDGTopology GetGraphSize

### DIFF
--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -191,7 +191,10 @@ public:
   /// Marks the topologies storage as valid, since we are just telling the
   /// RDG about where the topology is located and not actually loading it for use.
   /// \param new_top must exist and be in the correct directory for this RDG but it need not be writable
-  katana::Result<void> AddCSRTopologyByFile(const katana::Uri& new_top);
+  /// \param num_nodes is the number of nodes in the topology file, used for validation
+  /// \param num_edges is the number of edges in the topology file, used for validation
+  katana::Result<void> AddCSRTopologyByFile(
+      const katana::Uri& new_top, uint64_t num_nodes, uint64_t num_edges);
 
   /// Ask this RDG if it has a topology matching the fields in shadow
   /// If it does, the RDG returns the topology

--- a/libtsuba/include/tsuba/RDGTopology.h
+++ b/libtsuba/include/tsuba/RDGTopology.h
@@ -203,7 +203,8 @@ public:
   /// bool storage_valid: whether this topology should be written out
   /// to a file on Store. Used by graph-convert, where we don't load the
   /// entire topology file into memory.
-  katana::Result<void> MapMetadataExtract(bool storage_valid = false);
+  katana::Result<void> MapMetadataExtract(
+      uint64_t num_nodes, uint64_t num_edges, bool storage_valid = false);
 
   katana::Result<void> DoStore(
       RDGHandle handle, std::unique_ptr<tsuba::WriteGroup>& write_group);
@@ -309,7 +310,7 @@ private:
       TransposeKind transpose_state, EdgeSortKind edge_sort_state,
       NodeSortKind node_sort_state);
 
-  constexpr uint64_t GetGraphSize() const;
+  size_t GetGraphSize() const;
 
   // Topology File Offset Definitions
   static constexpr size_t version_num_offset = 0;

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -981,14 +981,16 @@ tsuba::RDG::set_local_to_global_id(
 }
 
 katana::Result<void>
-tsuba::RDG::AddCSRTopologyByFile(const katana::Uri& new_top) {
+tsuba::RDG::AddCSRTopologyByFile(
+    const katana::Uri& new_top, uint64_t num_nodes, uint64_t num_edges) {
   katana::Uri dir = new_top.DirName();
   if (dir != rdg_dir()) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument,
         "new topology file must be in this RDG's directory ({})", rdg_dir());
   }
-  return core_->RegisterCSRTopologyFile(new_top.BaseName(), rdg_dir());
+  return core_->RegisterCSRTopologyFile(
+      new_top.BaseName(), rdg_dir(), num_nodes, num_edges);
 }
 
 katana::Result<tsuba::RDGTopology*>

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -209,7 +209,9 @@ public:
     if (!part_header_.IsMetadataOutsideTopologyFile()) {
       // need to bind & map topology file now to extract the metadata
       KATANA_CHECKED_CONTEXT(
-          topology_manager_.ExtractMetadata(metadata_dir),
+          topology_manager_.ExtractMetadata(
+              metadata_dir, part_header_.metadata().num_nodes_,
+              part_header_.metadata().num_edges_),
           "Extracting metadata from previous format topology file");
     }
 
@@ -235,7 +237,8 @@ public:
   /// Marks the topologies storage as valid, since we are just telling the
   /// RDG about where the topology is located and not actually loading it for use.
   katana::Result<void> RegisterCSRTopologyFile(
-      const std::string& new_topo_path, const katana::Uri& rdg_dir) {
+      const std::string& new_topo_path, const katana::Uri& rdg_dir,
+      uint64_t num_nodes, uint64_t num_edges) {
     // get the topology a metadata entry and add it to our entries set
     part_header_.MakePartitionTopologyMetadataEntry(new_topo_path);
 
@@ -246,7 +249,8 @@ public:
 
     // get the metadata we need from the topology file
     KATANA_CHECKED_CONTEXT(
-        topology_manager_.ExtractMetadata(rdg_dir, /*storage_valid=*/true),
+        topology_manager_.ExtractMetadata(
+            rdg_dir, num_nodes, num_edges, /*storage_valid=*/true),
         "Extracting metadata from previous format topology file");
     return katana::ResultSuccess();
   }

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -254,7 +254,8 @@ public:
       PartitionTopologyMetadataEntry entry =
           topology_metadata()->Entries().at(i);
       if (entry.topology_state_ == tsuba::RDGTopology::TopologyKind::kCSR &&
-          entry.transpose_state_ == tsuba::RDGTopology::TransposeKind::kNo &&
+          (entry.transpose_state_ == tsuba::RDGTopology::TransposeKind::kYes ||
+           entry.transpose_state_ == tsuba::RDGTopology::TransposeKind::kNo) &&
           entry.edge_sort_state_ == tsuba::RDGTopology::EdgeSortKind::kAny &&
           entry.node_sort_state_ == tsuba::RDGTopology::NodeSortKind::kAny) {
         return topology_metadata()->Entries().at(i).path_;

--- a/libtsuba/src/RDGTopologyManager.h
+++ b/libtsuba/src/RDGTopologyManager.h
@@ -60,7 +60,8 @@ public:
   /// *ONLY USE THIS FOR BACKWARDS COMPATIBILITY*
   /// bool storage_valid: used to control whether this topology should be written out on store. If storage is valid, no need to write the topology out to a file.
   katana::Result<void> ExtractMetadata(
-      const katana::Uri& metadata_dir, bool storage_valid = false) {
+      const katana::Uri& metadata_dir, uint64_t num_nodes, uint64_t num_edges,
+      bool storage_valid = false) {
     KATANA_LOG_WARN(
         "Extracting metadata from csr topology. Store the graph to avoid this "
         "(small) overhead");
@@ -79,7 +80,7 @@ public:
         topology->Bind(metadata_dir, 0, 4, true),
         "binding previous format topology file");
     KATANA_CHECKED_CONTEXT(
-        topology->MapMetadataExtract(storage_valid),
+        topology->MapMetadataExtract(num_nodes, num_edges, storage_valid),
         "mapping previous format topology file");
     KATANA_CHECKED_CONTEXT(
         topology->unbind_file_storage(),

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -2919,7 +2919,9 @@ struct Gr2Kg : public Conversion {
 
     tsuba::RDG rdg;
     rdg.set_rdg_dir(tsuba::GetRDGDir(handle));
-    if (auto res = rdg.AddCSRTopologyByFile(top_file_name); !res) {
+    if (auto res = rdg.AddCSRTopologyByFile(
+            top_file_name, header.num_nodes, header.num_edges);
+        !res) {
       return res.error();
     }
     auto node_types = std::make_unique<tsuba::FileFrame>();


### PR DESCRIPTION
- improve error message when graph is not the expected size
- use num_nodes/edges from header as validation when extracting topology metadata

JIRA: KAT-2110