### PR TITLE
Respect Clang 12 warnings

### DIFF
--- a/cmake/Modules/BuildCommon.cmake
+++ b/cmake/Modules/BuildCommon.cmake
@@ -183,7 +183,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-copy>")
   endif ()
 
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 12)
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Werror>")
   endif ()
 endif ()

--- a/cmake/Modules/BuildCommon.cmake
+++ b/cmake/Modules/BuildCommon.cmake
@@ -183,7 +183,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-copy>")
   endif ()
 
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 12)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Werror>")
   endif ()
 endif ()


### PR DESCRIPTION
Without this change, `clang-12` warnings were not treated as errors after we changed to 12-only builds in CI.