### PR TITLE
Add edge iterator to python graphs

### DIFF
--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -22,6 +22,7 @@ from libcpp.vector cimport vector
 
 from ..native_interfacing.buffer_access cimport to_pyarrow
 from .entity_type cimport EntityType
+from .edge_iterator import EdgeIterator
 
 from abc import abstractmethod
 
@@ -143,6 +144,12 @@ cdef class GraphBase:
         Can be called from numba compiled code with the name `self.nodes()`.
         """
         return iter(range(self.num_nodes()))
+
+    def edge_iterator(self):
+        """
+        Returns an iterator over the edges of this graph.
+        """
+        return EdgeIterator(self)
 
     def edges(self, uint64_t n):
         """

--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -22,9 +22,10 @@ from libcpp.vector cimport vector
 
 from ..native_interfacing.buffer_access cimport to_pyarrow
 from .entity_type cimport EntityType
-from .edge_iterator import EdgeIterator
 
 from abc import abstractmethod
+
+from .edge_iterator import EdgeIterator
 
 __all__ = ["GraphBase", "Graph"]
 

--- a/python/katana/local/edge_iterator.py
+++ b/python/katana/local/edge_iterator.py
@@ -1,4 +1,4 @@
-class EdgeIterator():
+class EdgeIterator:
     """
     An iterator over the edges of a graph
     """

--- a/python/katana/local/edge_iterator.py
+++ b/python/katana/local/edge_iterator.py
@@ -1,0 +1,24 @@
+class EdgeIterator():
+    """
+    An iterator over the edges of a graph
+    """
+
+    def __init__(self, graph):
+        self._graph = graph
+        self._curr_node = 0
+        self._curr_edge = 0
+
+    def __next__(self):
+        if self._curr_edge >= self._graph.num_edges():
+            raise StopIteration
+        if len(self._graph.edges(self._curr_node)) == 0:
+            self._curr_node += 1
+            return self.__next__()
+        if self._curr_edge > self._graph.edges(self._curr_node)[-1]:
+            self._curr_node += 1
+        next_edge = (self._curr_node, self._graph.get_edge_dest(self._curr_edge))
+        self._curr_edge += 1
+        return next_edge
+
+    def __iter__(self):
+        return self

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -252,6 +252,7 @@ def test_simple_algorithm(graph):
     assert oprop[4].as_py() == 0
     assert oprop[-1].as_py() == 0
 
+
 def test_edge_iterator(graph):
     edges = graph.edge_iterator()
     for i, edge in enumerate(edges):

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -251,3 +251,9 @@ def test_simple_algorithm(graph):
     assert oprop[0].as_py() == 0
     assert oprop[4].as_py() == 0
     assert oprop[-1].as_py() == 0
+
+def test_edge_iterator(graph):
+    edges = graph.edge_iterator()
+    for i, edge in enumerate(edges):
+        expected_dest = graph.get_edge_dest(i)
+        assert edge[-1] == expected_dest


### PR DESCRIPTION
Previously, there was no easy way to step through all the edges of a graph in python, especially if you want the edge source, dest pairs. This PR adds a method to the python Graph objects which provides an iterator over all the edges in the graph. This iterator returns tuples of the form (src, dest).

This will be used in downstream data science applications. Being able to get an edge list like this from a graph is an important operation in conversion to DGL/PyG graph representation, as well as allow sampling over edges uniformly at random.