### PR TITLE
Remove assert from Undirected View

### DIFF
--- a/libgalois/include/katana/GraphTopology.h
+++ b/libgalois/include/katana/GraphTopology.h
@@ -1371,7 +1371,6 @@ protected:
 
 private:
   Edge fake_id_offset() const noexcept {
-    KATANA_LOG_DEBUG_ASSERT(out().num_edges() > 0);
     return out().num_edges() +
            1;  // +1 so that last edge iterator of out() is different from first edge of in()
   }


### PR DESCRIPTION
This PR removes an assertion from UndirectedTopology class that checks if outgoing number of edges is greater than 0. This check is problematic for clustering on very small graphs since we can arise at a situation where the number of edges in a merged/coarsened graph is zero on one of the hosts.