### PR TITLE
Ensure there is always at least an empty topology

### DIFF
--- a/libgalois/include/katana/PropertyGraph.h
+++ b/libgalois/include/katana/PropertyGraph.h
@@ -83,7 +83,11 @@ private:
   tsuba::RDG rdg_;
   std::unique_ptr<tsuba::RDGFile> file_;
 
-  std::shared_ptr<katana::GraphTopology> topology_;
+  // Users of PropertyGraph rely on the topology to always be present
+  // even if it is empty. This is a temporary solution, since this variable
+  // is going away.
+  std::shared_ptr<katana::GraphTopology> topology_ =
+      std::make_shared<katana::GraphTopology>();
 
   /// Manages the relations between the node entity types
   EntityTypeManager node_entity_type_manager_;

--- a/libgalois/src/PropertyGraphRetractor.cpp
+++ b/libgalois/src/PropertyGraphRetractor.cpp
@@ -16,6 +16,6 @@ katana::PropertyGraphRetractor::InformPath(const std::string& input_path) {
 Result<void>
 katana::PropertyGraphRetractor::DropTopologies() {
   //TODO: emcginnis reset all topologies in PGViewCache
-  pg_->topology_ = nullptr;
+  pg_->topology_ = std::make_shared<katana::GraphTopology>();
   return pg_->rdg_.DropAllTopologies();
 }


### PR DESCRIPTION
A quick fix, to make `katana-enterprise` tests pass.