### PR TITLE
PropertyGraph: remove type properties after inference during V1 convert

### DIFF
--- a/libgalois/src/PropertyGraph.cpp
+++ b/libgalois/src/PropertyGraph.cpp
@@ -347,9 +347,13 @@ katana::PropertyGraph::ConstructEntityTypeIDs() {
   node_entity_type_manager_ = EntityTypeManager{};
   node_entity_type_ids_ = EntityTypeIDArray{};
   node_entity_type_ids_.allocateInterleaved(num_nodes());
-  KATANA_CHECKED(EntityTypeManager::AssignEntityTypeIDsFromProperties(
-      num_nodes(), rdg_.node_properties(), &node_entity_type_manager_,
-      &node_entity_type_ids_));
+  auto node_props_to_remove =
+      KATANA_CHECKED(EntityTypeManager::AssignEntityTypeIDsFromProperties(
+          num_nodes(), rdg_.node_properties(), &node_entity_type_manager_,
+          &node_entity_type_ids_));
+  for (const auto& node_prop : node_props_to_remove) {
+    KATANA_CHECKED(RemoveNodeProperty(node_prop));
+  }
 
   int64_t total_num_edge_props = full_edge_schema()->num_fields();
   for (int64_t i = 0; i < total_num_edge_props; ++i) {
@@ -363,9 +367,13 @@ katana::PropertyGraph::ConstructEntityTypeIDs() {
   edge_entity_type_manager_ = EntityTypeManager{};
   edge_entity_type_ids_ = EntityTypeIDArray{};
   edge_entity_type_ids_.allocateInterleaved(num_edges());
-  KATANA_CHECKED(EntityTypeManager::AssignEntityTypeIDsFromProperties(
-      num_edges(), rdg_.edge_properties(), &edge_entity_type_manager_,
-      &edge_entity_type_ids_));
+  auto edge_props_to_remove =
+      KATANA_CHECKED(EntityTypeManager::AssignEntityTypeIDsFromProperties(
+          num_edges(), rdg_.edge_properties(), &edge_entity_type_manager_,
+          &edge_entity_type_ids_));
+  for (const auto& edge_prop : edge_props_to_remove) {
+    KATANA_CHECKED(RemoveEdgeProperty(edge_prop));
+  }
 
   return katana::ResultSuccess();
 }

--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -137,8 +137,11 @@ public:
   /// The length of entity_type_ids should be equal to topo_size.
   /// properties->num_rows() should be equal to the length of entity_type_ids or
   /// 0.
+  ///
+  /// It returns a list of the properties used for types so that they can be
+  /// removed as properties.
   template <typename EntityTypeArray>
-  static Result<void> AssignEntityTypeIDsFromProperties(
+  static Result<std::vector<std::string>> AssignEntityTypeIDsFromProperties(
       const size_t topo_size,  // == either num_nodes() or  num_edges()
       const std::shared_ptr<arrow::Table>& properties,
       katana::EntityTypeManager* entity_type_manager,
@@ -161,7 +164,7 @@ public:
     if (num_rows == 0) {
       std::fill(
           entity_type_ids->begin(), entity_type_ids->end(), kUnknownEntityType);
-      return ResultSuccess();
+      return std::vector<std::string>();
     }
     auto num_rows_for_comparison = static_cast<size_t>(num_rows);
     if (entity_type_ids->size() != num_rows_for_comparison) {
@@ -175,7 +178,7 @@ public:
     auto res =
         DoAssignEntityTypeIDsFromProperties(properties, entity_type_manager);
     if (!res) {
-      return ResultError(std::move(res.error()));
+      return katana::Result<std::vector<std::string>>(std::move(res.error()));
     }
     TypeProperties type_properties = std::move(res.value());
 
@@ -197,7 +200,13 @@ public:
       }
     }
 
-    return ResultSuccess();
+    std::vector<std::string> properties_used;
+    for (const auto& prop_col : type_properties.uint8_properties) {
+      properties_used.emplace_back(
+          properties->field(prop_col.field_index)->name());
+    }
+
+    return properties_used;
   }
 
   /// adds a new entity type for the atomic type with name \p name

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -15,8 +15,8 @@ from katana.local.import_data import from_csr
 def test_load(graph):
     assert graph.num_nodes() == 29946
     assert graph.num_edges() == 43072
-    assert len(graph.loaded_node_schema()) == 31
-    assert len(graph.loaded_edge_schema()) == 18
+    assert len(graph.loaded_node_schema()) == 17
+    assert len(graph.loaded_edge_schema()) == 3
 
 
 def test_write(graph):
@@ -27,8 +27,8 @@ def test_write(graph):
         graph = Graph(tmpdir)
     assert graph.num_nodes() == 29946
     assert graph.num_edges() == 43072
-    assert len(graph.loaded_node_schema()) == 31
-    assert len(graph.loaded_edge_schema()) == 18
+    assert len(graph.loaded_node_schema()) == 17
+    assert len(graph.loaded_edge_schema()) == 3
 
     assert graph == old_graph
 
@@ -43,8 +43,8 @@ def test_commit(graph):
         graph = Graph(tmpdir)
     assert graph.num_nodes() == 29092
     assert graph.num_edges() == 39283
-    assert len(graph.loaded_node_schema()) == 31
-    assert len(graph.loaded_edge_schema()) == 19
+    assert len(graph.loaded_node_schema()) == 17
+    assert len(graph.loaded_edge_schema()) == 3
 
 
 def test_get_edge_dest(graph):
@@ -94,9 +94,9 @@ def test_get_node_property_chunked(graph):
 
 def test_remove_node_property(graph):
     graph.remove_node_property(10)
-    assert len(graph.loaded_node_schema()) == 30
+    assert len(graph.loaded_node_schema()) == 16
     graph.remove_node_property("length")
-    assert len(graph.loaded_node_schema()) == 29
+    assert len(graph.loaded_node_schema()) == 15
     assert graph.loaded_node_schema()[4].name == "email"
 
 
@@ -127,33 +127,33 @@ def test_upsert_node_property(graph):
     prop = graph.loaded_node_schema().names[0]
     t = pyarrow.table({prop: range(graph.num_nodes())})
     graph.upsert_node_property(t)
-    assert len(graph.loaded_node_schema()) == 31
+    assert len(graph.loaded_node_schema()) == 17
     assert graph.get_node_property_chunked(prop) == pyarrow.chunked_array([range(graph.num_nodes())])
     assert graph.get_node_property(prop) == pyarrow.array(range(graph.num_nodes()))
 
 
 def test_get_edge_property(graph):
-    prop1 = graph.get_edge_property(15)
+    prop1 = graph.get_edge_property(2)
     assert not prop1[10].as_py()
     # TODO re-enable this test
-    # prop2 = graph.get_edge_property("IS_SUBCLASS_OF")
+    # prop2 = graph.get_edge_property("creationDate")
     # assert prop1 == prop2
 
 
 def test_get_edge_property_chunked(graph):
-    prop1 = graph.get_edge_property(5)
+    prop1 = graph.get_edge_property(2)
     assert isinstance(prop1, pyarrow.Array)
-    prop2 = graph.get_edge_property_chunked(5)
+    prop2 = graph.get_edge_property_chunked(2)
     assert isinstance(prop2, pyarrow.ChunkedArray)
     assert prop1 == prop2.chunk(0)
 
 
 def test_remove_edge_property(graph):
-    graph.remove_edge_property(7)
-    assert len(graph.loaded_edge_schema()) == 17
+    graph.remove_edge_property(2)
+    assert len(graph.loaded_edge_schema()) == 2
     graph.remove_edge_property("classYear")
-    assert len(graph.loaded_edge_schema()) == 16
-    assert graph.loaded_edge_schema()[3].name == "HAS_CREATOR"
+    assert len(graph.loaded_edge_schema()) == 1
+    assert graph.loaded_edge_schema()[0].name == "creationDate"
 
 
 def test_add_edge_property_exception(graph):
@@ -166,7 +166,7 @@ def test_add_edge_property_exception(graph):
 def test_add_edge_property(graph):
     t = pyarrow.table(dict(new_prop=range(graph.num_edges())))
     graph.add_edge_property(t)
-    assert len(graph.loaded_edge_schema()) == 19
+    assert len(graph.loaded_edge_schema()) == 4
     assert graph.get_edge_property("new_prop") == pyarrow.array(range(graph.num_edges()))
 
 
@@ -174,14 +174,14 @@ def test_upsert_edge_property(graph):
     prop = graph.loaded_edge_schema().names[0]
     t = pyarrow.table({prop: range(graph.num_edges())})
     graph.upsert_edge_property(t)
-    assert len(graph.loaded_edge_schema()) == 18
+    assert len(graph.loaded_edge_schema()) == 3
     assert graph.get_edge_property(prop) == pyarrow.array(range(graph.num_edges()))
 
 
 def test_upsert_edge_property_dict(graph):
     prop = graph.loaded_edge_schema().names[0]
     graph.upsert_edge_property({prop: range(graph.num_edges())})
-    assert len(graph.loaded_edge_schema()) == 18
+    assert len(graph.loaded_edge_schema()) == 3
     assert graph.get_edge_property(prop) == pyarrow.array(range(graph.num_edges()))
 
 


### PR DESCRIPTION
I noticed that RDGs we convert still keep references to these files.
They're not useful and can actually be confusing for cases when a caller
want's to iterate over properties.

They also cause problems for some code paths that aren't aware they
should ignore uint8 properties (like Ensure{Node,Edge}PropertyLoaded)
which is what got me looking at this.

Eventually, I think we should re-introduce support for the uint8 type,
but our codebase's dislike for the type is too far reaching to adress
in a release bugfix PR.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>