### PR TITLE
Avoid backwards dependency of get_inputs_directory on callers

### DIFF
--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -11,14 +11,8 @@ from pathlib import Path
 __all__ = ["get_input", "get_input_as_url"]
 
 
-def get_inputs_directory(*, invalidate=False, rel_path=None) -> Path:
+def get_inputs_directory(*, invalidate=False) -> Path:
     inputs_dir = None
-    if rel_path == "csv-datasets":
-        paths_to_check = list(Path(__file__).parents) + list(Path.cwd().parents)
-        for path in paths_to_check:
-            csv_path = (path / "katana-enterprise" / "external").resolve()
-            if csv_path.exists():
-                return csv_path
 
     # Use the build paths if they exist.
     if "KATANA_BUILD_DIR" in os.environ:
@@ -61,7 +55,7 @@ def get_input(rel_path) -> Path:
     >>> from katana.local import Graph
     ... graph = Graph(get_input("propertygraphs/ldbc_003"))
     """
-    path = get_inputs_directory(rel_path=rel_path) / rel_path
+    path = get_inputs_directory() / rel_path
     if path.exists():
         return path
     return get_inputs_directory(invalidate=True) / rel_path


### PR DESCRIPTION
A recent change to get_inputs_directory 7158d308776f3e makes its
behavior dependent on the directory structure of source trees that
include this source tree.

This seems unnecessary. If a caller knows something that
get_inputs_directory does not, the caller can handle that detail itself
rather than ask get_inputs_directory to search around in the caller's
context.