### PR TITLE
Add wget dependency to conda docker build image

### DIFF
--- a/scripts/build_in_container_conda.Dockerfile
+++ b/scripts/build_in_container_conda.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN set -eux; \
     ${APT_GET} update; \
-    ${APT_GET} install curl bzip2 ca-certificates git libnuma1 texlive-font-utils; \
+    ${APT_GET} install curl bzip2 ca-certificates git libnuma1 texlive-font-utils wget; \
     ${APT_GET} clean
 
 ENV CONDA_PREFIX=/opt/conda

--- a/scripts/build_in_container_conda.Dockerfile
+++ b/scripts/build_in_container_conda.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN set -eux; \
     ${APT_GET} update; \
-    ${APT_GET} install curl bzip2 ca-certificates git libnuma1 texlive-font-utils wget; \
+    ${APT_GET} install curl bzip2 ca-certificates git libnuma1 libxml2 texlive-font-utils wget; \
     ${APT_GET} clean
 
 ENV CONDA_PREFIX=/opt/conda


### PR DESCRIPTION
fixes:
```
ERROR conda.core.link:_execute(699): An error occurred while installing package 'conda-forge::cudatoolkit-dev-11.4.0-py38h497a2fe_2'.
Rolling back transaction: ...working... done

LinkError: post-link script failed for package conda-forge::cudatoolkit-dev-11.4.0-py38h497a2fe_2
location of failed script: /opt/conda/bin/.cudatoolkit-dev-post-link.sh
==> script messages <==
<None>
==> script output <==
stdout: Running Post installation
downloading https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux.run to /opt/conda/pkgs/cudatoolkit-dev/cuda_11.4.0_470.42.01_linux.run

stderr: Traceback (most recent call last):
  File "/opt/conda/bin/cudatoolkit-dev-post-install.py", line 291, in <module>
    _main()
  File "/opt/conda/bin/cudatoolkit-dev-post-install.py", line 284, in _main
    extractor.download_blobs()
  File "/opt/conda/bin/cudatoolkit-dev-post-install.py", line 90, in download_blobs
    self.download(dl_url, dl_path)
  File "/opt/conda/bin/cudatoolkit-dev-post-install.py", line 75, in download
    subprocess.check_call(cmd)
  File "/opt/conda/lib/python3.8/subprocess.py", line 359, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/opt/conda/lib/python3.8/subprocess.py", line 340, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/opt/conda/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/conda/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'wget'
```

JIRA: NOJIRA


Encountered when running:
```
scripts/build_in_container.py -B python_build --type conda
```
