### PR TITLE
[KAT-2703] Enable uint64_t type for index

### DIFF
--- a/libgalois/include/katana/PropertyIndex.h
+++ b/libgalois/include/katana/PropertyIndex.h
@@ -30,7 +30,7 @@ public:
   // The set key type is either a node/edge id (all the keys in the actual set)
   // or a value representing the search key.
   using set_key_type = typename std::variant<
-      IndexID, bool, uint8_t, int64_t, double_t, std::string_view*>;
+      IndexID, bool, uint8_t, int64_t, uint64_t, double_t, std::string_view*>;
 
   // PropertyIndex::iterator returns a sequence of node or edge ids.
   using base_iterator = typename std::multiset<set_key_type>::iterator;

--- a/libgalois/src/PropertyIndex.cpp
+++ b/libgalois/src/PropertyIndex.cpp
@@ -25,6 +25,10 @@ MakeTypedIndex(
     index = std::make_unique<PrimitivePropertyIndex<node_or_edge, int64_t>>(
         column_name, num_entities, property);
     break;
+  case arrow::Type::UINT64:
+    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, uint64_t>>(
+        column_name, num_entities, property);
+    break;
   case arrow::Type::DOUBLE:
     index = std::make_unique<PrimitivePropertyIndex<node_or_edge, double_t>>(
         column_name, num_entities, property);
@@ -86,8 +90,12 @@ StringPropertyIndex<node_or_edge>::BuildFromProperty() {
 // Forward declare template types to allow implementation in .cpp.
 template class PrimitivePropertyIndex<GraphTopology::Node, bool>;
 template class PrimitivePropertyIndex<GraphTopology::Edge, bool>;
+template class PrimitivePropertyIndex<GraphTopology::Node, uint8_t>;
+template class PrimitivePropertyIndex<GraphTopology::Edge, uint8_t>;
 template class PrimitivePropertyIndex<GraphTopology::Node, int64_t>;
 template class PrimitivePropertyIndex<GraphTopology::Edge, int64_t>;
+template class PrimitivePropertyIndex<GraphTopology::Node, uint64_t>;
+template class PrimitivePropertyIndex<GraphTopology::Edge, uint64_t>;
 template class PrimitivePropertyIndex<GraphTopology::Node, double_t>;
 template class PrimitivePropertyIndex<GraphTopology::Edge, double_t>;
 


### PR DESCRIPTION
Add `uint64_t` data type for louvian clustering. 
At some point we would like to have all the data types arrow supports be included here.