### PR TITLE
Graph helpers: replace some unsigned with size_t

### DIFF
--- a/libgalois/include/katana/LC_CSR_Graph.h
+++ b/libgalois/include/katana/LC_CSR_Graph.h
@@ -714,7 +714,7 @@ public:
   }
 
   auto divideByNode(size_t nodeSize, size_t edgeSize, size_t id, size_t total) {
-    return katana::divideNodesBinarySearch(
+    return katana::DivideNodesBinarySearch(
         numNodes, numEdges, nodeSize, edgeSize, id, total, edgeIndData);
   }
 

--- a/libgalois/include/katana/OfflineGraph.h
+++ b/libgalois/include/katana/OfflineGraph.h
@@ -329,9 +329,8 @@ public:
    */
   auto divideByNode(
       size_t nodeWeight, size_t edgeWeight, size_t id, size_t total,
-      std::vector<unsigned> scaleFactor = std::vector<unsigned>())
-      -> GraphRange {
-    return katana::divideNodesBinarySearch<OfflineGraph>(
+      std::vector<size_t> scaleFactor = std::vector<size_t>()) -> GraphRange {
+    return katana::DivideNodesBinarySearch<OfflineGraph>(
         numNodes, numEdges, nodeWeight, edgeWeight, id, total, *this,
         scaleFactor);
   }

--- a/libgalois/src/FileGraph.cpp
+++ b/libgalois/src/FileGraph.cpp
@@ -511,9 +511,9 @@ FileGraph::findIndex(
 auto
 FileGraph::divideByNode(
     size_t nodeSize, size_t edgeSize, size_t id, size_t total) -> GraphRange {
-  std::vector<unsigned> dummy_scale_factor;  // dummy passed in to function call
+  std::vector<size_t> dummy_scale_factor;  // dummy passed in to function call
 
-  return katana::divideNodesBinarySearch(
+  return katana::DivideNodesBinarySearch(
       numNodes, numEdges, nodeSize, edgeSize, id, total, outIdx,
       dummy_scale_factor, edgeOffset);
 }

--- a/libgalois/src/GraphHelpers.cpp
+++ b/libgalois/src/GraphHelpers.cpp
@@ -23,17 +23,17 @@ namespace katana {
 
 namespace internal {
 
-uint32_t
+size_t
 determine_block_division(
-    uint32_t numDivisions, std::vector<unsigned>& scaleFactor) {
-  uint32_t numBlocks = 0;
+    size_t numDivisions, std::vector<size_t>& scaleFactor) {
+  size_t numBlocks = 0;
 
   if (scaleFactor.empty()) {
     // if scale factor isn't specified, everyone gets the same amount
     numBlocks = numDivisions;
 
     // scale factor holds a prefix sum of the scale factor
-    for (uint32_t i = 0; i < numDivisions; i++) {
+    for (size_t i = 0; i < numDivisions; i++) {
       scaleFactor.push_back(i + 1);
     }
   } else {
@@ -42,7 +42,7 @@ determine_block_division(
 
     // get numDivisions number of blocks we need + save a prefix sum of the
     // scale factor vector to scaleFactor
-    for (uint32_t i = 0; i < numDivisions; i++) {
+    for (size_t i = 0; i < numDivisions; i++) {
       numBlocks += scaleFactor[i];
       scaleFactor[i] = numBlocks;
     }


### PR DESCRIPTION
This doesn't modify large vectors or anything where adding a few bytes
will blow up the memory use.

It is primarily to allow
divideNodesBinarySearch() to accept std::vector<size_t> instead of
std::vector<unsigned> for the scaleFactor parameter. This gives that
parameter some more expressiveness and makes it safer by making it
impossible to pass in a vector of too-large values.