### PR TITLE
add max-height style for notebook outputs

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,3 +1,3 @@
 div.nboutput.container div.output_area {
-	max-height: 60vh;
+	max-height: 50vh;
 }

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,0 +1,3 @@
+div.nboutput.container div.output_area {
+	max-height: 60vh;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ html_theme_options = {"show_prev_next": False}
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_css_files = ["style.css"]
 
 autodoc_preserve_defaults = True
 autodoc_member_order = "groupwise"


### PR DESCRIPTION
Some basic css to add scrolling to large notebook outputs. IMO, better to allow for verbose/long outputs than to alter code to try to truncate.

After:
<img width="936" alt="Screen Shot 2021-12-01 at 1 05 11 PM" src="https://user-images.githubusercontent.com/4110880/144313889-3403dc11-6fa2-49bc-9c51-bd23d94aef8b.png">

Before:
<img width="870" alt="Screen Shot 2021-12-01 at 1 04 29 PM" src="https://user-images.githubusercontent.com/4110880/144313879-42cd2fe1-b602-491a-a6ae-777fc22f779c.png">

Unfortunately, does not handle multiple outputs from a single input (running a loop of different graph operations - queries/imports) which needs alteration in how we output progress bars:
<img width="860" alt="Screen Shot 2021-12-01 at 1 07 16 PM" src="https://user-images.githubusercontent.com/4110880/144314093-3730669c-13a8-4947-ad96-172579ebade7.png">


