### PR TITLE
Add the transposed property graph view

### DIFF
--- a/libgalois/test/CMakeLists.txt
+++ b/libgalois/test/CMakeLists.txt
@@ -74,6 +74,7 @@ add_test_unit(property-graph-bench NOT_QUICK LINK_LIBRARIES benchmark::benchmark
 add_test_unit(property-graph-in-memory-props)
 add_test_unit(property-graph-topology)
 add_test_unit(property-graph-optional-topology-generation "${BASEINPUT}/propertygraphs/ldbc_003" LINK_LIBRARIES LLVMSupport)
+add_test_unit(property-graph-transposed-view)
 add_test_unit(property-index)
 add_test_unit(property-view)
 add_test_unit(reduction)

--- a/libgalois/test/property-graph-transposed-view.cpp
+++ b/libgalois/test/property-graph-transposed-view.cpp
@@ -1,0 +1,50 @@
+#include "katana/SharedMemSys.h"
+#include "katana/TopologyGeneration.h"
+
+using namespace katana;
+using Edge = PropertyGraph::Edge;
+using Node = PropertyGraph::Node;
+using TransposedGraphView = PropertyGraphViews::Transposed;
+
+Result<void>
+TestTransposedView() {
+  // We build a simple tree-like graph and its transpose.
+  // Then we compare the transposed view of the first graph with the second.
+  AsymmetricGraphTopologyBuilder builder, builder_tr;
+
+  builder.AddNodes(7);
+  builder_tr.AddNodes(7);
+
+  std::vector<std::array<int, 2>> edges = {{0, 1}, {0, 2}, {1, 3},
+                                           {1, 4}, {2, 5}, {2, 6}};
+  for (const auto& [n1, n2] : edges) {
+    builder.AddEdge(n1, n2);
+    builder_tr.AddEdge(n2, n1);
+  }
+
+  auto pg = KATANA_CHECKED(PropertyGraph::Make(builder.ConvertToCSR()));
+  TransposedGraphView pg_tr_view = pg->BuildView<TransposedGraphView>();
+
+  auto pg_tr = KATANA_CHECKED(PropertyGraph::Make(builder_tr.ConvertToCSR()));
+
+  for (Edge e : pg_tr_view.all_edges()) {
+    KATANA_LOG_VASSERT(
+        pg_tr->topology().edge_source(e) == pg_tr_view.edge_source(e),
+        "Edge sources do not match");
+    KATANA_LOG_VASSERT(
+        pg_tr->topology().edge_dest(e) == pg_tr_view.edge_dest(e),
+        "Edge destinations do not match");
+  }
+
+  return katana::ResultSuccess();
+}
+
+int
+main() {
+  SharedMemSys sys;
+
+  auto res = TestTransposedView();
+  KATANA_LOG_ASSERT(res);
+
+  return 0;
+}


### PR DESCRIPTION
The actual changes in this PR are tiny and only start at line 1299 of `GraphTopology.h`. Earlier changes are just reshuffling of the code that I thought was more consistent: topology classes first, then wrappers.