### PR TITLE
Safer API for slices in ParquetReader

### DIFF
--- a/libtsuba/include/tsuba/ParquetReader.h
+++ b/libtsuba/include/tsuba/ParquetReader.h
@@ -26,11 +26,7 @@ public:
   struct ReadOpts {
     /// if true (default) make sure canonical types are used and table columns
     /// are not chunked
-    bool make_cannonical{true};
-
-    /// if provided, slice the resulting table so that it only contains
-    /// Slice.length rows starting from Slice.offset
-    std::optional<Slice> slice{std::nullopt};
+    bool make_canonical{true};
 
     static ReadOpts Defaults() { return ReadOpts{}; }
   };
@@ -45,16 +41,16 @@ public:
   /// read table from storage
   ///   \param uri an identifier for a parquet file
   katana::Result<std::shared_ptr<arrow::Table>> ReadTable(
-      const katana::Uri& uri);
+      const katana::Uri& uri, std::optional<Slice> slice = std::nullopt);
 
   /// read part of a table from storage
-  /// n.b. support for the `slice` read option is missing here
   ///   \param uri an identifier for a parquet file
   ///   \param column_bitmap must have the same length as the number of columns
   ///      in the table in the parquet file. The loaded table will only contain
   ///      columns at indexes that are true in the bitmap
   katana::Result<std::shared_ptr<arrow::Table>> ReadTable(
-      const katana::Uri& uri, const std::vector<int32_t>& column_bitmap);
+      const katana::Uri& uri, const std::vector<int32_t>& column_bitmap,
+      std::optional<Slice> slice = std::nullopt);
 
   /// read only the schema from a parquet file in storage
   katana::Result<std::shared_ptr<arrow::Schema>> GetSchema(
@@ -81,8 +77,7 @@ public:
   katana::Result<std::vector<std::string>> GetFiles(const katana::Uri& uri);
 
 private:
-  ParquetReader(std::optional<Slice> slice, bool make_cannonical)
-      : slice_(slice), make_cannonical_{make_cannonical} {}
+  ParquetReader(bool make_canonical) : make_canonical_{make_canonical} {}
 
   katana::Result<std::shared_ptr<arrow::Table>> ReadFromUriSliced(
       const katana::Uri& uri);
@@ -93,8 +88,7 @@ private:
   katana::Result<std::shared_ptr<arrow::Schema>> FixSchema(
       const std::shared_ptr<arrow::Schema>& schema);
 
-  std::optional<Slice> slice_;
-  bool make_cannonical_;
+  bool make_canonical_;
 };
 
 }  // namespace tsuba

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -20,15 +20,13 @@ katana::Result<std::shared_ptr<arrow::Table>>
 DoLoadProperties(
     const std::string& expected_name, const katana::Uri& file_path,
     std::optional<tsuba::ParquetReader::Slice> slice = std::nullopt) {
-  auto read_opts = tsuba::ParquetReader::ReadOpts::Defaults();
-  read_opts.slice = slice;
-  auto reader_res = tsuba::ParquetReader::Make(read_opts);
+  auto reader_res = tsuba::ParquetReader::Make();
   if (!reader_res) {
     return reader_res.error().WithContext("loading property");
   }
   std::unique_ptr<tsuba::ParquetReader> reader = std::move(reader_res.value());
 
-  auto out_res = reader->ReadTable(file_path);
+  auto out_res = reader->ReadTable(file_path, slice);
   if (!out_res) {
     return out_res.error().WithContext("loading property");
   }


### PR DESCRIPTION
From https://github.com/KatanaGraph/katana-enterprise/pull/2265#discussion_r741829752.

Taking the slice in `Make()` and then _maybe_ respecting it depending on if we call `ReadTable(uri)` or `ReadTable(uri, columns)` is error-prone. I don't really see the use case for reading rows 23 to 45 of multiple files anyway. Better move the slice parameter to the `ReadTable()` calls.

I'm also adding slice support in `ReadTable(uri, columns)` and fixing a typo. (`make_cannonical` &rarr; `make_canonical`)

I've checked by renaming it, and `ReadTable(uri, columns)` is only called from one place. In the enterprise repo. I'll update that caller in https://github.com/KatanaGraph/katana-enterprise/pull/2265. What's the right way to synchronize the change across the two repos?

Thank you!