### PR TITLE
Disable -u while activating conda

### DIFF
--- a/.github/workflows/activate_miniconda.sh
+++ b/.github/workflows/activate_miniconda.sh
@@ -1,7 +1,20 @@
 # This is a bash INCLUDE file. Source it don't run it.
 
-if [ '!' -d $HOME/miniconda/bin ]; then
-  bash "$HOME/.cache/miniconda/mambaforge.sh" -f -b -p $HOME/miniconda
+if [ '!' -d "$HOME/miniconda/bin" ]; then
+  bash "$HOME/.cache/miniconda/mambaforge.sh" -f -b -p "$HOME/miniconda"
 fi
-export PATH=$HOME/miniconda/bin:$PATH
+export PATH="$HOME/miniconda/bin:$PATH"
+
+# Some conda packages have bash activation scripts. Some of those use unbound variable (for example, mkl).
+# So disable -u for activation.
+UNSET_U=false
+if echo "$-" | grep "u"; then
+  set +u
+  UNSET_U=true
+fi
+
 . activate
+
+if $UNSET_U; then
+  set -u
+fi


### PR DESCRIPTION
The problem is that some Conda packages have activation scripts that doesn't work when in the "strict" mode we write our scripts in where an unbound variable reference is an error. And since the activation scripts are sourced they are affected by our settings.