### PR TITLE
Fix handling of unicode files in requirements

### DIFF
--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -61,7 +61,7 @@ boost:
     - conda
     - conan
 breathe:
-  version: [ 4.30, ¯\(ツ)/¯ ]
+  version: [ 4.30, null ]
   labels:
     - conda
 cmake:
@@ -102,7 +102,7 @@ cython:
     apt: cython3
   version: [ 0.29.12, 3 ]
 doxygen:
-  version: [ 1.8, ¯\(ツ)/¯ ]
+  version: [ 1.8, null ]
   labels:
     - conda/dev
     - apt

--- a/scripts/katana_requirements/data.py
+++ b/scripts/katana_requirements/data.py
@@ -20,7 +20,7 @@ def load(input_files: Optional[Collection[Union[str, Path]]] = None) -> (Require
     data: Optional[Requirements] = None
     for input in reversed(inputs):
         # Use BaseLoader so everything is loaded as a string.
-        d = Requirements.from_dict(yaml.load(open(input, "r"), Loader=yaml.BaseLoader))
+        d = Requirements.from_dict(yaml.load(open(input, "r", encoding="UTF-8"), Loader=yaml.BaseLoader))
 
         if data:
             data = data.merge(d)


### PR DESCRIPTION
This fixes two issues:

1. I got cute and put unicode in the yaml file.
2. The code that loaded the yaml file didn't specify the encoding, so in some cases it's UTF-8 which works great, and it others it defaults to ASCII and fails.

Since this fixes both, we should be doubly safe from my stupidity in this case.