### PR TITLE
Document conda cudatoolkit-dev issue and workarounds

### DIFF
--- a/docs/contributing/building.rst
+++ b/docs/contributing/building.rst
@@ -67,6 +67,18 @@ configured. Then, create and activate the development environment:
 The ``conda env update`` line can be run later to update your environment. Deactivate your environment
 ``conda deactivate``, then run the update commands, then reactivate ``conda activate katana-dev``.
 
+.. warning::
+
+   Not all conda installation scripts are well-behaved. In particular, the default behavior of the ``cudatoolkit-dev`` package's post-installation script is to write a log to the hard-coded path ``/tmp/cuda-installer.log`` and not delete it. Once one user on a system has written this file all other users will fail to install the package because they won't be able to write the log file. The recommended workaround for this is to set the ``TMP`` variable in your shell environment (if that variable is set, the script will write its log to ``$TMP/cuda-installer.log`` so you can avoid conflicts with other users).
+
+.. code-block:: bash
+
+   # If you are sharing a system with other users,
+   # you will need to use the following workaround:
+   mkdir -p /tmp/$USER
+   TMP=/tmp/$USER conda env update --name katana-dev --file $SRC_DIR/conda_recipe/environment.yml
+
+
 Now, run ``cmake`` to configure your build directory and ``make`` to build Katana.
 
 .. code-block:: bash


### PR DESCRIPTION
I am concerned that the `/dev/null` workaround is just crowding the docs and we would be better off dropping it. Thoughts?