### PR TITLE
change line for each file mentioned in the backtrace

### DIFF
--- a/libsupport/include/katana/Result.h
+++ b/libsupport/include/katana/Result.h
@@ -629,7 +629,7 @@ CheckedExpressionToValue(arrow::Status&&) {
     if (::katana::internal::CheckedExpressionFailed(result_name)) {            \
       return ::katana::internal::CheckedExpressionToError(result_name)         \
           .WithContext(__VA_ARGS__)                                            \
-          .WithContext(FMT_STRING("({}:{})"), __FILE__, __LINE__);             \
+          .WithContext(FMT_STRING("\n({}:{})"), __FILE__, __LINE__);           \
     }                                                                          \
     std::move(                                                                 \
         ::katana::internal::CheckedExpressionToValue(std::move(result_name))); \


### PR DESCRIPTION
Feel free to reject this change if there are reasons I am not aware of.

Before the change the backtrace is too long to fit into one screen.
Not even within the screen of a ultrawide monitor with 4k resolution
using standard DPI. 


Before it was all within the same line, which means I need to scrolllllllll to the right to see what is going on:

```
ng/kg/forked/katana-enterprise/libquery/src/OpGraph.cpp:784): backtrace: (/home/cpchung/kg/forked/katana-enterprise/libquery/src/error-checker-passes/SymbolResolutionChecker.cpp:224): backtrace: (/home/cpchung/kg/forked/katana-enterprise/libquery/src/error-checker-passes/SymbolResolutionChecker.cpp:418): backtrace: (/home/cpchung/kg/forked/katana-enterprise/libquery/src/error-checker-passes/SymbolResolutionChecker.cpp:418): backtrace: parameter name endDate is undefined (SymbolResolutionChecker.cpp:355)

```


After the change, they are all in different lines:

```
kg/forked/katana-enterprise/libquery/src/OpGraph.cpp:784): backtrace: 
(/home/cpchung/kg/forked/katana-enterprise/libquery/src/error-checker-passes/SymbolResolutionChecker.cpp:224): backtrace: 
(/home/cpchung/kg/forked/katana-enterprise/libquery/src/error-checker-passes/SymbolResolutionChecker.cpp:418): backtrace: 
(/home/cpchung/kg/forked/katana-enterprise/libquery/src/error-checker-passes/SymbolResolutionChecker.cpp:418): backtrace: parameter name endDate is undefined (SymbolResolutionChecker.cpp:355)
TCK = Undefined Parameter Error
Katana = ParameterError:UndefinedParameter
```

I believe this change is beneficial
for debugging. At least now I dont need to scrolllllllll to the right and back most of the time, if not all.

Wouldn't it be nice to have? 



