### PR TITLE
include libdl error message when dynamically linking a katana plugin fails

### DIFF
--- a/libsupport/src/Plugin.cpp
+++ b/libsupport/src/Plugin.cpp
@@ -26,7 +26,7 @@ public:
     if (!handle) {
       KATANA_LOG_WARN(
           "skipping plugin {}: failed to dynamically link plugin: {}", path,
-          katana::ResultErrno());
+          dlerror());
       return;
     }
     const auto KatanaPluginInit =

--- a/libsupport/src/Plugin.cpp
+++ b/libsupport/src/Plugin.cpp
@@ -26,7 +26,7 @@ public:
     if (!handle) {
       KATANA_LOG_WARN(
           "skipping plugin {}: failed to dynamically link plugin: {}", path,
-          dlerror());
+          dlerror() );
       return;
     }
     const auto KatanaPluginInit =

--- a/libsupport/src/Plugin.cpp
+++ b/libsupport/src/Plugin.cpp
@@ -26,7 +26,7 @@ public:
     if (!handle) {
       KATANA_LOG_WARN(
           "skipping plugin {}: failed to dynamically link plugin: {}", path,
-          dlerror() );
+          dlerror());
       return;
     }
     const auto KatanaPluginInit =


### PR DESCRIPTION
When dlopen fails we get an awkward error message:
```
WARNING: /source/external/katana/libsupport/src/Plugin.cpp:27: skipping plugin "/usr/lib/katana/plugins/some_plugin.so": failed to dynamically link plugin: Success
``` 

use dlerror to produce a more useful error message and retrieve the cause of the error (e.g. which specific library is missing which the plugin depends on).