### PR TITLE
GraphTopology: don't barf on corner case where partition is empty

### DIFF
--- a/libgalois/src/GraphTopology.cpp
+++ b/libgalois/src/GraphTopology.cpp
@@ -152,18 +152,22 @@ katana::EdgeShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
   PropIndexVec edge_prop_indices;
   edge_prop_indices.allocateInterleaved(rdg_topo->num_edges());
 
-  katana::ParallelSTL::copy(
-      &(rdg_topo->adj_indices()[0]),
-      &(rdg_topo->adj_indices()[rdg_topo->num_nodes()]),
-      adj_indices_copy.begin());
-  katana::ParallelSTL::copy(
-      &(rdg_topo->dests()[0]), &(rdg_topo->dests()[rdg_topo->num_edges()]),
-      dests_copy.begin());
+  if (rdg_topo->num_nodes() > 0) {
+    katana::ParallelSTL::copy(
+        &(rdg_topo->adj_indices()[0]),
+        &(rdg_topo->adj_indices()[rdg_topo->num_nodes()]),
+        adj_indices_copy.begin());
+  }
+  if (rdg_topo->num_edges() > 0) {
+    katana::ParallelSTL::copy(
+        &(rdg_topo->dests()[0]), &(rdg_topo->dests()[rdg_topo->num_edges()]),
+        dests_copy.begin());
 
-  katana::ParallelSTL::copy(
-      &(rdg_topo->edge_index_to_property_index_map()[0]),
-      &(rdg_topo->edge_index_to_property_index_map()[rdg_topo->num_edges()]),
-      edge_prop_indices.begin());
+    katana::ParallelSTL::copy(
+        &(rdg_topo->edge_index_to_property_index_map()[0]),
+        &(rdg_topo->edge_index_to_property_index_map()[rdg_topo->num_edges()]),
+        edge_prop_indices.begin());
+  }
 
   // Since we copy the data we need out of the RDGTopology into our own arrays,
   // unbind the RDGTopologys file store to save memory.

--- a/libtsuba/include/tsuba/RDGTopology.h
+++ b/libtsuba/include/tsuba/RDGTopology.h
@@ -143,20 +143,26 @@ public:
   /// Optional field, may not be present depending on the kind of topology this is
   /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
   const katana::EntityTypeID* edge_condensed_type_id_map() const {
-    KATANA_LOG_VASSERT(
-        edge_condensed_type_id_map_ != nullptr,
-        "Either this optional field is not present, or the RDGTopology must be "
-        "either bound & mapped, or filled from memory.");
+    if (edge_condensed_type_id_map_size() > 0) {
+      KATANA_LOG_VASSERT(
+          edge_condensed_type_id_map_ != nullptr,
+          "Either this optional field is not present, or the RDGTopology must "
+          "be "
+          "either bound & mapped, or filled from memory.");
+    }
     return edge_condensed_type_id_map_;
   }
 
   /// Optional field, may not be present depending on the kind of topology this is
   /// Requires backing FileView to be mapped & bound, or the RDGTopology to be filled from memory
   const katana::EntityTypeID* node_condensed_type_id_map() const {
-    KATANA_LOG_VASSERT(
-        node_condensed_type_id_map_ != nullptr,
-        "Either this optional field is not present, or the RDGTopology must be "
-        "either bound & mapped, or filled from memory.");
+    if (node_condensed_type_id_map_size() > 0) {
+      KATANA_LOG_VASSERT(
+          node_condensed_type_id_map_ != nullptr,
+          "Either this optional field is not present, or the RDGTopology must "
+          "be "
+          "either bound & mapped, or filled from memory.");
+    }
     return node_condensed_type_id_map_;
   }
 

--- a/libtsuba/src/FileView.cpp
+++ b/libtsuba/src/FileView.cpp
@@ -45,7 +45,7 @@ FileView::Unbind() {
     // about to unmap
     KATANA_CHECKED(Resolve(0, file_size_));
 
-    if (map_start_ != nullptr) {
+    if (map_start_ != nullptr && file_size_ > 0) {
       if (int err = munmap(map_start_, file_size_); err) {
         return KATANA_ERROR(katana::ResultErrno(), "unmapping buffer");
       }


### PR DESCRIPTION
For some small graphs: if the user partitions them they have no nodes
or edges on some host. In this case some of these checks are too strong.

These adjustments let me load my tiny graph on 4 hosts.

I think this is causing the GraphML CI flake, the GraphML test graph is
small and random partitioning means that sometimes hosts are left
without any data.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>