### PR TITLE
Improve support for dev setup on Ubuntu 18.04.

### DIFF
--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -265,7 +265,8 @@ pandoc:
   version: [ 2a, null ]
   labels:
     - conda/dev
-    - pip/dev
+    # TODO(amp): Reinstate this once we don't need to have any support for 18.04 in the setup scripts.
+#    - pip/dev
 parquet-cpp:
   name_overrides:
     apt: libparquet-dev
@@ -391,7 +392,8 @@ clangd:
     conda: clang-tools
   version: *clang_version
   labels:
-    - apt/dev
+    # TODO(amp): Reinstate this once we don't need to have any support for 18.04 in the setup scripts.
+    #- apt/dev
   version_overrides: *clang_version_overrides
 graphviz:
   version: [2, null]

--- a/scripts/requirements
+++ b/scripts/requirements
@@ -2,4 +2,7 @@
 set -eu
 REPO_ROOT="$(cd "$(dirname "$0")/.."; pwd)"
 
-PYTHONPATH="$REPO_ROOT/external/katana/scripts:$REPO_ROOT/scripts:${PYTHONPATH:+:${PYTHONPATH}}" python3 -m katana_requirements "$@"
+export PYTHONPATH="$REPO_ROOT/external/katana/scripts:$REPO_ROOT/scripts:${PYTHONPATH:+:${PYTHONPATH}}"
+python3 -m katana_requirements "$@" || \
+  echo "HINT: If there are ImportErrors make sure you have the yaml and packaging python packages" \
+        "installed. (Apt packages: python3-yaml, python3-packaging)"

--- a/scripts/setup_dev_ubuntu.sh
+++ b/scripts/setup_dev_ubuntu.sh
@@ -6,6 +6,8 @@
 set -xeuo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.."; pwd)"
 
+lsb_release 2> /dev/null > /dev/null || sudo apt install -yq lsb-release
+
 EXPECTED_RELEASES=("21.04" "20.04" "18.04")
 RELEASE=$(lsb_release --release --short)
 

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -113,7 +113,7 @@ apt install --yes --quiet python3-yaml python3-packaging
 # Use the requirements tool to install apt packages with: apt-get satisfy --allow-downgrades --yes --quiet
 "$REPO_ROOT"/scripts/requirements install -a--allow-downgrades -a--yes -a--quiet -l apt -l apt/dev -f apt
 # Use the requirements tool to install pip packages with: python3 -m pip --upgrade
-run_as_original_user "$REPO_ROOT"/scripts/requirements install -a--upgrade -l pip -l pip/dev -f pip
+run_as_original_user "$REPO_ROOT"/scripts/requirements install -l pip -l pip/dev -f pip
 
 # Toolchain variants
 if [[ -n "${SETUP_TOOLCHAIN_VARIANTS}" ]]; then


### PR DESCRIPTION
This does not actually make it work fully. There are still issues with installing numba (via pip) on 18.04. I think that never actually worker correctly. The issue is that the LLVM available on 18.04 is too old. We probably never noticed because the people using that platform were doing C++ development and not dealing with Python much. Or had manually upgraded their LLVM.