### PR TITLE
Fix RDGCore::find_*_prop_info()

### DIFF
--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -122,20 +122,17 @@ EnsureTypeLoaded(const katana::Uri& rdg_dir, tsuba::PropStorageInfo* psi) {
   return katana::ResultSuccess();
 }
 
-katana::Result<tsuba::PropStorageInfo>
+tsuba::PropStorageInfo*
 find_prop_info(
-    const std::string& name,
-    const std::vector<tsuba::PropStorageInfo>& prop_infos) {
+    const std::string& name, std::vector<tsuba::PropStorageInfo>* prop_infos) {
   auto it = std::find_if(
-      prop_infos.begin(), prop_infos.end(),
-      [&name](const tsuba::PropStorageInfo& psi) {
-        return psi.name() == name;
-      });
-  if (it == prop_infos.end()) {
-    return tsuba::ErrorCode::PropertyNotFound;
+      prop_infos->begin(), prop_infos->end(),
+      [&name](tsuba::PropStorageInfo& psi) { return psi.name() == name; });
+  if (it == prop_infos->end()) {
+    return nullptr;
   }
 
-  return *it;
+  return &(*it);
 }
 }  // namespace
 
@@ -275,17 +272,17 @@ RDGCore::RemoveEdgeProperty(int i) {
   return part_header_.RemoveEdgeProperty(field->name());
 }
 
-katana::Result<PropStorageInfo>
-RDGCore::find_node_prop_info(const std::string& name) const {
-  return find_prop_info(name, part_header().node_prop_info_list());
+PropStorageInfo*
+RDGCore::find_node_prop_info(const std::string& name) {
+  return find_prop_info(name, &part_header().node_prop_info_list());
 }
-katana::Result<PropStorageInfo>
-RDGCore::find_edge_prop_info(const std::string& name) const {
-  return find_prop_info(name, part_header().edge_prop_info_list());
+PropStorageInfo*
+RDGCore::find_edge_prop_info(const std::string& name) {
+  return find_prop_info(name, &part_header().edge_prop_info_list());
 }
-katana::Result<PropStorageInfo>
-RDGCore::find_part_prop_info(const std::string& name) const {
-  return find_prop_info(name, part_header().part_prop_info_list());
+PropStorageInfo*
+RDGCore::find_part_prop_info(const std::string& name) {
+  return find_prop_info(name, &part_header().part_prop_info_list());
 }
 
 }  // namespace tsuba

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -198,12 +198,9 @@ public:
     part_header_ = std::move(part_header);
   }
 
-  katana::Result<PropStorageInfo> find_node_prop_info(
-      const std::string& name) const;
-  katana::Result<PropStorageInfo> find_edge_prop_info(
-      const std::string& name) const;
-  katana::Result<PropStorageInfo> find_part_prop_info(
-      const std::string& name) const;
+  PropStorageInfo* find_node_prop_info(const std::string& name);
+  PropStorageInfo* find_edge_prop_info(const std::string& name);
+  PropStorageInfo* find_part_prop_info(const std::string& name);
 
   const RDGTopologyManager& topology_manager() const {
     return topology_manager_;


### PR DESCRIPTION
The original implementations returned a copy of the found PropStorageInfo
object, meaning that the state of the original objects could not be
modified. Change the semantics of the search functions to return a
pointer to the object stored by the RDGCore object.

Also fix an error-checking mismatch between ErrorCode::NotFound and
ErrorCode::PropertyNotFound.