### PR TITLE
Write python_env.sh debugging output to stderr

### DIFF
--- a/cmake/Modules/PythonSetupSubdirectory.cmake
+++ b/cmake/Modules/PythonSetupSubdirectory.cmake
@@ -330,8 +330,10 @@ fi
   endforeach()
 
   string(APPEND ENV_SCRIPT_STR "
-echo PYTHONPATH=\$PYTHONPATH
-\"$@\"
+if [ \"$#\" -eq 0 ]; then
+  echo PYTHONPATH=\$PYTHONPATH 1>&2
+fi
+exec \"$@\"
 ")
   file(GENERATE OUTPUT ${PYTHON_ENV_SCRIPT}.tmp CONTENT "${ENV_SCRIPT_STR}")
 


### PR DESCRIPTION
Keep python_env.sh additions out of stdout for cases where someone may
want to parse the output of a python command.