### PR TITLE
tsuba: modified most functions to use KATANA_CHECKED

### DIFF
--- a/libtsuba/src/FileFrame.cpp
+++ b/libtsuba/src/FileFrame.cpp
@@ -38,7 +38,7 @@ FileFrame::Init(uint64_t reserved_size) {
   if (ptr == MAP_FAILED) {
     return KATANA_ERROR(katana::ResultErrno(), "mapping buffer");
   }
-  KATANA_CHECKED_CONTEXT(Destroy(), "Destroy");
+  KATANA_CHECKED(Destroy());
 
   path_ = "";
   map_size_ = map_size;

--- a/libtsuba/src/FileFrame.cpp
+++ b/libtsuba/src/FileFrame.cpp
@@ -38,9 +38,8 @@ FileFrame::Init(uint64_t reserved_size) {
   if (ptr == MAP_FAILED) {
     return KATANA_ERROR(katana::ResultErrno(), "mapping buffer");
   }
-  if (auto res = Destroy(); !res) {
-    KATANA_LOG_ERROR("Destroy: {}", res.error());
-  }
+  KATANA_CHECKED_CONTEXT(Destroy(), "Destroy");
+
   path_ = "";
   map_size_ = map_size;
   map_start_ = static_cast<uint8_t*>(ptr);
@@ -114,9 +113,8 @@ FileFrame::Persist() {
   if (path_.empty()) {
     return KATANA_ERROR(tsuba::ErrorCode::InvalidArgument, "no path provided");
   }
-  if (auto res = tsuba::FileStore(path_, map_start_, cursor_); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(tsuba::FileStore(path_, map_start_, cursor_));
+
   return katana::ResultSuccess();
 }
 

--- a/libtsuba/src/FileView.cpp
+++ b/libtsuba/src/FileView.cpp
@@ -43,9 +43,8 @@ FileView::Unbind() {
   if (bound_) {
     // Resolve all outstanding reads so they don't write to the memory we are
     // about to unmap
-    if (auto res = Resolve(0, file_size_); !res) {
-      return res.error().WithContext("resolving for unmap");
-    }
+    KATANA_CHECKED_CONTEXT(Resolve(0, file_size_), "resolving for unmap");
+
     if (map_start_ != nullptr) {
       if (int err = munmap(map_start_, file_size_); err) {
         return KATANA_ERROR(katana::ResultErrno(), "unmapping buffer");
@@ -70,9 +69,8 @@ FileView::Bind(
     std::string_view filename, uint64_t begin, uint64_t end, bool resolve) {
   StatBuf buf;
   filename_ = filename;
-  if (auto res = FileStat(filename_, &buf); !res) {
-    return res.error().WithContext("getting file size");
-  }
+  KATANA_CHECKED_CONTEXT(FileStat(filename_, &buf), "getting file size");
+
   uint64_t in_end = std::min<uint64_t>(end, static_cast<uint64_t>(buf.size));
   if (in_end < begin) {
     return KATANA_ERROR(
@@ -100,9 +98,7 @@ FileView::Bind(
     }
   }
 
-  if (auto res = Unbind(); !res) {
-    return res.error().WithContext("resetting for new content");
-  }
+  KATANA_CHECKED_CONTEXT(Unbind(), "resetting for new content");
 
   map_start_ = static_cast<uint8_t*>(tmp);
   mem_start_ = -1;
@@ -110,9 +106,7 @@ FileView::Bind(
   filling_.resize(page_number(buf.size) / 64 + 1, 0);
   file_size_ = buf.size;
   fetches_ = std::make_unique<std::vector<FillingRange>>();
-  if (auto res = Fill(begin, in_end, resolve); !res) {
-    return res.error().WithContext("reading content");
-  }
+  KATANA_CHECKED_CONTEXT(Fill(begin, in_end, resolve), "reading content");
 
   cursor_ = 0;
   bound_ = true;
@@ -159,13 +153,11 @@ FileView::Fill(uint64_t begin, uint64_t end, bool resolve) {
       KATANA_LOG_ASSERT(peek_fut.valid());
       FillingRange fetch = {first_page, last_page, std::move(peek_fut)};
       fetches_->push_back(std::move(fetch));
-      if (auto res = MarkFilled(&filling_[0], first_page, last_page); !res) {
-        return res.error().WithContext("updating bookkeeping data");
-      }
+      KATANA_CHECKED_CONTEXT(
+          MarkFilled(&filling_[0], first_page, last_page),
+          "updating bookkeeping data");
       if (resolve) {
-        if (auto res = Resolve(file_off, map_size); !res) {
-          return res.error().WithContext("resolving fill");
-        }
+        KATANA_CHECKED_CONTEXT(Resolve(file_off, map_size), "resolving fill");
       }
       int64_t signed_begin = static_cast<int64_t>(in_begin);
       if (mem_start_ < 0 || signed_begin < mem_start_) {
@@ -478,9 +470,7 @@ FileView::Resolve(int64_t start, int64_t size) {
         fetch->last_page >= page_number(start)) {
       // Complete the remaining work if there is some
       if (fetch->work.valid()) {
-        if (auto res = fetch->work.get(); !res) {
-          return res.error();
-        }
+        KATANA_CHECKED(fetch->work.get());
       } else {
         KATANA_LOG_DEBUG("bad future in FileView::Resolve {} {}", start, size);
       }
@@ -503,9 +493,7 @@ FileView::PreFetch(int64_t start, int64_t size) {
   KATANA_LOG_DEBUG_ASSERT(fetch_size >= 0);
   uint64_t begin = static_cast<uint64_t>(start + size);
   uint64_t end = static_cast<uint64_t>(start + size + fetch_size);
-  if (auto res = Fill(begin, end, false); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(Fill(begin, end, false));
   return katana::ResultSuccess();
 }
 }  // namespace tsuba

--- a/libtsuba/src/GlobalState.cpp
+++ b/libtsuba/src/GlobalState.cpp
@@ -52,7 +52,8 @@ tsuba::GlobalState::Init(katana::CommBackend* comm) {
       });
 
   for (FileStorage* fs : global_state->file_stores_) {
-    KATANA_CHECKED_CONTEXT(fs->Init(), "initializing backends");
+    KATANA_CHECKED_CONTEXT(
+        fs->Init(), "initializing backend ({})", fs->uri_scheme());
   }
 
   ref_ = std::move(global_state);

--- a/libtsuba/src/GlobalState.cpp
+++ b/libtsuba/src/GlobalState.cpp
@@ -52,9 +52,7 @@ tsuba::GlobalState::Init(katana::CommBackend* comm) {
       });
 
   for (FileStorage* fs : global_state->file_stores_) {
-    if (auto res = fs->Init(); !res) {
-      return res.error().WithContext("initializing backends");
-    }
+    KATANA_CHECKED_CONTEXT(fs->Init(), "initializing backends");
   }
 
   ref_ = std::move(global_state);
@@ -64,10 +62,8 @@ tsuba::GlobalState::Init(katana::CommBackend* comm) {
 katana::Result<void>
 tsuba::GlobalState::Fini() {
   for (FileStorage* fs : ref_->file_stores_) {
-    if (auto res = fs->Fini(); !res) {
-      return res.error().WithContext(
-          "file storage shutdown ({})", fs->uri_scheme());
-    }
+    KATANA_CHECKED_CONTEXT(
+        fs->Fini(), "file storage shutdown ({})", fs->uri_scheme());
   }
   ref_.reset(nullptr);
   return katana::ResultSuccess();

--- a/libtsuba/src/ParquetReader.cpp
+++ b/libtsuba/src/ParquetReader.cpp
@@ -61,10 +61,10 @@ BuildReader(
     const std::string& uri, bool preload,
     std::shared_ptr<tsuba::FileView>* fv) {
   auto fv_tmp = std::make_shared<tsuba::FileView>();
+  uint64_t end = preload ? std::numeric_limits<uint64_t>::max() : 0;
   KATANA_CHECKED_CONTEXT(
-      fv_tmp->Bind(
-          uri, 0, preload ? std::numeric_limits<uint64_t>::max() : 0, false),
-      "opening {}", uri);
+      fv_tmp->Bind(uri, 0, end, false), "opening {}; begin: {}, end: {}", uri,
+      0, end);
   *fv = fv_tmp;
 
   std::unique_ptr<parquet::arrow::FileReader> reader;

--- a/libtsuba/src/ParquetWriter.cpp
+++ b/libtsuba/src/ParquetWriter.cpp
@@ -86,17 +86,13 @@ DoStoreParquet(
         }
 
         TSUBA_PTP(tsuba::internal::FaultSensitivity::Normal);
-        if (auto res = ff->Persist(); !res) {
-          return res.error();
-        }
+        KATANA_CHECKED(ff->Persist());
+
         return katana::CopyableResultSuccess();
       });
 
   if (!desc) {
-    auto res = future.get();
-    if (!res) {
-      return res.error();
-    }
+    KATANA_CHECKED(future.get());
     return katana::ResultSuccess();
   }
 
@@ -199,11 +195,7 @@ tsuba::ParquetWriter::StoreParquet(
 
   std::unique_ptr<tsuba::WriteGroup> our_desc;
   if (!desc) {
-    auto desc_res = WriteGroup::Make();
-    if (!desc_res) {
-      return desc_res.error();
-    }
-    our_desc = std::move(desc_res.value());
+    our_desc = KATANA_CHECKED(WriteGroup::Make());
     desc = our_desc.get();
   }
 

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -50,12 +50,12 @@ katana::Result<std::string>
 StoreArrowArrayAtName(
     const std::shared_ptr<arrow::ChunkedArray>& array, const katana::Uri& dir,
     const std::string& name, tsuba::WriteGroup* desc) {
-  auto writer = KATANA_CHECKED_CONTEXT(
-      tsuba::ParquetWriter::Make(array, name), "making property writer");
+  std::unique_ptr<tsuba::ParquetWriter> writer =
+      KATANA_CHECKED(tsuba::ParquetWriter::Make(array, name));
 
   katana::Uri new_path = dir.RandFile(name);
   KATANA_CHECKED_CONTEXT(
-      writer->WriteToUri(new_path, desc), "writing property writer");
+      writer->WriteToUri(new_path, desc), "writing to: {}", new_path);
   return new_path.BaseName();
 }
 
@@ -318,11 +318,10 @@ tsuba::RDG::DoStore(
   std::vector<PropStorageInfo*> node_props_to_store = KATANA_CHECKED(
       core_->part_header().SelectNodeProperties(node_prop_names));
 
-  KATANA_CHECKED_CONTEXT(
-      WriteProperties(
-          *core_->node_properties(), node_props_to_store,
-          handle.impl_->rdg_manifest().dir(), write_group.get()),
-      "writing node properties");
+  // writing node properties
+  KATANA_CHECKED(WriteProperties(
+      *core_->node_properties(), node_props_to_store,
+      handle.impl_->rdg_manifest().dir(), write_group.get()));
 
   std::vector<std::string> edge_prop_names;
   for (const auto& field : core_->edge_properties()->fields()) {
@@ -332,15 +331,14 @@ tsuba::RDG::DoStore(
   std::vector<PropStorageInfo*> edge_props_to_store = KATANA_CHECKED(
       core_->part_header().SelectEdgeProperties(edge_prop_names));
 
-  KATANA_CHECKED_CONTEXT(
-      WriteProperties(
-          *core_->edge_properties(), edge_props_to_store,
-          handle.impl_->rdg_manifest().dir(), write_group.get()),
-      "writing edge properties");
+  // writing edge properties
+  KATANA_CHECKED(WriteProperties(
+      *core_->edge_properties(), edge_props_to_store,
+      handle.impl_->rdg_manifest().dir(), write_group.get()));
 
-  core_->part_header().set_part_properties(KATANA_CHECKED_CONTEXT(
-      WritePartArrays(handle.impl_->rdg_manifest().dir(), write_group.get()),
-      "writing partition metadata"));
+  // writing partition metadata
+  core_->part_header().set_part_properties(KATANA_CHECKED(
+      WritePartArrays(handle.impl_->rdg_manifest().dir(), write_group.get())));
 
   //If a view type has been set, use it otherwise pass in the default view type
   if (view_type_.empty()) {
@@ -349,18 +347,16 @@ tsuba::RDG::DoStore(
     handle.impl_->set_viewtype(view_type_);
   }
 
-  KATANA_CHECKED_CONTEXT(
-      core_->part_header().Write(handle, write_group.get(), versioning_action),
-      "failed to write metadata");
+  // writing metadata
+  KATANA_CHECKED(
+      core_->part_header().Write(handle, write_group.get(), versioning_action));
 
   // Update lineage and commit
   core_->AddCommandLine(command_line);
-  KATANA_CHECKED_CONTEXT(
-      CommitRDG(
-          handle, core_->part_header().metadata().policy_id_,
-          core_->part_header().metadata().transposed_, versioning_action,
-          core_->lineage(), std::move(write_group)),
-      "failed to finalize RDG");
+  KATANA_CHECKED(CommitRDG(
+      handle, core_->part_header().metadata().policy_id_,
+      core_->part_header().metadata().transposed_, versioning_action,
+      core_->lineage(), std::move(write_group)));
   return katana::ResultSuccess();
 }
 
@@ -371,65 +367,61 @@ tsuba::RDG::DoMake(
     const katana::Uri& metadata_dir) {
   ReadGroup grp;
 
-  KATANA_CHECKED_CONTEXT(
-      AddProperties(
-          metadata_dir, tsuba::NodeEdge::kNode, prop_cache_, this,
-          node_props_to_be_loaded, &grp,
-          [rdg = this](const std::shared_ptr<arrow::Table>& props)
-              -> katana::Result<void> {
-            std::shared_ptr<arrow::Table> prop_table =
-                rdg->core_->node_properties();
+  // populating node properties
+  KATANA_CHECKED(AddProperties(
+      metadata_dir, tsuba::NodeEdge::kNode, prop_cache_, this,
+      node_props_to_be_loaded, &grp,
+      [rdg = this](
+          const std::shared_ptr<arrow::Table>& props) -> katana::Result<void> {
+        std::shared_ptr<arrow::Table> prop_table =
+            rdg->core_->node_properties();
 
-            if (prop_table && prop_table->num_columns() > 0) {
-              for (int i = 0; i < props->num_columns(); ++i) {
-                prop_table = KATANA_CHECKED(prop_table->AddColumn(
-                    prop_table->num_columns(), props->field(i),
-                    props->column(i)));
-              }
-            } else {
-              prop_table = props;
-            }
-            rdg->core_->set_node_properties(std::move(prop_table));
-            return katana::ResultSuccess();
-          }),
-      "populating node properties");
+        if (prop_table && prop_table->num_columns() > 0) {
+          for (int i = 0; i < props->num_columns(); ++i) {
+            prop_table = KATANA_CHECKED(prop_table->AddColumn(
+                prop_table->num_columns(), props->field(i), props->column(i)));
+          }
+        } else {
+          prop_table = props;
+        }
+        rdg->core_->set_node_properties(std::move(prop_table));
+        return katana::ResultSuccess();
+      }));
 
-  KATANA_CHECKED_CONTEXT(
-      AddProperties(
-          metadata_dir, tsuba::NodeEdge::kEdge, prop_cache_, this,
-          edge_props_to_be_loaded, &grp,
-          [rdg = this](const std::shared_ptr<arrow::Table>& props)
-              -> katana::Result<void> {
-            std::shared_ptr<arrow::Table> prop_table =
-                rdg->core_->edge_properties();
+  // populating edge properties
+  KATANA_CHECKED(AddProperties(
+      metadata_dir, tsuba::NodeEdge::kEdge, prop_cache_, this,
+      edge_props_to_be_loaded, &grp,
+      [rdg = this](
+          const std::shared_ptr<arrow::Table>& props) -> katana::Result<void> {
+        std::shared_ptr<arrow::Table> prop_table =
+            rdg->core_->edge_properties();
 
-            if (prop_table && prop_table->num_columns() > 0) {
-              for (int i = 0; i < props->num_columns(); ++i) {
-                prop_table = KATANA_CHECKED(prop_table->AddColumn(
-                    prop_table->num_columns(), props->field(i),
-                    props->column(i)));
-              }
-            } else {
-              prop_table = props;
-            }
-            rdg->core_->set_edge_properties(std::move(prop_table));
-            return katana::ResultSuccess();
-          }),
-      "populating edge properties");
+        if (prop_table && prop_table->num_columns() > 0) {
+          for (int i = 0; i < props->num_columns(); ++i) {
+            prop_table = KATANA_CHECKED(prop_table->AddColumn(
+                prop_table->num_columns(), props->field(i), props->column(i)));
+          }
+        } else {
+          prop_table = props;
+        }
+        rdg->core_->set_edge_properties(std::move(prop_table));
+        return katana::ResultSuccess();
+      }));
 
-  KATANA_CHECKED_CONTEXT(
-      core_->MakeTopologyManager(metadata_dir), "populating topologies");
+  // populating topologies
+  KATANA_CHECKED(core_->MakeTopologyManager(metadata_dir));
 
   // find & bind the default csr topology
   RDGTopology shadow_csr = RDGTopology::MakeShadowCSR();
-  RDGTopology* csr = KATANA_CHECKED_CONTEXT(
-      core_->topology_manager().GetTopology(shadow_csr),
-      "unable to find csr topology, must have csr topology");
+  RDGTopology* csr =
+      KATANA_CHECKED(core_->topology_manager().GetTopology(shadow_csr));
 
   KATANA_LOG_VASSERT(csr != nullptr, "csr topology is null");
   //TODO: emcginnis is there any reason we should be binding the csr topology here?
   // getting it makes sense, to make sure it is present, but I don't think we need to bind it
-  KATANA_CHECKED_CONTEXT(csr->Bind(metadata_dir), "binding csr topology");
+  // binding csr topology
+  KATANA_CHECKED(csr->Bind(metadata_dir));
 
   if (core_->part_header().IsEntityTypeIDsOutsideProperties()) {
     katana::Uri node_entity_type_id_array_path = metadata_dir.Join(
@@ -455,14 +447,13 @@ tsuba::RDG::DoMake(
     return grp.Finish();
   }
 
-  KATANA_CHECKED_CONTEXT(
-      AddProperties(
-          metadata_dir, tsuba::NodeEdge::kNeitherNodeNorEdge, nullptr, nullptr,
-          part_info, &grp,
-          [rdg = this](const std::shared_ptr<arrow::Table>& props) {
-            return rdg->core_->AddPartitionMetadataArray(props);
-          }),
-      "populating partition metadata");
+  // populating partition metadata
+  KATANA_CHECKED(AddProperties(
+      metadata_dir, tsuba::NodeEdge::kNeitherNodeNorEdge, nullptr, nullptr,
+      part_info, &grp,
+      [rdg = this](const std::shared_ptr<arrow::Table>& props) {
+        return rdg->core_->AddPartitionMetadataArray(props);
+      }));
   KATANA_CHECKED(grp.Finish());
 
   if (local_to_user_id()->length() == 0) {
@@ -515,7 +506,7 @@ tsuba::RDG::Make(const RDGManifest& manifest, const RDGLoadOptions& opts) {
 
   katana::Uri partition_path = manifest.PartitionFileName(partition_id_to_load);
 
-  auto part_header = KATANA_CHECKED_CONTEXT(
+  RDGPartHeader part_header = KATANA_CHECKED_CONTEXT(
       RDGPartHeader::Make(partition_path), "failed to read path {}",
       partition_path);
 
@@ -591,7 +582,7 @@ tsuba::RDG::Store(
   }
 
   // All write buffers must outlive desc
-  auto desc = KATANA_CHECKED(WriteGroup::Make());
+  std::unique_ptr<WriteGroup> desc = KATANA_CHECKED(WriteGroup::Make());
 
   KATANA_CHECKED(core_->topology_manager().DoStore(handle, desc));
 
@@ -960,8 +951,8 @@ katana::Result<tsuba::RDGTopology*>
 tsuba::RDG::GetTopology(const tsuba::RDGTopology& shadow) {
   RDGTopology* topology =
       KATANA_CHECKED(core_->topology_manager().GetTopology(shadow));
-  KATANA_CHECKED_CONTEXT(topology->Bind(rdg_dir()), "binding topology file");
-  KATANA_CHECKED_CONTEXT(topology->Map(), "mapping topology file");
+  KATANA_CHECKED(topology->Bind(rdg_dir()));
+  KATANA_CHECKED(topology->Map());
   return topology;
 }
 

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -60,11 +60,13 @@ UpsertProperties(
         next = arrow::Table::Make(arrow::schema({field}), {props->column(i)});
       } else {
         next = KATANA_CHECKED_CONTEXT(
-            next->AddColumn(last++, field, props->column(i)), "insert");
+            next->AddColumn(last++, field, props->column(i)),
+            "insert; column {}", i);
       }
     } else {
       next = KATANA_CHECKED_CONTEXT(
-          next->SetColumn(current_col, field, props->column(i)), "update");
+          next->SetColumn(current_col, field, props->column(i)),
+          "update; column {}", i);
     }
     prop_info_it->WasModified(field->type());
   }

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -208,11 +208,9 @@ public:
     topology_manager_ = std::move(topo_manager);
     if (!part_header_.IsMetadataOutsideTopologyFile()) {
       // need to bind & map topology file now to extract the metadata
-      KATANA_CHECKED_CONTEXT(
-          topology_manager_.ExtractMetadata(
-              metadata_dir, part_header_.metadata().num_nodes_,
-              part_header_.metadata().num_edges_),
-          "Extracting metadata from previous format topology file");
+      KATANA_CHECKED(topology_manager_.ExtractMetadata(
+          metadata_dir, part_header_.metadata().num_nodes_,
+          part_header_.metadata().num_edges_));
     }
 
     return katana::ResultSuccess();
@@ -248,10 +246,8 @@ public:
     topology_manager_ = std::move(topo_manager);
 
     // get the metadata we need from the topology file
-    KATANA_CHECKED_CONTEXT(
-        topology_manager_.ExtractMetadata(
-            rdg_dir, num_nodes, num_edges, /*storage_valid=*/true),
-        "Extracting metadata from previous format topology file");
+    KATANA_CHECKED(topology_manager_.ExtractMetadata(
+        rdg_dir, num_nodes, num_edges, /*storage_valid=*/true));
     return katana::ResultSuccess();
   }
 

--- a/libtsuba/src/RDGManifest.cpp
+++ b/libtsuba/src/RDGManifest.cpp
@@ -54,9 +54,7 @@ Result<tsuba::RDGManifest>
 RDGManifest::MakeFromStorage(const katana::Uri& uri) {
   tsuba::FileView fv;
 
-  if (auto res = fv.Bind(uri.string(), true); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(fv.Bind(uri.string(), true));
 
   tsuba::RDGManifest manifest(uri.DirName());
   auto manifest_res = katana::JsonParse<tsuba::RDGManifest>(fv, &manifest);

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -112,7 +112,7 @@ katana::Result<void>
 RDGPartHeader::Write(
     RDGHandle handle, WriteGroup* writes,
     RDG::RDGVersioningPolicy retain_version) const {
-  auto serialized = KATANA_CHECKED(katana::JsonDump(*this));
+  std::string serialized = KATANA_CHECKED(katana::JsonDump(*this));
 
   // POSIX files end with newlines
   serialized = serialized + "\n";

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -91,18 +91,15 @@ const int kPartitionMatchHostIndex = 3;
 katana::Result<RDGPartHeader>
 RDGPartHeader::MakeJson(const katana::Uri& partition_path) {
   tsuba::FileView fv;
-  if (auto res = fv.Bind(partition_path.string(), true); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(fv.Bind(partition_path.string(), true));
+
   if (fv.size() == 0) {
     return tsuba::RDGPartHeader();
   }
 
   tsuba::RDGPartHeader header;
-  auto json_res = katana::JsonParse<tsuba::RDGPartHeader>(fv, &header);
-  if (!json_res) {
-    return json_res.error();
-  }
+  KATANA_CHECKED(katana::JsonParse<tsuba::RDGPartHeader>(fv, &header));
+
   return header;
 }
 
@@ -115,21 +112,14 @@ katana::Result<void>
 RDGPartHeader::Write(
     RDGHandle handle, WriteGroup* writes,
     RDG::RDGVersioningPolicy retain_version) const {
-  auto serialized_res = katana::JsonDump(*this);
-  if (!serialized_res) {
-    return serialized_res.error();
-  }
-
-  std::string serialized = std::move(serialized_res.value());
+  auto serialized = KATANA_CHECKED(katana::JsonDump(*this));
 
   // POSIX files end with newlines
   serialized = serialized + "\n";
 
   TSUBA_PTP(internal::FaultSensitivity::Normal);
   auto ff = std::make_unique<FileFrame>();
-  if (auto res = ff->Init(serialized.size()); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(ff->Init(serialized.size()));
   if (auto res = ff->Write(serialized.data(), serialized.size()); !res.ok()) {
     return KATANA_ERROR(ArrowToTsuba(res.code()), "arrow error: {}", res);
   }

--- a/libtsuba/src/RDGPrefix.cpp
+++ b/libtsuba/src/RDGPrefix.cpp
@@ -11,12 +11,9 @@ namespace tsuba {
 
 katana::Result<tsuba::RDGPrefix>
 RDGPrefix::DoMakePrefix(const tsuba::RDGManifest& manifest) {
-  auto meta_res = RDGPartHeader::Make(manifest.PartitionFileName(0));
-  if (!meta_res) {
-    return meta_res.error();
-  }
+  auto part_header =
+      KATANA_CHECKED(RDGPartHeader::Make(manifest.PartitionFileName(0)));
 
-  tsuba::RDGPartHeader part_header = std::move(meta_res.value());
   if (part_header.csr_topology_path().empty()) {
     return RDGPrefix{};
   }
@@ -24,17 +21,16 @@ RDGPrefix::DoMakePrefix(const tsuba::RDGManifest& manifest) {
   katana::Uri t_path = manifest.dir().Join(part_header.csr_topology_path());
 
   CSRTopologyHeader gr_header;
-  if (auto res = FileGet(t_path.string(), &gr_header); !res) {
-    return res.error().WithContext(
-        "file get failed: {}: sz: {}", t_path, sizeof(gr_header));
-  }
+  KATANA_CHECKED_CONTEXT(
+      FileGet(t_path.string(), &gr_header), "file get failed: {}: sz: {}",
+      t_path, sizeof(gr_header));
+
   FileView fv;
-  if (auto res = fv.Bind(
+  KATANA_CHECKED_CONTEXT(
+      fv.Bind(
           t_path.string(),
-          sizeof(gr_header) + (gr_header.num_nodes * sizeof(uint64_t)), true);
-      !res) {
-    return res.error().WithContext("failed to bind {}", t_path);
-  }
+          sizeof(gr_header) + (gr_header.num_nodes * sizeof(uint64_t)), true),
+      "failed to bind {}", t_path);
 
   return RDGPrefix(
       std::move(fv),

--- a/libtsuba/src/RDGPrefix.cpp
+++ b/libtsuba/src/RDGPrefix.cpp
@@ -22,19 +22,17 @@ RDGPrefix::DoMakePrefix(const tsuba::RDGManifest& manifest) {
 
   CSRTopologyHeader gr_header;
   KATANA_CHECKED_CONTEXT(
-      FileGet(t_path.string(), &gr_header), "file get failed: {}: sz: {}",
+      FileGet(t_path.string(), &gr_header), "file get failed: {}; sz: {}",
       t_path, sizeof(gr_header));
 
   FileView fv;
+  uint64_t offset =
+      sizeof(gr_header) + (gr_header.num_nodes * sizeof(uint64_t));
   KATANA_CHECKED_CONTEXT(
-      fv.Bind(
-          t_path.string(),
-          sizeof(gr_header) + (gr_header.num_nodes * sizeof(uint64_t)), true),
-      "failed to bind {}", t_path);
+      fv.Bind(t_path.string(), offset, true),
+      "failed to bind {}; begin: 0, end: {}", t_path, offset);
 
-  return RDGPrefix(
-      std::move(fv),
-      sizeof(gr_header) + (gr_header.num_nodes * sizeof(uint64_t)));
+  return RDGPrefix(std::move(fv), offset);
 }
 
 katana::Result<tsuba::RDGPrefix>

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -213,11 +213,8 @@ tsuba::RDGSlice::Make(
 
   RDGSlice rdg_slice(std::make_unique<RDGCore>(std::move(part_header)));
 
-  if (auto res =
-          rdg_slice.DoMake(node_props, edge_props, manifest.dir(), slice);
-      !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(
+      rdg_slice.DoMake(node_props, edge_props, manifest.dir(), slice));
 
   return RDGSlice(std::move(rdg_slice));
 }

--- a/libtsuba/src/RDGTopology.cpp
+++ b/libtsuba/src/RDGTopology.cpp
@@ -75,9 +75,7 @@ RDGTopology::Bind(const katana::Uri& metadata_dir, bool resolve) {
   katana::Uri t_path = metadata_dir.Join(path());
   KATANA_LOG_DEBUG(
       "binding to entire topology file at path {}", t_path.string());
-  if (auto res = file_storage_.Bind(t_path.string(), resolve); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(file_storage_.Bind(t_path.string(), resolve));
 
   file_store_bound_ = true;
   storage_valid_ = true;
@@ -93,10 +91,7 @@ RDGTopology::Bind(
   KATANA_LOG_DEBUG(
       "binding from {} to {} with topology file at path {}", begin, end,
       t_path.string());
-  if (auto res = file_storage_.Bind(t_path.string(), begin, end, resolve);
-      !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(file_storage_.Bind(t_path.string(), begin, end, resolve));
 
   file_store_bound_ = true;
   storage_valid_ = true;
@@ -312,9 +307,8 @@ tsuba::RDGTopology::DoStore(
         topology_state_, transpose_state_, edge_sort_state_, node_sort_state_);
 
     auto ff = std::make_unique<tsuba::FileFrame>();
-    if (auto res = ff->Init(); !res) {
-      return res.error();
-    }
+    KATANA_CHECKED(ff->Init());
+
     uint64_t data[4] = {1, 0, num_nodes_, num_edges_};
     arrow::Status aro_sts = ff->Write(&data, 4 * sizeof(uint64_t));
     if (!aro_sts.ok()) {

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -21,23 +21,18 @@ FileList(const std::string& dir) {
   auto list_fut = tsuba::FileListAsync(dir, &files);
   KATANA_LOG_ASSERT(list_fut.valid());
 
-  if (auto res = list_fut.get(); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(list_fut.get());
   return files;
 }
 
 katana::Result<katana::Uri>
 FindAnyManifestForLatestVersion(const katana::Uri& name) {
   KATANA_LOG_DEBUG_ASSERT(!tsuba::RDGManifest::IsManifestUri(name));
-  auto list_res = FileList(name.string());
-  if (!list_res) {
-    return list_res.error();
-  }
+  auto file_list = KATANA_CHECKED(FileList(name.string()));
 
   uint64_t version = 0;
   std::string found_manifest;
-  for (const std::string& file : list_res.value()) {
+  for (const std::string& file : file_list) {
     if (auto res = tsuba::RDGManifest::ParseVersionFromName(file); res) {
       uint64_t new_version = res.value();
       if (new_version >= version) {
@@ -95,11 +90,7 @@ tsuba::Close(RDGHandle handle) {
 
 katana::Result<void>
 tsuba::Create(const std::string& name) {
-  auto uri_res = katana::Uri::Make(name);
-  if (!uri_res) {
-    return uri_res.error();
-  }
-  katana::Uri uri = std::move(uri_res.value());
+  auto uri = KATANA_CHECKED(katana::Uri::Make(name));
 
   KATANA_LOG_DEBUG_ASSERT(!RDGManifest::IsManifestUri(uri));
   // the default construction is the empty RDG
@@ -174,11 +165,7 @@ tsuba::ListViewsOfVersion(
 
     katana::Uri manifest_path = rdg_uri.Join(file);
 
-    auto manifest_res = RDGManifest::Make(manifest_path);
-    if (!manifest_res) {
-      continue;
-    }
-    const RDGManifest& manifest = manifest_res.value();
+    const auto& manifest = KATANA_CHECKED(RDGManifest::Make(manifest_path));
 
     if (manifest.num_hosts() == 0) {
       // empty sentinal; not a valid view

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -28,7 +28,7 @@ FileList(const std::string& dir) {
 katana::Result<katana::Uri>
 FindAnyManifestForLatestVersion(const katana::Uri& name) {
   KATANA_LOG_DEBUG_ASSERT(!tsuba::RDGManifest::IsManifestUri(name));
-  auto file_list = KATANA_CHECKED(FileList(name.string()));
+  std::vector<std::string> file_list = KATANA_CHECKED(FileList(name.string()));
 
   uint64_t version = 0;
   std::string found_manifest;
@@ -90,7 +90,7 @@ tsuba::Close(RDGHandle handle) {
 
 katana::Result<void>
 tsuba::Create(const std::string& name) {
-  auto uri = KATANA_CHECKED(katana::Uri::Make(name));
+  katana::Uri uri = KATANA_CHECKED(katana::Uri::Make(name));
 
   KATANA_LOG_DEBUG_ASSERT(!RDGManifest::IsManifestUri(uri));
   // the default construction is the empty RDG
@@ -165,7 +165,8 @@ tsuba::ListViewsOfVersion(
 
     katana::Uri manifest_path = rdg_uri.Join(file);
 
-    const auto& manifest = KATANA_CHECKED(RDGManifest::Make(manifest_path));
+    const RDGManifest& manifest =
+        KATANA_CHECKED(RDGManifest::Make(manifest_path));
 
     if (manifest.num_hosts() == 0) {
       // empty sentinal; not a valid view


### PR DESCRIPTION
Now that I have some time, I decided to do some code cleanup in our storage code to make use of `KATANA_CHECKED` wherever I saw it was most appropriate. 