### PR TITLE
RDGSlice: out of core properties

### DIFF
--- a/libtsuba/include/tsuba/RDGSlice.h
+++ b/libtsuba/include/tsuba/RDGSlice.h
@@ -94,6 +94,10 @@ public:
   /// The semantics of these two functions are about memory use. So they set
   /// their respective arrays to empty, removing them from memory without
   /// semantically removing them from the object.
+  katana::Result<void> unload_local_to_user_id();
+  katana::Result<void> unload_local_to_global_id();
+  /// deprecated duplicates of the unload_* functions for
+  /// backwards-compatibility
   katana::Result<void> remove_local_to_user_id();
   katana::Result<void> remove_local_to_global_id();
 

--- a/libtsuba/include/tsuba/RDGSlice.h
+++ b/libtsuba/include/tsuba/RDGSlice.h
@@ -46,7 +46,7 @@ public:
   };
 
   static katana::Result<RDGSlice> Make(
-      RDGHandle handle, const SliceArg& slice, const uint32_t partition_id = 0,
+      RDGHandle handle, const SliceArg& slice, uint32_t partition_id = 0,
       const std::optional<std::vector<std::string>>& node_props = std::nullopt,
       const std::optional<std::vector<std::string>>& edge_props = std::nullopt);
 
@@ -73,6 +73,30 @@ public:
   std::shared_ptr<arrow::Schema> full_edge_schema() const;
   const std::shared_ptr<arrow::Table>& node_properties() const;
   const std::shared_ptr<arrow::Table>& edge_properties() const;
+
+  // NB: The following interface differs from the one provided by RDG for
+  // property loading/unloading. You can't remove a property by its
+  // index in the loaded property table and you can't specify an index for a
+  // loaded property in that table. These differences are because RDGSlice has
+  // many fewer users than RDG and those users require a less rich interface.
+  // There is also no upsert call because RDGSlice is read-only.
+
+  /// load the specified node property and append it to the Table returned by
+  /// node_properties()
+  /// @param name the name of the property in full_node_schema()
+  katana::Result<void> load_node_property(const std::string& name);
+  /// remove the specified node property from the Table returned by
+  /// node_properties()
+  /// @param name the name of the property in full_node_schema()
+  katana::Result<void> unload_node_property(const std::string& name);
+  /// load the specified edge property and append it to the Table returned by
+  /// edge_properties()
+  /// @param name the name of the property in full_edge_schema()
+  katana::Result<void> load_edge_property(const std::string& name);
+  /// remove the specified edge property from the Table returned by
+  /// edge_properties()
+  /// @param name the name of the property in full_edge_schema()
+  katana::Result<void> unload_edge_property(const std::string& name);
 
   // topology and friends
   const FileView& topology_file_storage() const;

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -122,6 +122,21 @@ EnsureTypeLoaded(const katana::Uri& rdg_dir, tsuba::PropStorageInfo* psi) {
   return katana::ResultSuccess();
 }
 
+katana::Result<tsuba::PropStorageInfo>
+find_prop_info(
+    const std::string& name,
+    const std::vector<tsuba::PropStorageInfo>& prop_infos) {
+  auto it = std::find_if(
+      prop_infos.begin(), prop_infos.end(),
+      [&name](const tsuba::PropStorageInfo& psi) {
+        return psi.name() == name;
+      });
+  if (it == prop_infos.end()) {
+    return tsuba::ErrorCode::PropertyNotFound;
+  }
+
+  return *it;
+}
 }  // namespace
 
 namespace tsuba {
@@ -258,6 +273,19 @@ RDGCore::RemoveEdgeProperty(int i) {
   edge_properties_ = KATANA_CHECKED(edge_properties_->RemoveColumn(i));
 
   return part_header_.RemoveEdgeProperty(field->name());
+}
+
+katana::Result<PropStorageInfo>
+RDGCore::find_node_prop_info(const std::string& name) const {
+  return find_prop_info(name, part_header().node_prop_info_list());
+}
+katana::Result<PropStorageInfo>
+RDGCore::find_edge_prop_info(const std::string& name) const {
+  return find_prop_info(name, part_header().edge_prop_info_list());
+}
+katana::Result<PropStorageInfo>
+RDGCore::find_part_prop_info(const std::string& name) const {
+  return find_prop_info(name, part_header().part_prop_info_list());
 }
 
 }  // namespace tsuba

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -198,6 +198,13 @@ public:
     part_header_ = std::move(part_header);
   }
 
+  katana::Result<PropStorageInfo> find_node_prop_info(
+      const std::string& name) const;
+  katana::Result<PropStorageInfo> find_edge_prop_info(
+      const std::string& name) const;
+  katana::Result<PropStorageInfo> find_part_prop_info(
+      const std::string& name) const;
+
   const RDGTopologyManager& topology_manager() const {
     return topology_manager_;
   }


### PR DESCRIPTION
`RDGSlice` can now load and remove property columns on demand. The interface for this is closer to the `RDGSlice` interface for loading and removing metadata arrays than it is to the `RDG` interface for loading and unloading properties. That is because `RDGSlice` is read-only and provides only a small subset of the interface provided by `RDG`.