### PR TITLE
libsupport: Remove redundant fmt specialization

### DIFF
--- a/docs/reference/cxx/index.rst
+++ b/docs/reference/cxx/index.rst
@@ -5,5 +5,7 @@ C++ Library
 .. toctree::
    arrow
    error-handling
+   logging
    property-graph
+   strings
    tracing

--- a/docs/reference/cxx/logging.rst
+++ b/docs/reference/cxx/logging.rst
@@ -1,0 +1,28 @@
+=======
+Logging
+=======
+
+.. doxygenfile:: Logging.h
+   :sections: briefdescription detaileddescription
+
+.. doxygendefine:: KATANA_LOG_FATAL
+
+.. doxygendefine:: KATANA_LOG_ERROR
+
+.. doxygendefine:: KATANA_LOG_WARN
+
+.. doxygendefine:: KATANA_WARN_ONCE
+
+.. doxygendefine:: KATANA_LOG_VERBOSE
+
+.. doxygendefine:: KATANA_LOG_ASSERT
+
+.. doxygendefine:: KATANA_LOG_VASSERT
+
+.. doxygendefine:: KATANA_LOG_DEBUG
+
+.. doxygendefine:: KATANA_LOG_DEBUG_ASSERT
+
+.. doxygendefine:: KATANA_LOG_DEBUG_VASSERT
+
+.. doxygendefine:: KATANA_DEBUG_WARN_ONCE

--- a/docs/reference/cxx/strings.rst
+++ b/docs/reference/cxx/strings.rst
@@ -1,0 +1,26 @@
+=======
+Strings
+=======
+
+.. doxygenfile:: Strings.h
+   :sections: briefdescription detaileddescription
+
+.. doxygenfunction:: katana::FromBase64
+
+.. doxygenfunction:: katana::ToBase64
+
+.. doxygenfunction:: katana::TrimPrefix
+
+.. doxygenfunction:: katana::HasPrefix
+
+.. doxygenfunction:: katana::TrimSuffix
+
+.. doxygenfunction:: katana::HasSuffix
+
+.. doxygenfunction:: katana::SplitView
+
+.. doxygenfunction:: katana::Join(It, It, std::string_view)
+
+.. doxygenfunction:: katana::Join(const Range&, std::string_view)
+
+.. doxygenfunction:: katana::Join(const std::initializer_list<T>&, std::string_view)

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -4,7 +4,6 @@
 #include <iostream>
 
 #include <boost/math/tools/precision.hpp>
-#include <fmt/format.h>
 
 namespace katana {
 
@@ -293,16 +292,3 @@ struct OpaqueIDLess : private std::less<opaque_id_value_type<T>> {
 };
 
 }  // namespace katana
-
-template <typename T, typename Char>
-struct fmt::formatter<
-    T, Char,
-    std::enable_if_t<std::is_convertible<
-        T*,
-        katana::OpaqueID<typename T::IDType, typename T::ValueType>*>::value>>
-    : formatter<std::string> {
-  template <typename FormatContext>
-  auto format(const T& id, FormatContext& ctx) {
-    return format_to(ctx.out(), "{}", id.value());
-  }
-};

--- a/libsupport/include/katana/Strings.h
+++ b/libsupport/include/katana/Strings.h
@@ -10,21 +10,28 @@
 
 #include "katana/config.h"
 
-/// @file Strings.h
-///
 /// Basic string manipulation functions for situations where you can tolerate
 /// some string copies in exchange for a clear API.
 ///
-/// C++20 will have string.starts_with and string.ends_with.
+/// Some of these functions can eventually be replaced with updated libraries:
+///
+/// - katana::HasPrefix and katana::HasSuffix can be replaced with (C++20)
+///   std::string.starts_with and std::string.ends_with.
+/// - katana::Join can be replaced with (fmt>=8) fmt::join
+///
+/// \file Strings.h
 
 namespace katana {
 
 /// FromBase64 converts from base64 string into a binary encoded string
+///
 /// \param input base64 encoded input string
 KATANA_EXPORT std::string FromBase64(const std::string& input);
 
 /// ToBase64 encodes message string into a Base64 string.
-/// \param url_safe forces URL-safe encoding of result base64 result (replacing +/ with -_)
+///
+/// \param url_safe forces URL-safe encoding of result base64 result (replacing
+///   +/ with -_)
 /// \param message binary string input
 KATANA_EXPORT std::string ToBase64(
     const std::string& message, bool url_safe = false);

--- a/libsupport/test/opaque-id.cpp
+++ b/libsupport/test/opaque-id.cpp
@@ -33,7 +33,31 @@ static_assert(
 static_assert(
     std::is_same_v<decltype(TestLongOrdered::sentinel()), TestLongOrdered>);
 
+struct IntID : public katana::OpaqueIDLinear<IntID, int> {
+  using OpaqueIDLinear::OpaqueIDLinear;
+};
+
+void
+TestPrint() {
+  int value = 1;
+  IntID id(value);
+
+  std::stringstream expected;
+  expected << value;
+
+  fmt::memory_buffer fmt_buf;
+  fmt::format_to(std::back_inserter(fmt_buf), "{}", id);
+
+  std::stringstream stl_buf;
+  stl_buf << id;
+
+  KATANA_LOG_ASSERT(to_string(fmt_buf) == expected.str());
+  KATANA_LOG_ASSERT(stl_buf.str() == expected.str());
+}
+
 int
 main() {
+  TestPrint();
+
   return 0;
 }

--- a/libsupport/test/strings.cpp
+++ b/libsupport/test/strings.cpp
@@ -47,15 +47,15 @@ main() {
       std::vector<std::string_view>({"split", "the", "right", "amount"}));
 
   KATANA_LOG_ASSERT(
-      katana::Join(" ", {"list", "of", "strings"}) == "list of strings");
+      katana::Join({"list", "of", "strings"}, " ") == "list of strings");
   KATANA_LOG_ASSERT(
-      katana::Join("", {"list", "of", "strings"}) == "listofstrings");
-  KATANA_LOG_ASSERT(katana::Join(" ", {"string"}) == "string");
-  KATANA_LOG_ASSERT(katana::Join(" ", std::vector<std::string>{}).empty());
+      katana::Join({"list", "of", "strings"}, "") == "listofstrings");
+  KATANA_LOG_ASSERT(katana::Join({"string"}, " ") == "string");
+  KATANA_LOG_ASSERT(katana::Join(std::vector<std::string>{}, " ").empty());
   KATANA_LOG_ASSERT(
-      katana::Join(" ", {"list", "of", "", "strings"}) == "list of  strings");
+      katana::Join({"list", "of", "", "strings"}, " ") == "list of  strings");
 
-  KATANA_LOG_ASSERT(katana::Join(" ", std::list<int>{1, 2, 3}) == "1 2 3");
+  KATANA_LOG_ASSERT(katana::Join(std::list<int>{1, 2, 3}, " ") == "1 2 3");
 
   KATANA_LOG_ASSERT(katana::ToBase64("") == "");
   KATANA_LOG_ASSERT(katana::ToBase64("uchigatana") == "dWNoaWdhdGFuYQ==");

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -3293,7 +3293,7 @@ struct Svmlight2Gr : public HasNoVoidSpecialization {
 
 int
 main(int argc, char** argv) {
-  kCommandLine = katana::Join(" ", argv, argv + argc);
+  kCommandLine = katana::Join(argv, argv + argc, " ");
   katana::SharedMemSys G;
   llvm::cl::ParseCommandLineOptions(
       argc, argv,


### PR DESCRIPTION
    support: Remove redundant fmt specialization

    fmt picks up on ostream& operator<<(ostream&, T) overloads and there is
    typically no need to specialize printing functionality for fmt if
    there is already an ostream overload.

    This also has the benefit of supporting both fmt::print and std::cout
    with the same customization point.

    There is an issue with fmt<8 when using fmt::join(items, ...) when Item
    only overloads operator<<, which is what prompted the change in
    153ab8a80 that this commit reverts. This issue is larger than printing
    OpaqueIDs though and specific to fmt::join.

This partially reverts https://github.com/KatanaGraph/katana/pull/706