### PR TITLE
RDG Slice work

### DIFF
--- a/libgalois/include/katana/GraphHelpers.h
+++ b/libgalois/include/katana/GraphHelpers.h
@@ -234,22 +234,16 @@ divideNodesBinarySearch(
       edgePrefixSum, edgeOffset, nodeOffset);
 
   // get the edges bounds using node lower/upper bounds
-  uint64_t edgesLower = numEdges;
-  uint64_t edgesUpper = numEdges;
-
-  if (nodesLower != nodesUpper) {
-    if ((nodesLower + nodeOffset) != 0) {
-      edgesLower = internal::getEdgePrefixSum(
-                       edgePrefixSum, nodesLower - 1 + nodeOffset) -
-                   edgeOffset;
-    } else {
-      edgesLower = 0;
-    }
-
-    edgesUpper =
-        internal::getEdgePrefixSum(edgePrefixSum, nodesUpper - 1 + nodeOffset) -
-        edgeOffset;
-  }
+  uint64_t edgesLower = (nodesLower + nodeOffset == 0)
+                            ? 0
+                            : internal::getEdgePrefixSum(
+                                  edgePrefixSum, nodesLower - 1 + nodeOffset) -
+                                  edgeOffset;
+  uint64_t edgesUpper = (nodesUpper + nodeOffset == 0)
+                            ? 0
+                            : internal::getEdgePrefixSum(
+                                  edgePrefixSum, nodesUpper - 1 + nodeOffset) -
+                                  edgeOffset;
 
   // katana::gDebug("Unit ", id, " nodes ", nodesLower, " to ",
   //               nodesUpper, " edges ", edgesLower, " ",

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include <boost/math/tools/precision.hpp>
+#include <fmt/format.h>
 
 namespace katana {
 
@@ -58,6 +59,7 @@ struct OpaqueID {
   // TODO(amp): We need some check that _IDType is a subtype of
   //  OpaqueID<_IDType, _Value>. There doesn't seem to be any way to do that.
   using ValueType = _Value;
+  using IDType = _IDType;
 
   using Count = typename count_traits<_Value>::Count;
 
@@ -291,3 +293,16 @@ struct OpaqueIDLess : private std::less<opaque_id_value_type<T>> {
 };
 
 }  // namespace katana
+
+template <typename T, typename Char>
+struct fmt::formatter<
+    T, Char,
+    std::enable_if_t<std::is_convertible<
+        T*,
+        katana::OpaqueID<typename T::IDType, typename T::ValueType>*>::value>>
+    : formatter<std::string> {
+  template <typename FormatContext>
+  auto format(const T& id, FormatContext& ctx) {
+    return format_to(ctx.out(), "{}", id.value());
+  }
+};

--- a/libtsuba/include/tsuba/RDGPrefix.h
+++ b/libtsuba/include/tsuba/RDGPrefix.h
@@ -16,7 +16,8 @@ class RDGManifest;
 /// partitioning decisions
 class KATANA_EXPORT RDGPrefix {
 public:
-  static katana::Result<RDGPrefix> Make(RDGHandle handle);
+  static katana::Result<RDGPrefix> Make(
+      RDGHandle handle, uint32_t partition_id = 0);
 
   uint64_t num_nodes() const { return prefix_->header.num_nodes; }
   uint64_t num_edges() const { return prefix_->header.num_edges; }
@@ -49,7 +50,8 @@ private:
   uint64_t view_offset_;
   const CSRTopologyPrefix* prefix_{nullptr};
 
-  static katana::Result<RDGPrefix> DoMakePrefix(const RDGManifest& manifest);
+  static katana::Result<RDGPrefix> DoMakePrefix(
+      const RDGManifest& manifest, uint32_t partition_id);
 };
 
 /// EntityTypeIDArrayHeader describes the header in the on disk representation

--- a/libtsuba/include/tsuba/RDGSlice.h
+++ b/libtsuba/include/tsuba/RDGSlice.h
@@ -46,7 +46,7 @@ public:
   };
 
   static katana::Result<RDGSlice> Make(
-      RDGHandle handle, const SliceArg& slice,
+      RDGHandle handle, const SliceArg& slice, const uint32_t partition_id = 0,
       const std::optional<std::vector<std::string>>& node_props = std::nullopt,
       const std::optional<std::vector<std::string>>& edge_props = std::nullopt);
 
@@ -54,6 +54,15 @@ public:
       const std::string& rdg_manifest_path, const SliceArg& slice,
       const std::optional<std::vector<std::string>>& node_props = std::nullopt,
       const std::optional<std::vector<std::string>>& edge_props = std::nullopt);
+
+  /// Returns two vectors (one for nodes and one for edges), each with one entry
+  /// per partition in the graph pointed to by handle. Each entry is the number
+  /// of nodes or edges owned by the corresponding partitions.
+  ///
+  /// This information can be useful to users of RDGSlice who want to decide
+  /// what slice of what partition to load.
+  static katana::Result<std::pair<std::vector<size_t>, std::vector<size_t>>>
+  GetPerPartitionCounts(RDGHandle handle);
 
   // metadata sorts of things
   const katana::Uri& rdg_dir() const;
@@ -69,28 +78,24 @@ public:
   const FileView& topology_file_storage() const;
 
   // optional partition metadata
-  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes()
-      const {
-    return master_nodes_;
-  }
-  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes()
-      const {
-    return mirror_nodes_;
-  }
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& master_nodes() const;
+  const std::vector<std::shared_ptr<arrow::ChunkedArray>>& mirror_nodes() const;
   const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_node_ids()
-      const {
-    return host_to_owned_global_node_ids_;
-  }
+      const;
   const std::shared_ptr<arrow::ChunkedArray>& host_to_owned_global_edge_ids()
-      const {
-    return host_to_owned_global_edge_ids_;
-  }
-  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const {
-    return local_to_user_id_;
-  }
-  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const {
-    return local_to_global_id_;
-  }
+      const;
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_user_id() const;
+  const std::shared_ptr<arrow::ChunkedArray>& local_to_global_id() const;
+
+  /// If the RDG underlying this object is missing either of these arrays, an
+  /// empty array will be loaded instead
+  katana::Result<void> load_local_to_user_id();
+  katana::Result<void> load_local_to_global_id();
+  /// The semantics of these two functions are about memory use. So they set
+  /// their respective arrays to empty, removing them from memory without
+  /// semantically removing them from the object.
+  katana::Result<void> remove_local_to_user_id();
+  katana::Result<void> remove_local_to_global_id();
 
   // type info
   /// Determine if the EntityTypeIDs are stored in properties, or outside
@@ -119,16 +124,13 @@ private:
 
   std::unique_ptr<RDGCore> core_;
   // NB: we intentionally do not include a property cache here because that will
-  // complicate the property cache logic; one could be added in the future if it
-  // seems necessary
+  // complicate the property cache logic and RDGSlice is read-only
+  //
+  // one could be added in the future if it seems useful
 
-  void InitArrowVectors();
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> mirror_nodes_;
-  std::vector<std::shared_ptr<arrow::ChunkedArray>> master_nodes_;
-  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_node_ids_;
-  std::shared_ptr<arrow::ChunkedArray> host_to_owned_global_edge_ids_;
-  std::shared_ptr<arrow::ChunkedArray> local_to_user_id_;
-  std::shared_ptr<arrow::ChunkedArray> local_to_global_id_;
+  // the SliceArg used to Make this object, useful for on-demand loading of
+  // properties and metadata arrays
+  SliceArg slice_arg_;
 
   // How this graph was derived from the previous version
   RDGLineage lineage_;

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -307,6 +307,9 @@ public:
   const std::vector<PropStorageInfo>& part_prop_info_list() const {
     return part_prop_info_list_;
   }
+  std::vector<PropStorageInfo>& part_prop_info_list() {
+    return part_prop_info_list_;
+  }
   void set_part_properties(std::vector<PropStorageInfo>&& part_prop_info_list) {
     part_prop_info_list_ = std::move(part_prop_info_list);
   }

--- a/libtsuba/src/RDGPrefix.cpp
+++ b/libtsuba/src/RDGPrefix.cpp
@@ -10,9 +10,10 @@
 namespace tsuba {
 
 katana::Result<tsuba::RDGPrefix>
-RDGPrefix::DoMakePrefix(const tsuba::RDGManifest& manifest) {
-  auto part_header =
-      KATANA_CHECKED(RDGPartHeader::Make(manifest.PartitionFileName(0)));
+RDGPrefix::DoMakePrefix(
+    const tsuba::RDGManifest& manifest, uint32_t partition_id) {
+  auto part_header = KATANA_CHECKED(
+      RDGPartHeader::Make(manifest.PartitionFileName(partition_id)));
 
   if (part_header.csr_topology_path().empty()) {
     return RDGPrefix{};
@@ -36,14 +37,8 @@ RDGPrefix::DoMakePrefix(const tsuba::RDGManifest& manifest) {
 }
 
 katana::Result<tsuba::RDGPrefix>
-RDGPrefix::Make(RDGHandle handle) {
-  if (handle.impl_->rdg_manifest().num_hosts() != 1) {
-    return KATANA_ERROR(
-        ErrorCode::NotImplemented,
-        "cannot construct RDGPrefix for partitioned graph");
-  }
-
-  return DoMakePrefix(handle.impl_->rdg_manifest());
+RDGPrefix::Make(RDGHandle handle, uint32_t partition_id) {
+  return DoMakePrefix(handle.impl_->rdg_manifest(), partition_id);
 }
 
 }  // namespace tsuba


### PR DESCRIPTION
This PR got a little out of hand, but it has a few main thrusts:

- All OpaqueIDs can now be passed directly to fmt functions (this was for convenience while debugging other issues)
- One-off interface improvement to `divideNodesBinarySearch()`
- Improve `RDGPrefix` and `RDGSlice` compatibility with partitioned graphs. This involved moving more logic out of `RDGSlice` and into `RDGCore` as well as providing the `GetPerPartitionCounts()` static function for helping load slices of partitioned graphs.
- On-demand loading and unloading of some metadata arrays in `RDGSlice`