### PR TITLE
Reset default topology pointer to more constrained topology if available

### DIFF
--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -1669,6 +1669,8 @@ struct PGViewBuilder<PGViewEdgesSortedByDestID> {
         pg, tsuba::RDGTopology::TransposeKind::kNo,
         tsuba::RDGTopology::EdgeSortKind::kSortedByDestID);
 
+    viewCache.ReseatDefaultTopo(sorted_topo);
+
     return PGViewEdgesSortedByDestID{
         pg, EdgesSortedByDestTopology{sorted_topo}};
   }
@@ -1753,6 +1755,9 @@ struct PGViewBuilder<PGViewEdgeTypeAwareBiDir> {
     auto in_topo = viewCache.BuildOrGetEdgeTypeAwareTopo(
         pg, tsuba::RDGTopology::TransposeKind::kYes);
 
+    // The new topology can replace the defaut one.
+    viewCache.ReseatDefaultTopo(out_topo);
+
     return PGViewEdgeTypeAwareBiDir{
         pg, EdgeTypeAwareBiDirTopology{out_topo, in_topo}};
   }
@@ -1832,10 +1837,14 @@ public:
   // Avoids a copy of the default topology.
   const GraphTopology& GetDefaultTopologyRef() const noexcept;
 
+  // Purge cache and construct an empty topology as the default one.
   void DropAllTopologies() noexcept;
 
 private:
   std::shared_ptr<GraphTopology> GetDefaultTopology() const noexcept;
+
+  // Reseat the default topology pointer to a more constrained one.
+  bool ReseatDefaultTopo(const std::shared_ptr<GraphTopology>& other) noexcept;
 
   std::shared_ptr<CondensedTypeIDMap> BuildOrGetEdgeTypeIndex(
       const PropertyGraph* pg) noexcept;

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -528,14 +528,15 @@ public:
   }
 
   /// \return returns the most specific edge entity type for @param edge
-  EntityTypeID GetTypeOfEdge(Edge edge) const {
+  EntityTypeID GetTypeOfEdgeFromTopoIndex(Edge edge) const {
     auto idx = edge_property_index(edge);
     return edge_entity_type_ids_[idx];
   }
 
   /// \return returns the most specific edge entity type for @param edge
-  EntityTypeID GetTypeOfOriginalEdge(Edge edge) const {
-    return edge_entity_type_ids_[edge];
+  EntityTypeID GetTypeOfEdgeFromPropertyIndex(
+      GraphTopology::PropertyIndex prop_index) const {
+    return edge_entity_type_ids_[prop_index];
   }
 
   /// \return true iff the node @param node has the given entity type
@@ -548,12 +549,16 @@ public:
   /// \return true iff the edge @param edge has the given entity type
   /// @param edge_entity_type_id (need not be the most specific type)
   /// (assumes that the edge entity type exists)
-  bool DoesEdgeHaveType(Edge edge, EntityTypeID edge_entity_type_id) const {
-    return IsEdgeSubtypeOf(edge_entity_type_id, GetTypeOfEdge(edge));
+  bool DoesEdgeHaveTypeFromTopoIndex(
+      Edge edge, EntityTypeID edge_entity_type_id) const {
+    return IsEdgeSubtypeOf(
+        edge_entity_type_id, GetTypeOfEdgeFromTopoIndex(edge));
   }
 
-  bool DoesOriginalEdgeHaveType(Edge edge, EntityTypeID edge_entity_type_id) const {
-    return IsEdgeSubtypeOf(edge_entity_type_id, GetTypeOfOriginalEdge(edge));
+  bool DoesEdgeHaveTypeFromPropertyIndex(
+      Edge edge, EntityTypeID edge_entity_type_id) const {
+    return IsEdgeSubtypeOf(
+        edge_entity_type_id, GetTypeOfEdgeFromPropertyIndex(edge));
   }
 
   // Return type dictated by arrow

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -83,12 +83,6 @@ private:
   tsuba::RDG rdg_;
   std::unique_ptr<tsuba::RDGFile> file_;
 
-  // Users of PropertyGraph rely on the topology to always be present
-  // even if it is empty. This is a temporary solution, since this variable
-  // is going away.
-  std::shared_ptr<katana::GraphTopology> topology_ =
-      std::make_shared<katana::GraphTopology>();
-
   /// Manages the relations between the node entity types
   EntityTypeManager node_entity_type_manager_;
   /// Manages the relations between the edge entity types
@@ -243,11 +237,11 @@ public:
       EntityTypeManager&& edge_type_manager) noexcept
       : rdg_(std::move(rdg)),
         file_(std::move(rdg_file)),
-        topology_(std::make_shared<GraphTopology>(std::move(topo))),
         node_entity_type_manager_(std::move(node_type_manager)),
         edge_entity_type_manager_(std::move(edge_type_manager)),
         node_entity_type_ids_(std::move(node_entity_type_ids)),
-        edge_entity_type_ids_(std::move(edge_entity_type_ids)) {
+        edge_entity_type_ids_(std::move(edge_entity_type_ids)),
+        pg_view_cache_(std::move(topo)) {
     KATANA_LOG_DEBUG_ASSERT(node_entity_type_ids_.size() == num_nodes());
     KATANA_LOG_DEBUG_ASSERT(edge_entity_type_ids_.size() == num_edges());
   }
@@ -529,12 +523,14 @@ public:
 
   /// \return returns the most specific node entity type for @param node
   EntityTypeID GetTypeOfNode(Node node) const {
-    return node_entity_type_ids_[node];
+    auto idx = node_property_index(node);
+    return node_entity_type_ids_[idx];
   }
 
   /// \return returns the most specific edge entity type for @param edge
   EntityTypeID GetTypeOfEdge(Edge edge) const {
-    return edge_entity_type_ids_[edge];
+    auto idx = edge_property_index(edge);
+    return edge_entity_type_ids_[idx];
   }
 
   /// \return true iff the node @param node has the given entity type
@@ -662,7 +658,13 @@ public:
     return MakeResult(std::move(array));
   }
 
-  const GraphTopology& topology() const noexcept { return *topology_; }
+  void DropAllTopologies() noexcept {
+    return pg_view_cache_.DropAllTopologies();
+  }
+
+  const GraphTopology& topology() const noexcept {
+    return pg_view_cache_.GetDefaultTopologyRef();
+  }
 
   const EntityTypeManager& node_entity_type_manager() const noexcept {
     return node_entity_type_manager_;
@@ -670,6 +672,16 @@ public:
 
   const EntityTypeManager& edge_entity_type_manager() const noexcept {
     return edge_entity_type_manager_;
+  }
+
+  GraphTopology::PropertyIndex edge_property_index(
+      const Edge& eid) const noexcept {
+    return topology().edge_property_index(eid);
+  }
+
+  GraphTopology::PropertyIndex node_property_index(
+      const Node& nid) const noexcept {
+    return topology().node_property_index(nid);
   }
 
   /// Add Node properties that do not exist in the current graph
@@ -755,6 +767,7 @@ public:
         .unload_property_fn = &PropertyGraph::UnloadNodeProperty,
     };
   }
+
   ReadOnlyPropertyView NodeReadOnlyPropertyView() const {
     return ReadOnlyPropertyView{
         .const_g = this,
@@ -786,6 +799,7 @@ public:
         .unload_property_fn = &PropertyGraph::UnloadEdgeProperty,
     };
   }
+
   ReadOnlyPropertyView EdgeReadOnlyPropertyView() const {
     return ReadOnlyPropertyView{
         .const_g = this,

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -530,7 +530,7 @@ public:
   /// \return returns the most specific edge entity type for @param edge
   EntityTypeID GetTypeOfEdgeFromTopoIndex(Edge edge) const {
     auto idx = edge_property_index(edge);
-    return edge_entity_type_ids_[idx];
+    return GetTypeOfEdgeFromPropertyIndex(idx);
   }
 
   /// \return returns the most specific edge entity type for @param edge
@@ -672,6 +672,7 @@ public:
     return MakeResult(std::move(array));
   }
 
+  //TODO(yan): Add fine-grained control for dropping specific topologies.
   void DropAllTopologies() noexcept {
     return pg_view_cache_.DropAllTopologies();
   }

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -533,6 +533,11 @@ public:
     return edge_entity_type_ids_[idx];
   }
 
+  /// \return returns the most specific edge entity type for @param edge
+  EntityTypeID GetTypeOfOriginalEdge(Edge edge) const {
+    return edge_entity_type_ids_[edge];
+  }
+
   /// \return true iff the node @param node has the given entity type
   /// @param node_entity_type_id (need not be the most specific type)
   /// (assumes that the node entity type exists)
@@ -545,6 +550,10 @@ public:
   /// (assumes that the edge entity type exists)
   bool DoesEdgeHaveType(Edge edge, EntityTypeID edge_entity_type_id) const {
     return IsEdgeSubtypeOf(edge_entity_type_id, GetTypeOfEdge(edge));
+  }
+
+  bool DoesOriginalEdgeHaveType(Edge edge, EntityTypeID edge_entity_type_id) const {
+    return IsEdgeSubtypeOf(edge_entity_type_id, GetTypeOfOriginalEdge(edge));
   }
 
   // Return type dictated by arrow

--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -76,7 +76,8 @@ public:
   template <typename NodeIndex>
   PropertyReferenceType<NodeIndex> GetData(const Node& node) {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
-    return std::get<prop_col_index>(node_view_).GetValue(node);
+    return std::get<prop_col_index>(node_view_)
+        .GetValue(pg_->node_property_index(node));
   }
   template <typename NodeIndex>
   PropertyReferenceType<NodeIndex> GetData(const node_iterator& node) {
@@ -92,7 +93,8 @@ public:
   template <typename NodeIndex>
   PropertyConstReferenceType<NodeIndex> GetData(const Node& node) const {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
-    return std::get<prop_col_index>(node_view_).GetValue(node);
+    return std::get<prop_col_index>(node_view_)
+        .GetValue(pg_->node_property_index(node));
   }
   template <typename NodeIndex>
   PropertyConstReferenceType<NodeIndex> GetData(
@@ -109,7 +111,8 @@ public:
   template <typename EdgeIndex>
   PropertyReferenceType<EdgeIndex> GetEdgeData(const edge_iterator& edge) {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
-    return std::get<prop_col_index>(edge_view_).GetValue(*edge);
+    return std::get<prop_col_index>(edge_view_)
+        .GetValue(pg_->edge_property_index(*edge));
   }
 
   /**
@@ -122,7 +125,8 @@ public:
   PropertyConstReferenceType<EdgeIndex> GetEdgeData(
       const edge_iterator& edge) const {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
-    return std::get<prop_col_index>(edge_view_).GetValue(*edge);
+    return std::get<prop_col_index>(edge_view_)
+        .GetValue(pg_->edge_property_index(*edge));
   }
 
   /**

--- a/libgraph/src/GraphTopology.cpp
+++ b/libgraph/src/GraphTopology.cpp
@@ -332,8 +332,10 @@ katana::EdgeShuffleTopology::SortEdgesByTypeThenDest(
               static_assert(
                   std::is_same_v<decltype(e2), GraphTopology::PropertyIndex>);
 
-              katana::EntityTypeID data1 = pg->GetTypeOfEdge(e1);
-              katana::EntityTypeID data2 = pg->GetTypeOfEdge(e2);
+              katana::EntityTypeID data1 =
+                  pg->GetTypeOfEdgeFromPropertyIndex(e1);
+              katana::EntityTypeID data2 =
+                  pg->GetTypeOfEdgeFromPropertyIndex(e2);
               if (data1 != data2) {
                 return data1 < data2;
               }
@@ -463,7 +465,7 @@ katana::CondensedTypeIDMap::MakeFromEdgeTypes(
   katana::do_all(
       katana::iterate(Edge{0}, topo.num_edges()),
       [&](const Edge& e) {
-        katana::EntityTypeID type = pg->GetTypeOfEdge(e);
+        katana::EntityTypeID type = pg->GetTypeOfEdgeFromPropertyIndex(e);
         edgeTypes.getLocal()->insert(type);
       },
       katana::no_stats());
@@ -526,7 +528,8 @@ katana::EdgeTypeAwareTopology::CreatePerEdgeTypeAdjacencyIndex(
         for (auto e : e_topo.edges(N)) {
           // Since we sort the edges, we must use the
           // edge_property_index because EdgeShuffleTopology rearranges the edges
-          const auto type = pg.GetTypeOfEdge(e_topo.edge_property_index(e));
+          const auto type =
+              pg.GetTypeOfEdgeFromPropertyIndex(e_topo.edge_property_index(e));
           while (type != edge_type_index.GetType(index)) {
             adj_indices[offset + index] = e;
             index++;
@@ -829,7 +832,7 @@ katana::ProjectedTopology::MakeTypeProjectedTopology(
             auto dest = topology.edge_dest(e);
             if (bitset_nodes.test(dest)) {
               for (auto type : edge_entity_type_ids) {
-                if (pg->DoesEdgeHaveType(e, type)) {
+                if (pg->DoesEdgeHaveTypeFromTopoIndex(e, type)) {
                   accum_num_new_edges += 1;
                   bitset_edges.set(e);
                   out_indices[src] += 1;

--- a/libgraph/src/GraphTopology.cpp
+++ b/libgraph/src/GraphTopology.cpp
@@ -10,6 +10,8 @@
 #include "katana/Result.h"
 #include "tsuba/RDGTopology.h"
 
+katana::GraphTopology::~GraphTopology() = default;
+
 void
 katana::GraphTopology::Print() const noexcept {
   auto print_array = [](const auto& arr, const auto& name) {
@@ -42,6 +44,8 @@ katana::GraphTopology::Copy(const GraphTopology& that) noexcept {
       that.dests_.size());
 }
 
+katana::ShuffleTopology::~ShuffleTopology() = default;
+
 std::shared_ptr<katana::ShuffleTopology>
 katana::ShuffleTopology::MakeFrom(
     const PropertyGraph*, const katana::EdgeShuffleTopology&) noexcept {
@@ -49,6 +53,8 @@ katana::ShuffleTopology::MakeFrom(
   std::shared_ptr<ShuffleTopology> ret;
   return ret;
 }
+
+katana::EdgeShuffleTopology::~EdgeShuffleTopology() = default;
 
 std::shared_ptr<katana::EdgeShuffleTopology>
 katana::EdgeShuffleTopology::MakeTransposeCopy(
@@ -489,45 +495,46 @@ katana::CondensedTypeIDMap::MakeFromEdgeTypes(
       std::move(edge_type_to_index), std::move(edge_index_to_type)});
 }
 
+katana::EdgeTypeAwareTopology::~EdgeTypeAwareTopology() = default;
+
 katana::EdgeTypeAwareTopology::AdjIndexVec
 katana::EdgeTypeAwareTopology::CreatePerEdgeTypeAdjacencyIndex(
-    const PropertyGraph* pg, const CondensedTypeIDMap* edge_type_index,
-    const EdgeShuffleTopology* e_topo) noexcept {
-  if (e_topo->num_nodes() == 0) {
+    const PropertyGraph& pg, const CondensedTypeIDMap& edge_type_index,
+    const EdgeShuffleTopology& e_topo) noexcept {
+  if (e_topo.num_nodes() == 0) {
     KATANA_LOG_VASSERT(
-        e_topo->num_edges() == 0, "Found graph with edges but no nodes");
+        e_topo.num_edges() == 0, "Found graph with edges but no nodes");
     return AdjIndexVec{};
   }
 
-  if (edge_type_index->num_unique_types() == 0) {
+  if (edge_type_index.num_unique_types() == 0) {
     KATANA_LOG_VASSERT(
-        e_topo->num_edges() == 0, "Found graph with edges but no edge types");
+        e_topo.num_edges() == 0, "Found graph with edges but no edge types");
     // Graph has some nodes but no edges.
     return AdjIndexVec{};
   }
 
-  const size_t sz = e_topo->num_nodes() * edge_type_index->num_unique_types();
+  const size_t sz = e_topo.num_nodes() * edge_type_index.num_unique_types();
   AdjIndexVec adj_indices;
   adj_indices.allocateInterleaved(sz);
 
   katana::do_all(
-      katana::iterate(e_topo->all_nodes()),
+      katana::iterate(e_topo.all_nodes()),
       [&](Node N) {
-        auto offset = N * edge_type_index->num_unique_types();
+        auto offset = N * edge_type_index.num_unique_types();
         uint32_t index = 0;
-        for (auto e : e_topo->edges(N)) {
+        for (auto e : e_topo.edges(N)) {
           // Since we sort the edges, we must use the
           // edge_property_index because EdgeShuffleTopology rearranges the edges
-          const auto type = pg->GetTypeOfEdge(e_topo->edge_property_index(e));
-          while (type != edge_type_index->GetType(index)) {
+          const auto type = pg.GetTypeOfEdge(e_topo.edge_property_index(e));
+          while (type != edge_type_index.GetType(index)) {
             adj_indices[offset + index] = e;
             index++;
-            KATANA_LOG_DEBUG_ASSERT(
-                index < edge_type_index->num_unique_types());
+            KATANA_LOG_DEBUG_ASSERT(index < edge_type_index.num_unique_types());
           }
         }
-        auto e = *e_topo->edges(N).end();
-        while (index < edge_type_index->num_unique_types()) {
+        auto e = *e_topo.edges(N).end();
+        while (index < edge_type_index.num_unique_types()) {
           adj_indices[offset + index] = e;
           index++;
         }
@@ -541,27 +548,26 @@ std::shared_ptr<katana::EdgeTypeAwareTopology>
 katana::EdgeTypeAwareTopology::MakeFrom(
     const katana::PropertyGraph* pg,
     std::shared_ptr<const CondensedTypeIDMap> edge_type_index,
-    std::shared_ptr<const EdgeShuffleTopology> e_topo) noexcept {
-  KATANA_LOG_DEBUG_ASSERT(e_topo->has_edges_sorted_by(
+    EdgeShuffleTopology&& e_topo) noexcept {
+  KATANA_LOG_DEBUG_ASSERT(e_topo.has_edges_sorted_by(
       tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType));
 
-  KATANA_LOG_DEBUG_ASSERT(e_topo->num_edges() == pg->topology().num_edges());
+  KATANA_LOG_DEBUG_ASSERT(e_topo.num_edges() == pg->topology().num_edges());
 
   AdjIndexVec per_type_adj_indices =
-      CreatePerEdgeTypeAdjacencyIndex(pg, edge_type_index.get(), e_topo.get());
+      CreatePerEdgeTypeAdjacencyIndex(*pg, *edge_type_index, e_topo);
 
   return std::make_shared<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
-      std::move(edge_type_index), std::move(e_topo),
+      std::move(e_topo), std::move(edge_type_index),
       std::move(per_type_adj_indices)});
 }
 
 katana::Result<tsuba::RDGTopology>
 katana::EdgeTypeAwareTopology::ToRDGTopology() const {
   tsuba::RDGTopology topo = KATANA_CHECKED(tsuba::RDGTopology::Make(
-      per_type_adj_indices_.data(), num_nodes(), edge_shuff_topo_->dest_data(),
-      num_edges(), tsuba::RDGTopology::TopologyKind::kEdgeTypeAwareTopology,
-      transpose_state(), edge_sort_state(),
-      edge_shuff_topo_->edge_property_index_data(),
+      per_type_adj_indices_.data(), num_nodes(), Base::dest_data(), num_edges(),
+      tsuba::RDGTopology::TopologyKind::kEdgeTypeAwareTopology,
+      transpose_state(), edge_sort_state(), Base::edge_property_index_data(),
       edge_type_index_->num_unique_types(),
       edge_type_index_->index_to_type_map_data()));
 
@@ -572,31 +578,31 @@ std::shared_ptr<katana::EdgeTypeAwareTopology>
 katana::EdgeTypeAwareTopology::Make(
     tsuba::RDGTopology* rdg_topo,
     std::shared_ptr<const CondensedTypeIDMap> edge_type_index,
-    std::shared_ptr<const EdgeShuffleTopology> e_topo) {
+    EdgeShuffleTopology&& e_topo) {
   KATANA_LOG_DEBUG_ASSERT(rdg_topo);
+
   KATANA_LOG_ASSERT(
       rdg_topo->edge_sort_state() ==
       tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType);
-  KATANA_LOG_DEBUG_ASSERT(e_topo->has_edges_sorted_by(
+
+  KATANA_LOG_DEBUG_ASSERT(e_topo.has_edges_sorted_by(
       tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType));
 
   KATANA_LOG_VASSERT(
       edge_type_index->index_to_type_map_matches(
           rdg_topo->edge_condensed_type_id_map_size(),
           rdg_topo->edge_condensed_type_id_map()) &&
-          e_topo->num_edges() == rdg_topo->num_edges() &&
-          e_topo->num_nodes() == rdg_topo->num_nodes(),
+          e_topo.num_edges() == rdg_topo->num_edges() &&
+          e_topo.num_nodes() == rdg_topo->num_nodes(),
       "tried to load out of date EdgeTypeAwareTopology; on disk topologies "
       "must be invalidated when updates occur");
 
   AdjIndexVec per_type_adj_indices;
-  per_type_adj_indices.allocateInterleaved(
-      rdg_topo->num_nodes() * edge_type_index->num_unique_types());
+  size_t sz = rdg_topo->num_nodes() * edge_type_index->num_unique_types();
+  per_type_adj_indices.allocateInterleaved(sz);
 
   katana::ParallelSTL::copy(
-      &(rdg_topo->adj_indices()[0]),
-      &(rdg_topo->adj_indices()
-            [rdg_topo->num_nodes() * edge_type_index->num_unique_types()]),
+      &(rdg_topo->adj_indices()[0]), &(rdg_topo->adj_indices()[sz]),
       per_type_adj_indices.begin());
 
   // Since we copy the data we need out of the RDGTopology into our own arrays,
@@ -605,7 +611,7 @@ katana::EdgeTypeAwareTopology::Make(
   KATANA_LOG_ASSERT(res);
 
   return std::make_shared<EdgeTypeAwareTopology>(EdgeTypeAwareTopology{
-      std::move(edge_type_index), std::move(e_topo),
+      std::move(e_topo), std::move(edge_type_index),
       std::move(per_type_adj_indices)});
 }
 
@@ -906,10 +912,26 @@ katana::ProjectedTopology::MakeTypeProjectedTopology(
       std::move(projected_to_original_edges_mapping), std::move(node_bitmask),
       std::move(edge_bitmask)});
 }
+
+const katana::GraphTopology&
+katana::PGViewCache::GetDefaultTopologyRef() const noexcept {
+  return *original_topo_;
+}
+
 std::shared_ptr<katana::GraphTopology>
-katana::PGViewCache::GetOriginalTopology(
-    const PropertyGraph* pg) const noexcept {
-  return pg->topology_;
+katana::PGViewCache::GetDefaultTopology() const noexcept {
+  return original_topo_;
+}
+
+void
+katana::PGViewCache::DropAllTopologies() noexcept {
+  original_topo_ = std::make_shared<katana::GraphTopology>();
+
+  edge_shuff_topos_.clear();
+  fully_shuff_topos_.clear();
+  edge_type_aware_topos_.clear();
+  edge_type_id_map_.reset();
+  projected_topos_.reset();
 }
 
 std::shared_ptr<katana::CondensedTypeIDMap>
@@ -936,7 +958,23 @@ katana::PGViewCache::BuildOrGetEdgeShuffTopo(
     katana::PropertyGraph* pg,
     const tsuba::RDGTopology::TransposeKind& tpose_kind,
     const tsuba::RDGTopology::EdgeSortKind& sort_kind) noexcept {
-  // try to find a matching topology in the cache
+  return BuildOrGetEdgeShuffTopoImpl(pg, tpose_kind, sort_kind, false);
+}
+
+std::shared_ptr<katana::EdgeShuffleTopology>
+katana::PGViewCache::PopEdgeShuffTopo(
+    katana::PropertyGraph* pg,
+    const tsuba::RDGTopology::TransposeKind& tpose_kind,
+    const tsuba::RDGTopology::EdgeSortKind& sort_kind) noexcept {
+  return BuildOrGetEdgeShuffTopoImpl(pg, tpose_kind, sort_kind, true);
+}
+
+std::shared_ptr<katana::EdgeShuffleTopology>
+katana::PGViewCache::BuildOrGetEdgeShuffTopoImpl(
+    katana::PropertyGraph* pg,
+    const tsuba::RDGTopology::TransposeKind& tpose_kind,
+    const tsuba::RDGTopology::EdgeSortKind& sort_kind, bool pop) noexcept {
+  // Try to find a matching topology in the cache.
   auto pred = [&](const auto& topo_ptr) {
     return topo_ptr->is_valid() && topo_ptr->has_transpose_state(tpose_kind) &&
            topo_ptr->has_edges_sorted_by(sort_kind);
@@ -946,25 +984,46 @@ katana::PGViewCache::BuildOrGetEdgeShuffTopo(
 
   if (it != edge_shuff_topos_.end()) {
     KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, it->get()));
-    return *it;
-  } else {
-    // no matching topology in cache, see if we have it in storage
-    tsuba::RDGTopology shadow = tsuba::RDGTopology::MakeShadow(
-        tsuba::RDGTopology::TopologyKind::kEdgeShuffleTopology, tpose_kind,
-        sort_kind, tsuba::RDGTopology::NodeSortKind::kAny);
-
-    auto res = pg->LoadTopology(std::move(shadow));
-    if (!res) {
-      // no matching topology in cache or storage, generate it
-      edge_shuff_topos_.emplace_back(
-          EdgeShuffleTopology::Make(pg, tpose_kind, sort_kind));
+    if (pop) {
+      auto topo = *it;
+      edge_shuff_topos_.erase(it);
+      return topo;
     } else {
-      // found matching topology in storage
-      tsuba::RDGTopology* topo = res.value();
-      edge_shuff_topos_.emplace_back(katana::EdgeShuffleTopology::Make(topo));
+      return *it;
     }
+  }
 
-    KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, edge_shuff_topos_.back().get()));
+  // Then in edge type aware topologies. We don't pop from it.
+  if (sort_kind == tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType) {
+    auto it = std::find_if(
+        edge_type_aware_topos_.begin(), edge_type_aware_topos_.end(), pred);
+    if (it != edge_type_aware_topos_.end()) {
+      KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, it->get()));
+      return *it;
+    }
+  }
+
+  // No matching topology in cache, see if we have it in storage
+  tsuba::RDGTopology shadow = tsuba::RDGTopology::MakeShadow(
+      tsuba::RDGTopology::TopologyKind::kEdgeShuffleTopology, tpose_kind,
+      sort_kind, tsuba::RDGTopology::NodeSortKind::kAny);
+
+  auto res = pg->LoadTopology(std::move(shadow));
+  auto new_topo = (!res) ? EdgeShuffleTopology::Make(pg, tpose_kind, sort_kind)
+                         : EdgeShuffleTopology::Make(res.value());
+  KATANA_LOG_DEBUG_ASSERT(CheckTopology(pg, new_topo.get()));
+
+  if (pop) {
+    return new_topo;
+  } else {
+    edge_shuff_topos_.emplace_back(std::move(new_topo));
+    if (tpose_kind == tsuba::RDGTopology::TransposeKind::kNo &&
+        original_topo_->edge_sort_state() ==
+            tsuba::RDGTopology::EdgeSortKind::kAny) {
+      // The new topology can replace the defaut one. We check for the original sort state
+      // to avoid doing this every time a new edge shuffle topo is cached.
+      original_topo_ = edge_shuff_topos_.back();
+    }
     return edge_shuff_topos_.back();
   }
 }
@@ -1037,15 +1096,15 @@ katana::PGViewCache::BuildOrGetEdgeTypeAwareTopo(
     return *it;
   } else {
     // no matching topology in cache, see if we have it in storage
-
     tsuba::RDGTopology shadow = tsuba::RDGTopology::MakeShadow(
         tsuba::RDGTopology::TopologyKind::kEdgeTypeAwareTopology, tpose_kind,
         tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType,
         tsuba::RDGTopology::NodeSortKind::kAny);
     auto res = pg->LoadTopology(std::move(shadow));
 
-    // In either generation, or loading, the EdgeTypeAwareTopology depends on an EdgeShuffleTopology
-    auto sorted_topo = BuildOrGetEdgeShuffTopo(
+    // In either generation, or loading, the EdgeTypeAwareTopology depends on an EdgeShuffleTopology.
+    // This call does NOT cache the resulting edge shuffled topology.
+    auto sorted_topo = PopEdgeShuffTopo(
         pg, tpose_kind, tsuba::RDGTopology::EdgeSortKind::kSortedByEdgeType);
 
     // There are two use cases for the EdgeTypeIndex, either we:
@@ -1060,15 +1119,20 @@ katana::PGViewCache::BuildOrGetEdgeTypeAwareTopo(
       tsuba::RDGTopology* rdg_topo = res.value();
 
       edge_type_aware_topos_.emplace_back(katana::EdgeTypeAwareTopology::Make(
-          rdg_topo, std::move(edge_type_index), std::move(sorted_topo)));
+          rdg_topo, std::move(edge_type_index), std::move(*sorted_topo)));
     } else {
       // no matching topology in cache or storage, generate it
       edge_type_aware_topos_.emplace_back(EdgeTypeAwareTopology::MakeFrom(
-          pg, std::move(edge_type_index), std::move(sorted_topo)));
+          pg, std::move(edge_type_index), std::move(*sorted_topo)));
     }
 
     KATANA_LOG_DEBUG_ASSERT(
         CheckTopology(pg, edge_type_aware_topos_.back().get()));
+
+    if (tpose_kind == tsuba::RDGTopology::TransposeKind::kNo) {
+      // The new topology can replace the defaut one.
+      original_topo_ = edge_type_aware_topos_.back();
+    }
     return edge_type_aware_topos_.back();
   }
 }

--- a/libgraph/src/GraphTopology.cpp
+++ b/libgraph/src/GraphTopology.cpp
@@ -35,6 +35,20 @@ katana::GraphTopology::GraphTopology(
   katana::ParallelSTL::copy(
       &adj_indices[0], &adj_indices[num_nodes], adj_indices_.begin());
   katana::ParallelSTL::copy(&dests[0], &dests[num_edges], dests_.begin());
+
+  edge_prop_indices_.allocateInterleaved(num_edges);
+
+  katana::ParallelSTL::iota(
+      edge_prop_indices_.begin(), edge_prop_indices_.end(), Edge{0});
+}
+
+katana::GraphTopology::GraphTopology(
+    NUMAArray<Edge>&& adj_indices, NUMAArray<Node>&& dests) noexcept
+    : adj_indices_(std::move(adj_indices)), dests_(std::move(dests)) {
+  edge_prop_indices_.allocateInterleaved(dests_.size());
+
+  katana::ParallelSTL::iota(
+      edge_prop_indices_.begin(), edge_prop_indices_.end(), Edge{0});
 }
 
 katana::GraphTopology

--- a/libgraph/src/PropertyGraphRetractor.cpp
+++ b/libgraph/src/PropertyGraphRetractor.cpp
@@ -15,7 +15,6 @@ katana::PropertyGraphRetractor::InformPath(const std::string& input_path) {
 
 Result<void>
 katana::PropertyGraphRetractor::DropTopologies() {
-  //TODO: emcginnis reset all topologies in PGViewCache
-  pg_->topology_ = std::make_shared<katana::GraphTopology>();
+  pg_->DropAllTopologies();
   return pg_->rdg_.DropAllTopologies();
 }

--- a/python/katana/cpp/libgalois/graphs/Graph.pxd
+++ b/python/katana/cpp/libgalois/graphs/Graph.pxd
@@ -165,9 +165,9 @@ cdef extern from "katana/Graph.h" namespace "katana" nogil:
         EntityTypeManager& GetNodeTypeManager() const
         EntityTypeManager& GetEdgeTypeManager() const
         EntityTypeID GetTypeOfNode(Node node) const
-        EntityTypeID GetTypeOfEdge(Edge edge) const
+        EntityTypeID GetTypeOfEdgeFromPropertyIndex(Edge edge) const
         bool DoesNodeHaveType(Node node, EntityTypeID node_entity_type_id) const
-        bool DoesEdgeHaveType(Edge edge, EntityTypeID edge_entity_type_id) const
+        bool DoesEdgeHaveTypeFromPropertyIndex(Edge edge, EntityTypeID edge_entity_type_id) const
 
         const string& rdg_dir()
 

--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -504,7 +504,7 @@ cdef class GraphBase:
         :param e: edge id
         :return: the type id of the edge
         """
-        return self.underlying_property_graph().GetTypeOfEdge(e)
+        return self.underlying_property_graph().GetTypeOfEdgeFromPropertyIndex(e)
 
     def does_edge_have_type(self, uint64_t e, entity_type):
         """
@@ -520,7 +520,7 @@ cdef class GraphBase:
             type_id = entity_type.type_id
         else:
             raise ValueError(f"{entity_type}'s type is not supported")
-        return self.underlying_property_graph().DoesEdgeHaveType(e, type_id)
+        return self.underlying_property_graph().DoesEdgeHaveTypeFromPropertyIndex(e, type_id)
 
     @abstractmethod
     def global_out_degree(self, uint64_t node):


### PR DESCRIPTION
This commit has cosmetic and functional changes. The cosmetic change is that `EdgeTypeAwareTopology` now derives directly from `EdgeShuffleTopology`. The code in `GraphTopology.h` has been moved around so that all Topology class definitions precede TopologyWrapper definitions. The functional change is that the default topology has been moved to the topology cache. Moreover, now its pointer may be reseated to point to a more constrained topology, if one is created, to reduce the overall memory consumption of topologies in cache. Concretely, we update the default topology when a new `EdgeShuffleTopology` or an `EdgeTypeAwareTopology` is constructed.

Here are the memory consumption breakdown when running a simple query on the friendster graph:

| Item | Before  | After | Comment |
| ------|------- | ----------|--- |
| Original topology | 14 GB  | 41 GB  | Original topology now stores the identity edge index mapping. We agreed to address this in a subsequent PR. This bump does not affect the query use case, since we now drop the original topology when we create the AttributedGraph.  |
| Two AttributedGraph topologies  | 2 x 41 GB  | 2 x 41 GB | No change |
| AttributedGraph's property index -> out-edge ID mapping  | N/A  | 26 GB | Current AttributedGraph's implementation relies on property indexes and local edge IDs to be the same for the default topology. When we replace the default topology with a shuffled one, we have to introduce this additional mapping. This will be addressed in a subsequent PR. |
| Overall memory usage | 105 GB | 117 GB | The increase of 12 GB is the difference between the new mapping of 26 GB and dropping the original topology of 14 GB |