### PR TITLE
Add a dependency on mistune<2.0 to prevent incompatible package installs

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -45,6 +45,7 @@ dependencies:
  - llvmdev>=8
  - make>=4.2
  - metagraph>=0.2.6
+ - mistune>=0.8,<2a0
  - nbconvert>=5.6,<6a0
  - nbsphinx>=0.8
  - ncurses>=6.1,<7a0

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -149,6 +149,7 @@ outputs:
         - jupyter_client {{ jupyter_client }}
         - attrs {{ attrs }}
         - nbconvert {{ nbconvert }}
+        - mistune {{ mistune }}
         - pexpect {{ pexpect }}
       source_files:
         - tools/graph-convert/test-inputs

--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -565,3 +565,8 @@ pexpect:
   labels:
     - pip/dev
     - conda/dev
+mistune:
+  version: [0.8, 2]
+  labels:
+    - pip/dev
+    - conda/dev


### PR DESCRIPTION
Need to backport this fix to the release branch.