### PR TITLE
PropertyGraphRetractor: add interface for manipulating cache

### DIFF
--- a/libgalois/include/katana/PropertyGraphRetractor.h
+++ b/libgalois/include/katana/PropertyGraphRetractor.h
@@ -124,6 +124,16 @@ public:
     pg_->rdg_.set_local_to_global_id(std::move(a));
   }
 
+  const tsuba::PropertyCache* prop_cache() const {
+    return pg_->rdg_.prop_cache();
+  }
+
+  tsuba::PropertyCache* prop_cache() { return pg_->rdg_.prop_cache(); }
+
+  void set_prop_cache(tsuba::PropertyCache* prop_cache) {
+    pg_->rdg_.set_prop_cache(prop_cache);
+  }
+
   /// Deallocate and forget about all topology information associated with the
   /// managed PropertyGraph
   Result<void> DropTopologies();

--- a/libtsuba/include/tsuba/RDG.h
+++ b/libtsuba/include/tsuba/RDG.h
@@ -285,6 +285,13 @@ public:
 
   void set_view_name(const std::string& v) { view_type_ = v; }
 
+  const tsuba::PropertyCache* prop_cache() const { return prop_cache_; }
+  tsuba::PropertyCache* prop_cache() { return prop_cache_; }
+
+  void set_prop_cache(tsuba::PropertyCache* prop_cache) {
+    prop_cache_ = prop_cache;
+  }
+
 private:
   std::string view_type_;
   RDG(std::unique_ptr<RDGCore>&& core);


### PR DESCRIPTION
There are cases where we need explicit control over when properties are
in memory. This exposes interfaces so that the partitioner and other
memory sensitive operations can take a heavier hand in managing property
memory.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>