### PR TITLE
Unbind RDGTopology FileView when no longer used

### DIFF
--- a/libgalois/src/GraphTopology.cpp
+++ b/libgalois/src/GraphTopology.cpp
@@ -7,6 +7,7 @@
 #include "katana/Logging.h"
 #include "katana/PropertyGraph.h"
 #include "katana/Random.h"
+#include "katana/Result.h"
 #include "tsuba/RDGTopology.h"
 
 void
@@ -163,6 +164,11 @@ katana::EdgeShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
       &(rdg_topo->edge_index_to_property_index_map()[0]),
       &(rdg_topo->edge_index_to_property_index_map()[rdg_topo->num_edges()]),
       edge_prop_indices.begin());
+
+  // Since we copy the data we need out of the RDGTopology into our own arrays,
+  // unbind the RDGTopologys file store to save memory.
+  auto res = rdg_topo->unbind_file_storage();
+  KATANA_LOG_ASSERT(res);
 
   std::unique_ptr<EdgeShuffleTopology> shuffle =
       std::make_unique<EdgeShuffleTopology>(EdgeShuffleTopology{
@@ -409,6 +415,11 @@ katana::ShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
       &(rdg_topo->node_index_to_property_index_map()[rdg_topo->num_nodes()]),
       node_prop_indices_copy.begin());
 
+  // Since we copy the data we need out of the RDGTopology into our own arrays,
+  // unbind the RDGTopologys file store to save memory.
+  auto res = rdg_topo->unbind_file_storage();
+  KATANA_LOG_ASSERT(res);
+
   std::unique_ptr<ShuffleTopology> shuffle =
       std::make_unique<ShuffleTopology>(ShuffleTopology{
           rdg_topo->transpose_state(), rdg_topo->node_sort_state(),
@@ -581,6 +592,11 @@ katana::EdgeTypeAwareTopology::Make(
       &(rdg_topo->adj_indices()
             [rdg_topo->num_nodes() * edge_type_index->num_unique_types()]),
       per_type_adj_indices.begin());
+
+  // Since we copy the data we need out of the RDGTopology into our own arrays,
+  // unbind the RDGTopologys file store to save memory.
+  auto res = rdg_topo->unbind_file_storage();
+  KATANA_LOG_ASSERT(res);
 
   return std::make_unique<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
       edge_type_index, e_topo, std::move(per_type_adj_indices)});

--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -153,6 +153,10 @@ katana::PropertyGraph::Make(
   katana::GraphTopology topo = katana::GraphTopology(
       csr->adj_indices(), csr->num_nodes(), csr->dests(), csr->num_edges());
 
+  // The GraphTopology constructor copies all of the required topology data.
+  // Clean up the RDGTopologies memory
+  KATANA_CHECKED(csr->unbind_file_storage());
+
   if (rdg.IsEntityTypeIDsOutsideProperties()) {
     KATANA_LOG_DEBUG("loading EntityType data from outside properties");
 

--- a/libtsuba/include/tsuba/RDGTopology.h
+++ b/libtsuba/include/tsuba/RDGTopology.h
@@ -104,23 +104,59 @@ public:
 
   uint64_t num_nodes() const { return num_nodes_; }
 
-  const uint64_t* adj_indices() const { return adj_indices_; }
+  /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
+  const uint64_t* adj_indices() const {
+    KATANA_LOG_VASSERT(
+        adj_indices_ != nullptr,
+        "RDGTopology must be either bound & mapped, or filled from memory");
+    return adj_indices_;
+  }
 
-  const uint32_t* dests() const { return dests_; }
+  /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
+  const uint32_t* dests() const {
+    KATANA_LOG_VASSERT(
+        dests_ != nullptr,
+        "RDGTopology must be either bound & mapped, or filled from memory");
+    return dests_;
+  }
 
+  /// Optional field, may not be present depending on the kind of topology this is
+  /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
   const uint64_t* node_index_to_property_index_map() const {
+    KATANA_LOG_VASSERT(
+        node_index_to_property_index_map_ != nullptr,
+        "Either this optional field is not present, or the RDGTopology must be "
+        "either bound & mapped, or filled from memory.");
     return node_index_to_property_index_map_;
   }
 
+  /// Optional field, may not be present depending on the kind of topology this is
+  /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
   const uint64_t* edge_index_to_property_index_map() const {
+    KATANA_LOG_VASSERT(
+        edge_index_to_property_index_map_ != nullptr,
+        "Either this optional field is not present, or the RDGTopology must be "
+        "either bound & mapped, or filled from memory.");
     return edge_index_to_property_index_map_;
   }
 
+  /// Optional field, may not be present depending on the kind of topology this is
+  /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
   const katana::EntityTypeID* edge_condensed_type_id_map() const {
+    KATANA_LOG_VASSERT(
+        edge_condensed_type_id_map_ != nullptr,
+        "Either this optional field is not present, or the RDGTopology must be "
+        "either bound & mapped, or filled from memory.");
     return edge_condensed_type_id_map_;
   }
 
+  /// Optional field, may not be present depending on the kind of topology this is
+  /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
   const katana::EntityTypeID* node_condensed_type_id_map() const {
+    KATANA_LOG_VASSERT(
+        node_condensed_type_id_map_ != nullptr,
+        "Either this optional field is not present, or the RDGTopology must be "
+        "either bound & mapped, or filled from memory.");
     return node_condensed_type_id_map_;
   }
 
@@ -208,7 +244,8 @@ public:
       uint64_t num_nodes, uint64_t num_edges, bool storage_valid = false);
 
   katana::Result<void> DoStore(
-      RDGHandle handle, std::unique_ptr<tsuba::WriteGroup>& write_group);
+      RDGHandle handle, const katana::Uri& current_rdg_dir,
+      std::unique_ptr<tsuba::WriteGroup>& write_group);
 
   bool Equals(const RDGTopology& other) const;
 

--- a/libtsuba/src/PartitionTopologyMetadata.h
+++ b/libtsuba/src/PartitionTopologyMetadata.h
@@ -41,6 +41,9 @@ public:
   /// a PartitionTopologyMetadataEntry marked as invalid has been superseded and should not be stored
   bool invalid_{false};
 
+  /// The old location of the topology file, used during relocation of the RDG
+  std::string old_path_{""};
+
   void Update(
       std::string path, uint64_t num_edges, uint64_t num_nodes,
       bool edge_index_to_property_index_map_present,
@@ -113,6 +116,7 @@ public:
   // actual relocation occurs during RDG::Store, blanking the paths indicates we must relocate
   void ChangeStorageLocation() {
     for (size_t i = 0; i < num_entries_; i++) {
+      entries_.at(i).old_path_ = entries_.at(i).path_;
       entries_.at(i).path_ = "";
     }
   }

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -412,16 +412,12 @@ tsuba::RDG::DoMake(
   // populating topologies
   KATANA_CHECKED(core_->MakeTopologyManager(metadata_dir));
 
-  // find & bind the default csr topology
+  // ensure we can find the default csr topology
   RDGTopology shadow_csr = RDGTopology::MakeShadowCSR();
-  RDGTopology* csr =
-      KATANA_CHECKED(core_->topology_manager().GetTopology(shadow_csr));
-
+  RDGTopology* csr = KATANA_CHECKED_CONTEXT(
+      core_->topology_manager().GetTopology(shadow_csr),
+      "unable to find csr topology, must have csr topology");
   KATANA_LOG_VASSERT(csr != nullptr, "csr topology is null");
-  //TODO: emcginnis is there any reason we should be binding the csr topology here?
-  // getting it makes sense, to make sure it is present, but I don't think we need to bind it
-  // binding csr topology
-  KATANA_CHECKED(csr->Bind(metadata_dir));
 
   if (core_->part_header().IsEntityTypeIDsOutsideProperties()) {
     katana::Uri node_entity_type_id_array_path = metadata_dir.Join(
@@ -584,7 +580,7 @@ tsuba::RDG::Store(
   // All write buffers must outlive desc
   std::unique_ptr<WriteGroup> desc = KATANA_CHECKED(WriteGroup::Make());
 
-  KATANA_CHECKED(core_->topology_manager().DoStore(handle, desc));
+  KATANA_CHECKED(core_->topology_manager().DoStore(handle, rdg_dir(), desc));
 
   KATANA_CHECKED(DoStoreNodeEntityTypeIDArray(
       handle, std::move(node_entity_type_id_array_ff), desc));

--- a/libtsuba/src/RDGTopologyManager.h
+++ b/libtsuba/src/RDGTopologyManager.h
@@ -28,7 +28,8 @@ public:
   void Upsert(RDGTopology topo) {
     auto res = GetTopology(topo);
     if (res) {
-      // we already have a topology matching this one
+      // we already have a topology matching this one. Mark the existing topology as invalid so it is not stored,
+      // and add the new topology to the manager.
       RDGTopology* existing_topo = res.value();
       existing_topo->set_invalid();
     }
@@ -53,7 +54,8 @@ public:
   }
 
   katana::Result<void> DoStore(
-      RDGHandle handle, std::unique_ptr<tsuba::WriteGroup>& write_group);
+      RDGHandle handle, const katana::Uri& current_rdg_dir,
+      std::unique_ptr<tsuba::WriteGroup>& write_group);
 
   /// Extract metadata from an previous storage format topology
   /// Only should be used when transitioning from a previous storage format topology


### PR DESCRIPTION
Unbind RDGTopology FileView when no longer used

Currently, we bind the RdgTopology FileView, copy its contents to arrays
and then move on. This wastes a ton of memory since we effectively have
two copies of the topology in memory at once.

Unbind the RDGTopology FileView after we copy out its contents to reduce
our memory usage.
Must then rebind the RDGTopology FileView when persisting in a new
location

modified libtsuba optional topology test to:
 - unbind the topologies before calling store
 - copy the csr topology data it was making optional topologies from since the csr topology is now unbound
 - cleanup topology validation code, and tmp rdg cleanup code

JIRA: KAT-2498