### PR TITLE
View cache stores topologies behind shared pointers.

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -83,7 +83,7 @@ private:
   tsuba::RDG rdg_;
   std::unique_ptr<tsuba::RDGFile> file_;
 
-  GraphTopology topology_;
+  std::shared_ptr<katana::GraphTopology> topology_;
 
   /// Manages the relations between the node entity types
   EntityTypeManager node_entity_type_manager_;
@@ -235,7 +235,7 @@ public:
       EntityTypeManager&& edge_type_manager) noexcept
       : rdg_(std::move(rdg)),
         file_(std::move(rdg_file)),
-        topology_(std::move(topo)),
+        topology_(std::make_shared<GraphTopology>(std::move(topo))),
         node_entity_type_manager_(std::move(node_type_manager)),
         edge_entity_type_manager_(std::move(edge_type_manager)),
         node_entity_type_ids_(std::move(node_entity_type_ids)),
@@ -650,7 +650,7 @@ public:
     return MakeResult(std::move(array));
   }
 
-  const GraphTopology& topology() const noexcept { return topology_; }
+  const GraphTopology& topology() const noexcept { return *topology_; }
 
   const EntityTypeManager& node_entity_type_manager() const noexcept {
     return node_entity_type_manager_;

--- a/libgalois/src/GraphTopology.cpp
+++ b/libgalois/src/GraphTopology.cpp
@@ -42,15 +42,15 @@ katana::GraphTopology::Copy(const GraphTopology& that) noexcept {
       that.dests_.size());
 }
 
-std::unique_ptr<katana::ShuffleTopology>
+std::shared_ptr<katana::ShuffleTopology>
 katana::ShuffleTopology::MakeFrom(
     const PropertyGraph*, const katana::EdgeShuffleTopology&) noexcept {
   KATANA_LOG_FATAL("Not implemented yet");
-  std::unique_ptr<ShuffleTopology> ret;
+  std::shared_ptr<ShuffleTopology> ret;
   return ret;
 }
 
-std::unique_ptr<katana::EdgeShuffleTopology>
+std::shared_ptr<katana::EdgeShuffleTopology>
 katana::EdgeShuffleTopology::MakeTransposeCopy(
     const katana::PropertyGraph* pg) {
   KATANA_LOG_DEBUG_ASSERT(pg);
@@ -59,7 +59,7 @@ katana::EdgeShuffleTopology::MakeTransposeCopy(
   if (topology.empty()) {
     EdgeShuffleTopology et;
     et.tpose_state_ = tsuba::RDGTopology::TransposeKind::kYes;
-    return std::make_unique<EdgeShuffleTopology>(std::move(et));
+    return std::make_shared<EdgeShuffleTopology>(std::move(et));
   }
 
   GraphTopologyTypes::AdjIndexVec out_indices;
@@ -119,13 +119,13 @@ katana::EdgeShuffleTopology::MakeTransposeCopy(
       },
       katana::steal(), katana::no_stats());
 
-  return std::make_unique<EdgeShuffleTopology>(EdgeShuffleTopology{
+  return std::make_shared<EdgeShuffleTopology>(EdgeShuffleTopology{
       tsuba::RDGTopology::TransposeKind::kYes,
       tsuba::RDGTopology::EdgeSortKind::kAny, std::move(out_indices),
       std::move(out_dests), std::move(edge_prop_indices)});
 }
 
-std::unique_ptr<katana::EdgeShuffleTopology>
+std::shared_ptr<katana::EdgeShuffleTopology>
 katana::EdgeShuffleTopology::MakeOriginalCopy(const katana::PropertyGraph* pg) {
   GraphTopology copy_topo = GraphTopology::Copy(pg->topology());
 
@@ -134,14 +134,14 @@ katana::EdgeShuffleTopology::MakeOriginalCopy(const katana::PropertyGraph* pg) {
   katana::ParallelSTL::iota(
       edge_prop_indices.begin(), edge_prop_indices.end(), Edge{0});
 
-  return std::make_unique<EdgeShuffleTopology>(EdgeShuffleTopology{
+  return std::make_shared<EdgeShuffleTopology>(EdgeShuffleTopology{
       tsuba::RDGTopology::TransposeKind::kNo,
       tsuba::RDGTopology::EdgeSortKind::kAny,
       std::move(copy_topo.GetAdjIndices()), std::move(copy_topo.GetDests()),
       std::move(edge_prop_indices)});
 }
 
-std::unique_ptr<katana::EdgeShuffleTopology>
+std::shared_ptr<katana::EdgeShuffleTopology>
 katana::EdgeShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
   KATANA_LOG_DEBUG_ASSERT(rdg_topo);
 
@@ -174,8 +174,8 @@ katana::EdgeShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
   auto res = rdg_topo->unbind_file_storage();
   KATANA_LOG_ASSERT(res);
 
-  std::unique_ptr<EdgeShuffleTopology> shuffle =
-      std::make_unique<EdgeShuffleTopology>(EdgeShuffleTopology{
+  std::shared_ptr<EdgeShuffleTopology> shuffle =
+      std::make_shared<EdgeShuffleTopology>(EdgeShuffleTopology{
           rdg_topo->transpose_state(), rdg_topo->edge_sort_state(),
           std::move(adj_indices_copy), std::move(dests_copy),
           std::move(edge_prop_indices)});
@@ -354,7 +354,7 @@ katana::EdgeShuffleTopology::SortEdgesByDestType(
   KATANA_LOG_FATAL("Not implemented yet");
 }
 
-std::unique_ptr<katana::ShuffleTopology>
+std::shared_ptr<katana::ShuffleTopology>
 katana::ShuffleTopology::MakeSortedByDegree(
     const PropertyGraph*,
     const katana::EdgeShuffleTopology& seed_topo) noexcept {
@@ -372,7 +372,7 @@ katana::ShuffleTopology::MakeSortedByDegree(
       seed_topo, cmp, tsuba::RDGTopology::NodeSortKind::kSortedByDegree);
 }
 
-std::unique_ptr<katana::ShuffleTopology>
+std::shared_ptr<katana::ShuffleTopology>
 katana::ShuffleTopology::MakeSortedByNodeType(
     const PropertyGraph* pg,
     const katana::EdgeShuffleTopology& seed_topo) noexcept {
@@ -389,7 +389,7 @@ katana::ShuffleTopology::MakeSortedByNodeType(
       seed_topo, cmp, tsuba::RDGTopology::NodeSortKind::kSortedByNodeType);
 }
 
-std::unique_ptr<katana::ShuffleTopology>
+std::shared_ptr<katana::ShuffleTopology>
 katana::ShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
   KATANA_LOG_DEBUG_ASSERT(rdg_topo);
   EdgeDestVec dests_copy;
@@ -424,8 +424,8 @@ katana::ShuffleTopology::Make(tsuba::RDGTopology* rdg_topo) {
   auto res = rdg_topo->unbind_file_storage();
   KATANA_LOG_ASSERT(res);
 
-  std::unique_ptr<ShuffleTopology> shuffle =
-      std::make_unique<ShuffleTopology>(ShuffleTopology{
+  std::shared_ptr<ShuffleTopology> shuffle =
+      std::make_shared<ShuffleTopology>(ShuffleTopology{
           rdg_topo->transpose_state(), rdg_topo->node_sort_state(),
           rdg_topo->edge_sort_state(), std::move(adj_indices_copy),
           std::move(node_prop_indices_copy), std::move(dests_copy),
@@ -444,7 +444,7 @@ katana::ShuffleTopology::ToRDGTopology() const {
   return tsuba::RDGTopology(std::move(topo));
 }
 
-std::unique_ptr<katana::CondensedTypeIDMap>
+std::shared_ptr<katana::CondensedTypeIDMap>
 katana::CondensedTypeIDMap::MakeFromEdgeTypes(
     const katana::PropertyGraph* pg) noexcept {
   TypeIDToIndexMap edge_type_to_index;
@@ -485,7 +485,7 @@ katana::CondensedTypeIDMap::MakeFromEdgeTypes(
     *edgeTypes.getLocal() = gstl::Set<katana::EntityTypeID>();
   });
 
-  return std::make_unique<CondensedTypeIDMap>(CondensedTypeIDMap{
+  return std::make_shared<CondensedTypeIDMap>(CondensedTypeIDMap{
       std::move(edge_type_to_index), std::move(edge_index_to_type)});
 }
 
@@ -537,21 +537,22 @@ katana::EdgeTypeAwareTopology::CreatePerEdgeTypeAdjacencyIndex(
   return adj_indices;
 }
 
-std::unique_ptr<katana::EdgeTypeAwareTopology>
+std::shared_ptr<katana::EdgeTypeAwareTopology>
 katana::EdgeTypeAwareTopology::MakeFrom(
     const katana::PropertyGraph* pg,
-    const katana::CondensedTypeIDMap* edge_type_index,
-    const katana::EdgeShuffleTopology* e_topo) noexcept {
+    std::shared_ptr<const CondensedTypeIDMap> edge_type_index,
+    std::shared_ptr<const EdgeShuffleTopology> e_topo) noexcept {
   KATANA_LOG_DEBUG_ASSERT(e_topo->has_edges_sorted_by(
       tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType));
 
   KATANA_LOG_DEBUG_ASSERT(e_topo->num_edges() == pg->topology().num_edges());
 
   AdjIndexVec per_type_adj_indices =
-      CreatePerEdgeTypeAdjacencyIndex(pg, edge_type_index, e_topo);
+      CreatePerEdgeTypeAdjacencyIndex(pg, edge_type_index.get(), e_topo.get());
 
-  return std::make_unique<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
-      edge_type_index, e_topo, std::move(per_type_adj_indices)});
+  return std::make_shared<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
+      std::move(edge_type_index), std::move(e_topo),
+      std::move(per_type_adj_indices)});
 }
 
 katana::Result<tsuba::RDGTopology>
@@ -567,10 +568,11 @@ katana::EdgeTypeAwareTopology::ToRDGTopology() const {
   return tsuba::RDGTopology(std::move(topo));
 }
 
-std::unique_ptr<katana::EdgeTypeAwareTopology>
+std::shared_ptr<katana::EdgeTypeAwareTopology>
 katana::EdgeTypeAwareTopology::Make(
-    tsuba::RDGTopology* rdg_topo, const CondensedTypeIDMap* edge_type_index,
-    const katana::EdgeShuffleTopology* e_topo) {
+    tsuba::RDGTopology* rdg_topo,
+    std::shared_ptr<const CondensedTypeIDMap> edge_type_index,
+    std::shared_ptr<const EdgeShuffleTopology> e_topo) {
   KATANA_LOG_DEBUG_ASSERT(rdg_topo);
   KATANA_LOG_ASSERT(
       rdg_topo->edge_sort_state() ==
@@ -602,8 +604,9 @@ katana::EdgeTypeAwareTopology::Make(
   auto res = rdg_topo->unbind_file_storage();
   KATANA_LOG_ASSERT(res);
 
-  return std::make_unique<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
-      edge_type_index, e_topo, std::move(per_type_adj_indices)});
+  return std::make_shared<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
+      std::move(edge_type_index), std::move(e_topo),
+      std::move(per_type_adj_indices)});
 }
 
 /// This function converts a bitset to a bitmask
@@ -632,7 +635,7 @@ katana::ProjectedTopology::FillBitMask(
   });
 }
 
-std::unique_ptr<katana::ProjectedTopology>
+std::shared_ptr<katana::ProjectedTopology>
 katana::ProjectedTopology::CreateEmptyEdgeProjectedTopology(
     const katana::PropertyGraph* pg, uint32_t num_new_nodes,
     const katana::DynamicBitset& bitset) {
@@ -668,7 +671,7 @@ katana::ProjectedTopology::CreateEmptyEdgeProjectedTopology(
   NUMAArray<uint8_t> edge_bitmask;
   edge_bitmask.allocateInterleaved((topology.num_edges() + 7) / 8);
 
-  return std::make_unique<katana::ProjectedTopology>(katana::ProjectedTopology{
+  return std::make_shared<katana::ProjectedTopology>(katana::ProjectedTopology{
       std::move(out_indices), std::move(out_dests),
       std::move(original_to_projected_nodes_mapping),
       std::move(projected_to_original_nodes_mapping),
@@ -677,13 +680,13 @@ katana::ProjectedTopology::CreateEmptyEdgeProjectedTopology(
       std::move(edge_bitmask)});
 }
 
-std::unique_ptr<katana::ProjectedTopology>
+std::shared_ptr<katana::ProjectedTopology>
 katana::ProjectedTopology::CreateEmptyProjectedTopology(
     const katana::PropertyGraph* pg, const katana::DynamicBitset& bitset) {
   return CreateEmptyEdgeProjectedTopology(pg, 0, bitset);
 }
 
-std::unique_ptr<katana::ProjectedTopology>
+std::shared_ptr<katana::ProjectedTopology>
 katana::ProjectedTopology::MakeTypeProjectedTopology(
     const katana::PropertyGraph* pg, const std::vector<std::string>& node_types,
     const std::vector<std::string>& edge_types) {
@@ -691,7 +694,7 @@ katana::ProjectedTopology::MakeTypeProjectedTopology(
 
   const auto& topology = pg->topology();
   if (topology.empty()) {
-    return std::make_unique<ProjectedTopology>(ProjectedTopology());
+    return std::make_shared<ProjectedTopology>(ProjectedTopology());
   }
 
   // calculate number of new nodes
@@ -895,7 +898,7 @@ katana::ProjectedTopology::MakeTypeProjectedTopology(
   });
 
   FillBitMask(topology.num_edges(), bitset_edges, &edge_bitmask);
-  return std::make_unique<ProjectedTopology>(ProjectedTopology{
+  return std::make_shared<ProjectedTopology>(ProjectedTopology{
       std::move(out_indices), std::move(out_dests),
       std::move(original_to_projected_nodes_mapping),
       std::move(projected_to_original_nodes_mapping),
@@ -903,22 +906,22 @@ katana::ProjectedTopology::MakeTypeProjectedTopology(
       std::move(projected_to_original_edges_mapping), std::move(node_bitmask),
       std::move(edge_bitmask)});
 }
-const katana::GraphTopology*
+std::shared_ptr<katana::GraphTopology>
 katana::PGViewCache::GetOriginalTopology(
     const PropertyGraph* pg) const noexcept {
-  return &pg->topology();
+  return pg->topology_;
 }
 
-katana::CondensedTypeIDMap*
+std::shared_ptr<katana::CondensedTypeIDMap>
 katana::PGViewCache::BuildOrGetEdgeTypeIndex(
     const katana::PropertyGraph* pg) noexcept {
   if (edge_type_id_map_ && edge_type_id_map_->is_valid()) {
-    return edge_type_id_map_.get();
+    return edge_type_id_map_;
   }
 
   edge_type_id_map_ = CondensedTypeIDMap::MakeFromEdgeTypes(pg);
   KATANA_LOG_DEBUG_ASSERT(edge_type_id_map_);
-  return edge_type_id_map_.get();
+  return edge_type_id_map_;
 };
 
 template <typename Topo>
@@ -928,7 +931,7 @@ CheckTopology(const katana::PropertyGraph* pg, const Topo* t) noexcept {
          (pg->num_edges() == t->num_edges());
 }
 
-katana::EdgeShuffleTopology*
+std::shared_ptr<katana::EdgeShuffleTopology>
 katana::PGViewCache::BuildOrGetEdgeShuffTopo(
     katana::PropertyGraph* pg,
     const tsuba::RDGTopology::TransposeKind& tpose_kind,
@@ -943,7 +946,7 @@ katana::PGViewCache::BuildOrGetEdgeShuffTopo(
 
   if (it != edge_shuff_topos_.end()) {
     KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, it->get()));
-    return it->get();
+    return *it;
   } else {
     // no matching topology in cache, see if we have it in storage
     tsuba::RDGTopology shadow = tsuba::RDGTopology::MakeShadow(
@@ -962,11 +965,11 @@ katana::PGViewCache::BuildOrGetEdgeShuffTopo(
     }
 
     KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, edge_shuff_topos_.back().get()));
-    return edge_shuff_topos_.back().get();
+    return edge_shuff_topos_.back();
   }
 }
 
-katana::ShuffleTopology*
+std::shared_ptr<katana::ShuffleTopology>
 katana::PGViewCache::BuildOrGetShuffTopo(
     katana::PropertyGraph* pg,
     const tsuba::RDGTopology::TransposeKind& tpose_kind,
@@ -984,7 +987,7 @@ katana::PGViewCache::BuildOrGetShuffTopo(
 
   if (it != fully_shuff_topos_.end()) {
     KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, it->get()));
-    return it->get();
+    return *it;
   } else {
     // no matching topology in cache, see if we have it in storage
 
@@ -1014,11 +1017,11 @@ katana::PGViewCache::BuildOrGetShuffTopo(
     }
 
     KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, fully_shuff_topos_.back().get()));
-    return fully_shuff_topos_.back().get();
+    return fully_shuff_topos_.back();
   }
 }
 
-katana::EdgeTypeAwareTopology*
+std::shared_ptr<katana::EdgeTypeAwareTopology>
 katana::PGViewCache::BuildOrGetEdgeTypeAwareTopo(
     katana::PropertyGraph* pg,
     const tsuba::RDGTopology::TransposeKind& tpose_kind) noexcept {
@@ -1031,7 +1034,7 @@ katana::PGViewCache::BuildOrGetEdgeTypeAwareTopo(
 
   if (it != edge_type_aware_topos_.end()) {
     KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, it->get()));
-    return it->get();
+    return *it;
   } else {
     // no matching topology in cache, see if we have it in storage
 
@@ -1057,33 +1060,31 @@ katana::PGViewCache::BuildOrGetEdgeTypeAwareTopo(
       tsuba::RDGTopology* rdg_topo = res.value();
 
       edge_type_aware_topos_.emplace_back(katana::EdgeTypeAwareTopology::Make(
-          rdg_topo, edge_type_index, sorted_topo));
-    }
-
-    else {
+          rdg_topo, std::move(edge_type_index), std::move(sorted_topo)));
+    } else {
       // no matching topology in cache or storage, generate it
-      edge_type_aware_topos_.emplace_back(
-          EdgeTypeAwareTopology::MakeFrom(pg, edge_type_index, sorted_topo));
+      edge_type_aware_topos_.emplace_back(EdgeTypeAwareTopology::MakeFrom(
+          pg, std::move(edge_type_index), std::move(sorted_topo)));
     }
 
     KATANA_LOG_DEBUG_ASSERT(
         CheckTopology(pg, edge_type_aware_topos_.back().get()));
-    return edge_type_aware_topos_.back().get();
+    return edge_type_aware_topos_.back();
   }
 }
 
-katana::ProjectedTopology*
+std::shared_ptr<katana::ProjectedTopology>
 katana::PGViewCache::BuildOrGetProjectedGraphTopo(
     const PropertyGraph* pg, const std::vector<std::string>& node_types,
     const std::vector<std::string>& edge_types) noexcept {
   if (projected_topos_) {
-    return projected_topos_.get();
+    return projected_topos_;
   }
 
   projected_topos_ =
       ProjectedTopology::MakeTypeProjectedTopology(pg, node_types, edge_types);
   KATANA_LOG_DEBUG_ASSERT(projected_topos_);
-  return projected_topos_.get();
+  return projected_topos_;
 }
 
 katana::Result<std::vector<tsuba::RDGTopology>>

--- a/libgalois/src/PropertyGraphRetractor.cpp
+++ b/libgalois/src/PropertyGraphRetractor.cpp
@@ -16,6 +16,6 @@ katana::PropertyGraphRetractor::InformPath(const std::string& input_path) {
 Result<void>
 katana::PropertyGraphRetractor::DropTopologies() {
   //TODO: emcginnis reset all topologies in PGViewCache
-  pg_->topology_ = GraphTopology{};
+  pg_->topology_ = nullptr;
   return pg_->rdg_.DropAllTopologies();
 }


### PR DESCRIPTION
This PR changes how topologies are stored in the PG view cache, to use shared pointers instead of unique pointers. This is the preliminary step in support of safe destruction of unused topologies.