### PR TITLE
tsuba: Return errors reading RDGPartHeader rather than dying

### DIFF
--- a/libsupport/include/katana/JSON.h
+++ b/libsupport/include/katana/JSON.h
@@ -17,7 +17,8 @@ JsonParse(U& obj) {
     auto j = nlohmann::json::parse(obj.begin(), obj.end());
     return j.template get<T>();
   } catch (const std::exception& exp) {
-    KATANA_LOG_DEBUG("nlohmann::json::parse exception: {}", exp.what());
+    return KATANA_ERROR(
+        katana::ErrorCode::JSONParseFailed, "parsing json: {}", exp.what());
   }
   return katana::ErrorCode::JSONParseFailed;
 }
@@ -30,7 +31,8 @@ JsonParse(U& obj, T* val) {
     j.get_to(*val);
     return katana::ResultSuccess();
   } catch (const std::exception& exp) {
-    KATANA_LOG_DEBUG("nlohmann::json::parse exception: {}", exp.what());
+    return KATANA_ERROR(
+        katana::ErrorCode::JSONParseFailed, "parsing json: {}", exp.what());
   }
   return katana::Result<void>(katana::ErrorCode::JSONParseFailed);
 }


### PR DESCRIPTION
Generally, one does not control what one's inputs are so return errors
rather than dying for invalid input. I left the asserts on the to_json
code paths under the assumption that we control the data so it is more
acceptable to fail violently.