### PR TITLE
fix-leiden

### DIFF
--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -686,9 +686,10 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static uint64_t GetRandomSubcommunity(
       const Graph& graph, GNode n, CommunityArray& subcomm_info,
-      uint64_t total_node_wt, [[maybe_unused]] uint64_t total_degree_wt,
-      uint64_t comm_id, [[maybe_unused]] double constant_for_second_term,
-      double resolution, [[maybe_unused]] double randomness) {
+      [[maybe_unused]] uint64_t total_node_wt,
+      [[maybe_unused]] uint64_t total_degree_wt, uint64_t comm_id,
+      [[maybe_unused]] double constant_for_second_term,
+      [[maybe_unused]] double resolution, [[maybe_unused]] double randomness) {
     auto& n_current_subcomm_id =
         graph.template GetData<CurrentSubCommunityID>(n);
     /*
@@ -774,52 +775,54 @@ struct ClusteringImplementationBase {
       [[maybe_unused]] double subcomm_degree_wt =
           subcomm_info[subcomm].degree_wt;
 
-      double tmp = resolution * subcomm_node_wt *
-                   (static_cast<double>(total_node_wt) - subcomm_node_wt);
-      katana::gPrint("\n tmp: ", tmp);
+      //double tmp = resolution * subcomm_node_wt *
+      //             (static_cast<double>(total_node_wt) - subcomm_node_wt);
+      //katana::gPrint("\n tmp: ", tmp);
 
-      katana::gPrint(
-          "\n subcomm_info[subcomm].num_internal_edges: ",
-          subcomm_info[subcomm].num_internal_edges);
+      //      katana::gPrint(
+      //        "\n subcomm_info[subcomm].num_internal_edges: ",
+      //      subcomm_info[subcomm].num_internal_edges);
 
       // check if subcommunity is well connected
-      if (double tmp = resolution * subcomm_node_wt *
-                       (static_cast<double>(total_node_wt) - subcomm_node_wt);
-          subcomm_info[subcomm].num_internal_edges >= tmp) {
-        quality_value_increment =
-            counter[pair.second] -
-            n_degree_wt * subcomm_degree_wt * constant_for_second_term;
+      // if (double tmp = resolution * subcomm_node_wt *
+      //                (static_cast<double>(total_node_wt) - subcomm_node_wt);
+      // subcomm_info[subcomm].num_internal_edges >= tmp) {
+      quality_value_increment =
+          counter[pair.second] -
+          n_degree_wt * subcomm_degree_wt * constant_for_second_term;
 
-        /*if (quality_value_increment > max_quality_value_increment) {
+      /*if (quality_value_increment > max_quality_value_increment) {
           best_cluster = subcomm;
           max_quality_value_increment = quality_value_increment;
         }*/
 
-        katana::gPrint("\n quality_value_increment: ", quality_value_increment);
+      //katana::gPrint("\n quality_value_increment: ", quality_value_increment);
 
-        if (quality_value_increment >= 0) {
-          total_transformed_quality_value_increment +=
-              std::exp(quality_value_increment);
-        }
+      if (quality_value_increment >= 0) {
+        total_transformed_quality_value_increment +=
+            std::exp(quality_value_increment);
       }
+      //}
       cum_transformed_quality_value_increment_per_cluster[pair.second] =
           total_transformed_quality_value_increment;
       counter[pair.second] = 0;
 
-      quality_value_increment =
+      /*quality_value_increment =
           counter[pair.second] -
           n_degree_wt * subcomm_degree_wt * constant_for_second_term;
 
       if (quality_value_increment > max_quality_value_increment) {
         best_cluster = subcomm;
         max_quality_value_increment = quality_value_increment;
-      }
+      }*/
     }
 
+    //return best_cluster;
     /*
    * Determine the neighboring cluster to which the currently
    * selected node will be moved.
    */
+
     int64_t min_idx, max_idx, mid_idx;
     double r;
     if (total_transformed_quality_value_increment > 0 &&
@@ -829,16 +832,16 @@ struct ClusteringImplementationBase {
 
       katana::gPrint("\n r: ", r);
 
-      katana::gPrint(
-          "\n total_transformed_quality_value_increment: ",
-          total_transformed_quality_value_increment);
+      //katana::gPrint(
+      //  "\n total_transformed_quality_value_increment: ",
+      //total_transformed_quality_value_increment);
 
       min_idx = -1;
       max_idx = num_unique_clusters;
       while (min_idx < max_idx) {
         mid_idx = (min_idx + max_idx) / 2;
 
-        katana::gPrint("\n mid idx: ", mid_idx);
+        //katana::gPrint("\n mid idx: ", mid_idx);
 
         if (cum_transformed_quality_value_increment_per_cluster[mid_idx] >= r) {
           if (max_idx == mid_idx) {
@@ -855,8 +858,9 @@ struct ClusteringImplementationBase {
       return (max_idx == 0) ? neighboring_cluster_ids[max_idx]
                             : neighboring_cluster_ids[max_idx - 1];
     } else {
-      katana::gPrint("here \n");
+      //katana::gPrint("here \n");
       return best_cluster;
+      //  return n_current_subcomm_id;
     }
   }
 
@@ -929,6 +933,7 @@ struct ClusteringImplementationBase {
      * - clusterWeights[j]) * resolution
      */
 
+      //seems like the source code is not doing this
       if (double tmp = resolution * static_cast<double>(node_wt) *
                        static_cast<double>(total_node_wt - node_wt);
           num_edges_within_cluster >= tmp) {
@@ -941,6 +946,9 @@ struct ClusteringImplementationBase {
       subcomm_info[n].size = 1;
       subcomm_info[n].degree_wt = degree_wt;
     }
+
+    std::random_shuffle(
+        cluster_nodes_to_move.begin(), cluster_nodes_to_move.end());
 
     for (GNode n : cluster_nodes_to_move) {
       const auto& n_degree_wt =

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -45,6 +45,7 @@ struct LeidenCommunityType {
   std::atomic<EdgeWeightType> degree_wt;
   std::atomic<uint64_t> node_wt;
   EdgeWeightType internal_edge_wt;
+  uint64_t num_internal_edges;
   uint64_t num_sub_communities;
 };
 
@@ -685,8 +686,9 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static uint64_t GetRandomSubcommunity(
       const Graph& graph, GNode n, CommunityArray& subcomm_info,
-      uint64_t total_degree_wt, uint64_t comm_id,
-      double constant_for_second_term, double resolution, double randomness) {
+      uint64_t total_node_wt, [[maybe_unused]] uint64_t total_degree_wt,
+      uint64_t comm_id, [[maybe_unused]] double constant_for_second_term,
+      double resolution, [[maybe_unused]] double randomness) {
     auto& n_current_subcomm_id =
         graph.template GetData<CurrentSubCommunityID>(n);
     /*
@@ -754,42 +756,64 @@ struct ClusteringImplementationBase {
     }  // End edge loop
 
     uint64_t best_cluster = n_current_subcomm_id;
-    double max_quality_value_increment = 0;
+    [[maybe_unused]] double max_quality_value_increment = 0;
     double total_transformed_quality_value_increment = 0;
     double quality_value_increment = 0;
     std::vector<double> cum_transformed_quality_value_increment_per_cluster(
         num_unique_clusters);
-    auto& n_node_wt = graph.template GetData<NodeWeight>(n);
+    [[maybe_unused]] auto& n_node_wt = graph.template GetData<NodeWeight>(n);
+    auto& n_degree_wt = graph.template GetData<DegreeWeight<EdgeWeightType>>(n);
+
     for (auto pair : cluster_local_map) {
       auto subcomm = pair.first;
       if (n_current_subcomm_id == subcomm) {
         continue;
       }
 
-      double subcomm_node_wt = subcomm_info[subcomm].node_wt;
-      double subcomm_degree_wt = subcomm_info[subcomm].degree_wt;
+      [[maybe_unused]] double subcomm_node_wt = subcomm_info[subcomm].node_wt;
+      [[maybe_unused]] double subcomm_degree_wt =
+          subcomm_info[subcomm].degree_wt;
+
+      double tmp = resolution * subcomm_node_wt *
+                   (static_cast<double>(total_node_wt) - subcomm_node_wt);
+      katana::gPrint("\n tmp: ", tmp);
+
+      katana::gPrint(
+          "\n subcomm_info[subcomm].num_internal_edges: ",
+          subcomm_info[subcomm].num_internal_edges);
 
       // check if subcommunity is well connected
-      if (double tmp =
-              constant_for_second_term * subcomm_degree_wt *
-              (static_cast<double>(total_degree_wt) - subcomm_degree_wt);
-          subcomm_info[subcomm].internal_edge_wt >= tmp) {
+      if (double tmp = resolution * subcomm_node_wt *
+                       (static_cast<double>(total_node_wt) - subcomm_node_wt);
+          subcomm_info[subcomm].num_internal_edges >= tmp) {
         quality_value_increment =
-            counter[pair.second] - n_node_wt * subcomm_node_wt * resolution;
+            counter[pair.second] -
+            n_degree_wt * subcomm_degree_wt * constant_for_second_term;
 
-        if (quality_value_increment > max_quality_value_increment) {
+        /*if (quality_value_increment > max_quality_value_increment) {
           best_cluster = subcomm;
           max_quality_value_increment = quality_value_increment;
-        }
+        }*/
+
+        katana::gPrint("\n quality_value_increment: ", quality_value_increment);
 
         if (quality_value_increment >= 0) {
           total_transformed_quality_value_increment +=
-              std::exp(quality_value_increment / randomness);
+              std::exp(quality_value_increment);
         }
       }
       cum_transformed_quality_value_increment_per_cluster[pair.second] =
           total_transformed_quality_value_increment;
       counter[pair.second] = 0;
+
+      quality_value_increment =
+          counter[pair.second] -
+          n_degree_wt * subcomm_degree_wt * constant_for_second_term;
+
+      if (quality_value_increment > max_quality_value_increment) {
+        best_cluster = subcomm;
+        max_quality_value_increment = quality_value_increment;
+      }
     }
 
     /*
@@ -798,13 +822,24 @@ struct ClusteringImplementationBase {
    */
     int64_t min_idx, max_idx, mid_idx;
     double r;
-    if (total_transformed_quality_value_increment < INFINITY_DOUBLE) {
+    if (total_transformed_quality_value_increment > 0 &&
+        total_transformed_quality_value_increment < INFINITY_DOUBLE) {
       r = total_transformed_quality_value_increment *
           GenerateRandonNumber(0.0, 1.0);
+
+      katana::gPrint("\n r: ", r);
+
+      katana::gPrint(
+          "\n total_transformed_quality_value_increment: ",
+          total_transformed_quality_value_increment);
+
       min_idx = -1;
       max_idx = num_unique_clusters;
       while (min_idx < max_idx) {
         mid_idx = (min_idx + max_idx) / 2;
+
+        katana::gPrint("\n mid idx: ", mid_idx);
+
         if (cum_transformed_quality_value_increment_per_cluster[mid_idx] >= r) {
           if (max_idx == mid_idx) {
             break;
@@ -820,6 +855,7 @@ struct ClusteringImplementationBase {
       return (max_idx == 0) ? neighboring_cluster_ids[max_idx]
                             : neighboring_cluster_ids[max_idx - 1];
     } else {
+      katana::gPrint("here \n");
       return best_cluster;
     }
   }
@@ -853,8 +889,9 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static void MergeNodesSubset(
       Graph* graph, std::vector<GNode>& cluster_nodes, uint64_t comm_id,
-      uint64_t total_degree_wt, CommunityArray& subcomm_info,
-      double constant_for_second_term, double resolution, double randomness) {
+      uint64_t total_node_wt, uint64_t total_degree_wt,
+      CommunityArray& subcomm_info, double constant_for_second_term,
+      double resolution, double randomness) {
     // select set R
     std::vector<GNode> cluster_nodes_to_move;
     for (uint64_t i = 0; i < cluster_nodes.size(); ++i) {
@@ -866,6 +903,8 @@ struct ClusteringImplementationBase {
      * Initialize with singleton sub-communities
      */
       EdgeWeightType node_edge_weight_within_cluster = 0;
+      uint64_t num_edges_within_cluster = 0;
+
       for (auto e : graph->edges(n)) {
         auto dst = graph->edge_dest(e);
         EdgeWeightType edge_wt =
@@ -877,6 +916,7 @@ struct ClusteringImplementationBase {
         if (dst != n &&
             graph->template GetData<CurrentCommunityID>(dst) == comm_id) {
           node_edge_weight_within_cluster += edge_wt;
+          num_edges_within_cluster++;
         }
       }
 
@@ -889,15 +929,15 @@ struct ClusteringImplementationBase {
      * - clusterWeights[j]) * resolution
      */
 
-      if (double tmp = constant_for_second_term *
-                       static_cast<double>(degree_wt) *
-                       static_cast<double>(total_degree_wt - degree_wt);
-          node_edge_weight_within_cluster >= tmp) {
+      if (double tmp = resolution * static_cast<double>(node_wt) *
+                       static_cast<double>(total_node_wt - node_wt);
+          num_edges_within_cluster >= tmp) {
         cluster_nodes_to_move.push_back(n);
       }
 
       subcomm_info[n].node_wt = node_wt;
       subcomm_info[n].internal_edge_wt = node_edge_weight_within_cluster;
+      subcomm_info[n].num_internal_edges = num_edges_within_cluster;
       subcomm_info[n].size = 1;
       subcomm_info[n].degree_wt = degree_wt;
     }
@@ -913,7 +953,7 @@ struct ClusteringImplementationBase {
      */
       if (subcomm_info[n_current_subcomm_id].size == 1) {
         uint64_t new_subcomm_ass = GetRandomSubcommunity<EdgeWeightType>(
-            *graph, n, subcomm_info, total_degree_wt, comm_id,
+            *graph, n, subcomm_info, total_node_wt, total_degree_wt, comm_id,
             constant_for_second_term, resolution, randomness);
         if (new_subcomm_ass != UNASSIGNED &&
             new_subcomm_ass != n_current_subcomm_id) {
@@ -936,8 +976,10 @@ struct ClusteringImplementationBase {
               if (graph->template GetData<CurrentSubCommunityID>(dst) ==
                   new_subcomm_ass) {
                 subcomm_info[new_subcomm_ass].internal_edge_wt -= edge_wt;
+                subcomm_info[new_subcomm_ass].num_internal_edges--;
               } else {
                 subcomm_info[new_subcomm_ass].internal_edge_wt += edge_wt;
+                subcomm_info[new_subcomm_ass].num_internal_edges++;
               }
             }
           }
@@ -1006,8 +1048,9 @@ struct ClusteringImplementationBase {
       comm_info[c].num_sub_communities = 0;
       if (cluster_bags[c].size() > 1) {
         MergeNodesSubset<EdgeWeightType>(
-            graph, cluster_bags[c], c, comm_info[c].degree_wt, subcomm_info,
-            constant_for_second_term, resolution, randomness);
+            graph, cluster_bags[c], c, comm_info[c].node_wt,
+            comm_info[c].degree_wt, subcomm_info, constant_for_second_term,
+            resolution, randomness);
       }
     });
   }

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -912,9 +912,6 @@ struct ClusteringImplementationBase {
       subcomm_info[n].degree_wt = degree_wt;
     }
 
-    std::random_shuffle(
-        cluster_nodes_to_move.begin(), cluster_nodes_to_move.end());
-
     for (GNode n : cluster_nodes_to_move) {
       const auto& n_degree_wt =
           graph->template GetData<DegreeWeight<EdgeWeightType>>(n);

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -859,9 +859,8 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static void MergeNodesSubset(
       Graph* graph, std::vector<GNode>& cluster_nodes, uint64_t comm_id,
-      uint64_t total_node_wt, [[maybe_unused]] uint64_t total_degree_wt,
-      CommunityArray& subcomm_info, double constant_for_second_term,
-      double resolution, [[maybe_unused]] double randomness) {
+      uint64_t total_node_wt, CommunityArray& subcomm_info,
+      double constant_for_second_term, double resolution) {
     // select set R
     std::vector<GNode> cluster_nodes_to_move;
     for (uint64_t i = 0; i < cluster_nodes.size(); ++i) {
@@ -967,8 +966,7 @@ struct ClusteringImplementationBase {
  * trying to split up each cluster into multiple clusters.
  */
   template <typename EdgeWeightType>
-  static void RefinePartition(
-      Graph* graph, double resolution, double randomness) {
+  static void RefinePartition(Graph* graph, double resolution) {
     double constant_for_second_term =
         CalConstantForSecondTerm<EdgeWeightType>(*graph);
     // set singleton subcommunities
@@ -1022,9 +1020,8 @@ struct ClusteringImplementationBase {
       comm_info[c].num_sub_communities = 0;
       if (cluster_bags[c].size() > 1) {
         MergeNodesSubset<EdgeWeightType>(
-            graph, cluster_bags[c], c, comm_info[c].node_wt,
-            comm_info[c].degree_wt, subcomm_info, constant_for_second_term,
-            resolution, randomness);
+            graph, cluster_bags[c], c, comm_info[c].node_wt, subcomm_info,
+            constant_for_second_term, resolution);
       }
     });
   }

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -686,10 +686,9 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static uint64_t GetRandomSubcommunity(
       const Graph& graph, GNode n, CommunityArray& subcomm_info,
-      [[maybe_unused]] uint64_t total_node_wt,
-      [[maybe_unused]] uint64_t total_degree_wt, uint64_t comm_id,
-      [[maybe_unused]] double constant_for_second_term,
-      [[maybe_unused]] double resolution, [[maybe_unused]] double randomness) {
+      uint64_t total_node_wt, [[maybe_unused]] uint64_t total_degree_wt,
+      uint64_t comm_id, double constant_for_second_term, double resolution,
+      [[maybe_unused]] double randomness) {
     auto& n_current_subcomm_id =
         graph.template GetData<CurrentSubCommunityID>(n);
     /*
@@ -757,12 +756,11 @@ struct ClusteringImplementationBase {
     }  // End edge loop
 
     uint64_t best_cluster = n_current_subcomm_id;
-    [[maybe_unused]] double max_quality_value_increment = 0;
+    double max_quality_value_increment = 0;
     double total_transformed_quality_value_increment = 0;
     double quality_value_increment = 0;
     std::vector<double> cum_transformed_quality_value_increment_per_cluster(
         num_unique_clusters);
-    [[maybe_unused]] auto& n_node_wt = graph.template GetData<NodeWeight>(n);
     auto& n_degree_wt = graph.template GetData<DegreeWeight<EdgeWeightType>>(n);
 
     for (auto pair : cluster_local_map) {
@@ -810,18 +808,10 @@ struct ClusteringImplementationBase {
       r = total_transformed_quality_value_increment *
           GenerateRandonNumber(0.0, 1.0);
 
-      katana::gPrint("\n r: ", r);
-
-      //katana::gPrint(
-      //  "\n total_transformed_quality_value_increment: ",
-      //total_transformed_quality_value_increment);
-
       min_idx = -1;
       max_idx = num_unique_clusters;
       while (min_idx < max_idx) {
         mid_idx = (min_idx + max_idx) / 2;
-
-        //katana::gPrint("\n mid idx: ", mid_idx);
 
         if (cum_transformed_quality_value_increment_per_cluster[mid_idx] >= r) {
           if (max_idx == mid_idx) {
@@ -838,9 +828,7 @@ struct ClusteringImplementationBase {
       return (max_idx == 0) ? neighboring_cluster_ids[max_idx]
                             : neighboring_cluster_ids[max_idx - 1];
     } else {
-      //katana::gPrint("here \n");
       return best_cluster;
-      //  return n_current_subcomm_id;
     }
   }
 

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -775,49 +775,29 @@ struct ClusteringImplementationBase {
       [[maybe_unused]] double subcomm_degree_wt =
           subcomm_info[subcomm].degree_wt;
 
-      //double tmp = resolution * subcomm_node_wt *
-      //             (static_cast<double>(total_node_wt) - subcomm_node_wt);
-      //katana::gPrint("\n tmp: ", tmp);
-
-      //      katana::gPrint(
-      //        "\n subcomm_info[subcomm].num_internal_edges: ",
-      //      subcomm_info[subcomm].num_internal_edges);
-
       // check if subcommunity is well connected
-      // if (double tmp = resolution * subcomm_node_wt *
-      //                (static_cast<double>(total_node_wt) - subcomm_node_wt);
-      // subcomm_info[subcomm].num_internal_edges >= tmp) {
-      quality_value_increment =
-          counter[pair.second] -
-          n_degree_wt * subcomm_degree_wt * constant_for_second_term;
+      if (double tmp = resolution * subcomm_node_wt *
+                       (static_cast<double>(total_node_wt) - subcomm_node_wt);
+          subcomm_info[subcomm].num_internal_edges >= tmp) {
+        quality_value_increment =
+            counter[pair.second] -
+            n_degree_wt * subcomm_degree_wt * constant_for_second_term;
 
-      /*if (quality_value_increment > max_quality_value_increment) {
+        if (quality_value_increment > max_quality_value_increment) {
           best_cluster = subcomm;
           max_quality_value_increment = quality_value_increment;
-        }*/
+        }
 
-      //katana::gPrint("\n quality_value_increment: ", quality_value_increment);
-
-      if (quality_value_increment >= 0) {
-        total_transformed_quality_value_increment +=
-            std::exp(quality_value_increment);
+        if (quality_value_increment >= 0) {
+          total_transformed_quality_value_increment +=
+              std::exp(quality_value_increment);
+        }
       }
-      //}
       cum_transformed_quality_value_increment_per_cluster[pair.second] =
           total_transformed_quality_value_increment;
       counter[pair.second] = 0;
-
-      /*quality_value_increment =
-          counter[pair.second] -
-          n_degree_wt * subcomm_degree_wt * constant_for_second_term;
-
-      if (quality_value_increment > max_quality_value_increment) {
-        best_cluster = subcomm;
-        max_quality_value_increment = quality_value_increment;
-      }*/
     }
 
-    //return best_cluster;
     /*
    * Determine the neighboring cluster to which the currently
    * selected node will be moved.

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -768,9 +768,8 @@ struct ClusteringImplementationBase {
         continue;
       }
 
-      [[maybe_unused]] double subcomm_node_wt = subcomm_info[subcomm].node_wt;
-      [[maybe_unused]] double subcomm_degree_wt =
-          subcomm_info[subcomm].degree_wt;
+      double subcomm_node_wt = subcomm_info[subcomm].node_wt;
+      double subcomm_degree_wt = subcomm_info[subcomm].degree_wt;
 
       // check if subcommunity is well connected
       if (double tmp = resolution * subcomm_node_wt *

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -686,9 +686,8 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static uint64_t GetRandomSubcommunity(
       const Graph& graph, GNode n, CommunityArray& subcomm_info,
-      uint64_t total_node_wt, [[maybe_unused]] uint64_t total_degree_wt,
-      uint64_t comm_id, double constant_for_second_term, double resolution,
-      [[maybe_unused]] double randomness) {
+      uint64_t total_node_wt, uint64_t comm_id, double constant_for_second_term,
+      double resolution) {
     auto& n_current_subcomm_id =
         graph.template GetData<CurrentSubCommunityID>(n);
     /*
@@ -861,9 +860,9 @@ struct ClusteringImplementationBase {
   template <typename EdgeWeightType>
   static void MergeNodesSubset(
       Graph* graph, std::vector<GNode>& cluster_nodes, uint64_t comm_id,
-      uint64_t total_node_wt, uint64_t total_degree_wt,
+      uint64_t total_node_wt, [[maybe_unused]] uint64_t total_degree_wt,
       CommunityArray& subcomm_info, double constant_for_second_term,
-      double resolution, double randomness) {
+      double resolution, [[maybe_unused]] double randomness) {
     // select set R
     std::vector<GNode> cluster_nodes_to_move;
     for (uint64_t i = 0; i < cluster_nodes.size(); ++i) {
@@ -929,8 +928,8 @@ struct ClusteringImplementationBase {
      */
       if (subcomm_info[n_current_subcomm_id].size == 1) {
         uint64_t new_subcomm_ass = GetRandomSubcommunity<EdgeWeightType>(
-            *graph, n, subcomm_info, total_node_wt, total_degree_wt, comm_id,
-            constant_for_second_term, resolution, randomness);
+            *graph, n, subcomm_info, total_node_wt, comm_id,
+            constant_for_second_term, resolution);
         if (new_subcomm_ass != UNASSIGNED &&
             new_subcomm_ass != n_current_subcomm_id) {
           n_current_subcomm_id = new_subcomm_ass;

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -898,7 +898,6 @@ struct ClusteringImplementationBase {
      * - clusterWeights[j]) * resolution
      */
 
-      //seems like the source code is not doing this
       if (double tmp = resolution * static_cast<double>(node_wt) *
                        static_cast<double>(total_node_wt - node_wt);
           num_edges_within_cluster >= tmp) {

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -85,7 +85,7 @@ struct LeidenClusteringImplementation
         Base::template CalConstantForSecondTerm<EdgeWeightType>(graph);
 
     katana::gPrint("\n constant_for_second_term : ", constant_for_second_term);
-    if (iter > 1) {
+    if (iter >= 1) {
       katana::do_all(katana::iterate(graph), [&](GNode n) {
         c_info[n].size = 0;
         c_info[n].degree_wt = 0;
@@ -232,7 +232,7 @@ struct LeidenClusteringImplementation
 
     katana::gPrint("\n constant_for_second_term : ", constant_for_second_term);
 
-    if (iter > 1) {
+    if (iter >= 1) {
       katana::do_all(katana::iterate(graph), [&](GNode n) {
         c_info[n].size = 0;
         c_info[n].degree_wt = 0;
@@ -318,8 +318,10 @@ struct LeidenClusteringImplementation
                     cluster_local_map, counter, self_loop_wt, c_info,
                     n_data_node_wt, n_data_curr_comm_id,
                     constant_for_second_term);
+
               } else {
                 local_target[n] = Base::UNASSIGNED;
+                katana::gPrint("\n unassigned");
               }
 
               /* Update cluster info */
@@ -600,8 +602,8 @@ public:
        */
         Graph graph_curr_tmp = KATANA_CHECKED(Graph::Make(pg_curr.get()));
         katana::do_all(katana::iterate(graph_curr_tmp), [&](GNode n) {
-          graph_curr_tmp.template GetData<CurrentCommunityID>(n) =
-              original_comm_ass[n];
+          graph_curr_tmp.template GetData<CurrentCommunityID>(n) = n;
+          //   original_comm_ass[n];
           graph_curr_tmp.template GetData<NodeWeight>(n) = cluster_node_wt[n];
         });
 
@@ -612,6 +614,11 @@ public:
         cluster_node_wt.destroy();
 
       } else {
+        katana::do_all(katana::iterate(graph_curr), [&](GNode n) {
+          clusters_orig[n] =
+              graph_curr.template GetData<CurrentCommunityID>(clusters_orig[n]);
+        });
+
         break;
       }
     }

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -528,7 +528,7 @@ public:
           Base::template RenumberClustersContiguously<CurrentCommunityID>(
               &graph_curr);
       Base::template RefinePartition<EdgeWeightType>(
-          &graph_curr, plan.resolution(), plan.randomness());
+          &graph_curr, plan.resolution());
       uint64_t num_unique_subclusters =
           Base::template RenumberClustersContiguously<CurrentSubCommunityID>(
               &graph_curr);

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -131,10 +131,6 @@ struct LeidenClusteringImplementation
               Base::template FindNeighboringClusters<EdgeWeightType>(
                   graph, n, cluster_local_map, counter, self_loop_wt);
               // Find the max gain in modularity
-              //local_target = Base::MaxCPMQualityWithoutSwaps(
-              //  cluster_local_map, counter, self_loop_wt, c_info,
-              //n_data_node_wt, n_data_curr_comm_id, resolution);
-
               local_target = Base::MaxModularityWithoutSwaps(
                   cluster_local_map, counter, self_loop_wt, c_info,
                   n_data_node_wt, n_data_curr_comm_id,
@@ -165,9 +161,6 @@ struct LeidenClusteringImplementation
       /* Calculate the overall modularity */
       double e_xx = 0;
       double a2_x = 0;
-
-      //curr_mod = Base::template CalCPMQuality<EdgeWeightType>(
-      //  graph, c_info, e_xx, a2_x, constant_for_second_term, resolution);
 
       curr_mod = Base::template CalModularity<EdgeWeightType>(
           graph, c_info, e_xx, a2_x, constant_for_second_term);
@@ -387,9 +380,6 @@ struct LeidenClusteringImplementation
       /* Calculate the overall modularity */
       double e_xx = 0;
       double a2_x = 0;
-
-      //curr_mod = Base::template CalCPMQuality<EdgeWeightType>(
-      //  graph, c_info, e_xx, a2_x, constant_for_second_term, resolution);
 
       curr_mod = Base::template CalModularity<EdgeWeightType>(
           graph, c_info, e_xx, a2_x, constant_for_second_term);

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -528,10 +528,6 @@ public:
         break;
       }
 
-      katana::gPrint("\n prev: ", prev_mod);
-      katana::gPrint("\n curr: ", curr_mod);
-
-      katana::gPrint("\n curr: ", curr_mod);
       [[maybe_unused]] uint64_t num_unique_clusters =
           Base::template RenumberClustersContiguously<CurrentCommunityID>(
               &graph_curr);

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -235,6 +235,8 @@ struct LeidenClusteringImplementation
         auto& n_data_degree_wt =
             graph.template GetData<DegreeWeight<EdgeWeightType>>(n);
         auto& n_data_node_wt = graph.template GetData<NodeWeight>(n);
+        katana::gPrint("\n id: ", n_data_curr_comm_id);
+        katana::gPrint("\n id: ", n_data_curr_comm_id);
         katana::atomicAdd(c_info[n_data_curr_comm_id].size, uint64_t{1});
         katana::atomicAdd(c_info[n_data_curr_comm_id].node_wt, n_data_node_wt);
         katana::atomicAdd(
@@ -310,7 +312,7 @@ struct LeidenClusteringImplementation
                     constant_for_second_term);
 
               } else {
-                local_target[n] = Base::UNASSIGNED;
+                local_target[n] = 0;
               }
 
               /* Update cluster info */
@@ -561,7 +563,7 @@ public:
               graph_curr.template GetData<CurrentCommunityID>(n);
           auto& n_node_wt = graph_curr.template GetData<NodeWeight>(n);
           if (n_curr_comm == Base::UNASSIGNED) {
-            original_comm_ass[n_curr_sub_comm] = n;
+            original_comm_ass[n_curr_sub_comm] = n_curr_comm;
           } else {
             original_comm_ass[n_curr_sub_comm] = n_curr_comm;
           }

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -602,8 +602,8 @@ public:
        */
         Graph graph_curr_tmp = KATANA_CHECKED(Graph::Make(pg_curr.get()));
         katana::do_all(katana::iterate(graph_curr_tmp), [&](GNode n) {
-          graph_curr_tmp.template GetData<CurrentCommunityID>(n) = n;
-          //   original_comm_ass[n];
+          graph_curr_tmp.template GetData<CurrentCommunityID>(n) =
+              original_comm_ass[n];
           graph_curr_tmp.template GetData<NodeWeight>(n) = cluster_node_wt[n];
         });
 

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -230,8 +230,6 @@ struct LeidenClusteringImplementation
     constant_for_second_term =
         Base::template CalConstantForSecondTerm<EdgeWeightType>(graph);
 
-    katana::gPrint("\n constant_for_second_term : ", constant_for_second_term);
-
     if (iter >= 1) {
       katana::do_all(katana::iterate(graph), [&](GNode n) {
         c_info[n].size = 0;

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -54,7 +54,7 @@ struct LeidenClusteringImplementation
   katana::Result<double> LeidenWithoutLockingDoAll(
       katana::PropertyGraph* pg, double lower,
       double modularity_threshold_per_round, uint32_t& iter,
-      double resolution) {
+      [[maybe_unused]] double resolution) {
     katana::StatTimer TimerClusteringTotal("Timer_Clustering_Total");
     TimerClusteringTotal.start();
 
@@ -84,6 +84,7 @@ struct LeidenClusteringImplementation
     constant_for_second_term =
         Base::template CalConstantForSecondTerm<EdgeWeightType>(graph);
 
+    katana::gPrint("\n constant_for_second_term : ", constant_for_second_term);
     if (iter > 1) {
       katana::do_all(katana::iterate(graph), [&](GNode n) {
         c_info[n].size = 0;
@@ -131,10 +132,14 @@ struct LeidenClusteringImplementation
               Base::template FindNeighboringClusters<EdgeWeightType>(
                   graph, n, cluster_local_map, counter, self_loop_wt);
               // Find the max gain in modularity
-              local_target = Base::MaxCPMQualityWithoutSwaps(
-                  cluster_local_map, counter, self_loop_wt, c_info,
-                  n_data_node_wt, n_data_curr_comm_id, resolution);
+              //local_target = Base::MaxCPMQualityWithoutSwaps(
+              //  cluster_local_map, counter, self_loop_wt, c_info,
+              //n_data_node_wt, n_data_curr_comm_id, resolution);
 
+              local_target = Base::MaxModularityWithoutSwaps(
+                  cluster_local_map, counter, self_loop_wt, c_info,
+                  n_data_node_wt, n_data_curr_comm_id,
+                  constant_for_second_term);
             } else {
               local_target = Base::UNASSIGNED;
             }
@@ -162,8 +167,11 @@ struct LeidenClusteringImplementation
       double e_xx = 0;
       double a2_x = 0;
 
-      curr_mod = Base::template CalCPMQuality<EdgeWeightType>(
-          graph, c_info, e_xx, a2_x, constant_for_second_term, resolution);
+      //curr_mod = Base::template CalCPMQuality<EdgeWeightType>(
+      //  graph, c_info, e_xx, a2_x, constant_for_second_term, resolution);
+
+      curr_mod = Base::template CalModularity<EdgeWeightType>(
+          graph, c_info, e_xx, a2_x, constant_for_second_term);
 
       if ((curr_mod - prev_mod) < modularity_threshold_per_round) {
         prev_mod = curr_mod;
@@ -190,7 +198,7 @@ struct LeidenClusteringImplementation
   katana::Result<double> LeidenDeterministic(
       katana::PropertyGraph* pg, double lower,
       double modularity_threshold_per_round, uint32_t& iter,
-      double resolution) {
+      [[maybe_unused]] double resolution) {
     katana::StatTimer TimerClusteringTotal("Timer_Clustering_Total");
     katana::TimerGuard TimerClusteringGuard(TimerClusteringTotal);
 
@@ -221,6 +229,8 @@ struct LeidenClusteringImplementation
     /* Compute the total weight (2m) and 1/2m terms */
     constant_for_second_term =
         Base::template CalConstantForSecondTerm<EdgeWeightType>(graph);
+
+    katana::gPrint("\n constant_for_second_term : ", constant_for_second_term);
 
     if (iter > 1) {
       katana::do_all(katana::iterate(graph), [&](GNode n) {
@@ -300,12 +310,16 @@ struct LeidenClusteringImplementation
                 Base::template FindNeighboringClusters<EdgeWeightType>(
                     graph, n, cluster_local_map, counter, self_loop_wt);
                 // Find the max gain in modularity
-                local_target[n] = Base::MaxCPMQualityWithoutSwaps(
-                    cluster_local_map, counter, self_loop_wt, c_info,
-                    n_data_node_wt, n_data_curr_comm_id, resolution);
+                //     local_target[n] = Base::MaxCPMQualityWithoutSwaps(
+                //       cluster_local_map, counter, self_loop_wt, c_info,
+                //     n_data_node_wt, n_data_curr_comm_id, resolution);
 
+                local_target[n] = Base::MaxModularityWithoutSwaps(
+                    cluster_local_map, counter, self_loop_wt, c_info,
+                    n_data_node_wt, n_data_curr_comm_id,
+                    constant_for_second_term);
               } else {
-                local_target[n] = 0;  //Base::UNASSIGNED;
+                local_target[n] = Base::UNASSIGNED;
               }
 
               /* Update cluster info */
@@ -376,8 +390,11 @@ struct LeidenClusteringImplementation
       double e_xx = 0;
       double a2_x = 0;
 
-      curr_mod = Base::template CalCPMQuality<EdgeWeightType>(
-          graph, c_info, e_xx, a2_x, constant_for_second_term, resolution);
+      //curr_mod = Base::template CalCPMQuality<EdgeWeightType>(
+      //  graph, c_info, e_xx, a2_x, constant_for_second_term, resolution);
+
+      curr_mod = Base::template CalModularity<EdgeWeightType>(
+          graph, c_info, e_xx, a2_x, constant_for_second_term);
 
       if ((curr_mod - prev_mod) < modularity_threshold_per_round) {
         prev_mod = curr_mod;
@@ -483,6 +500,7 @@ public:
           graph_curr.template GetData<CurrentCommunityID>(n) = n;
           graph_curr.template GetData<PreviousCommunityID>(n) = n;
           clusters_orig[n] = n;
+          graph_curr.template GetData<NodeWeight>(n) = 1;
         });
       }
       if (graph_curr.num_nodes() > plan.min_graph_size()) {
@@ -508,6 +526,10 @@ public:
         break;
       }
 
+      katana::gPrint("\n prev: ", prev_mod);
+      katana::gPrint("\n curr: ", curr_mod);
+
+      katana::gPrint("\n curr: ", curr_mod);
       [[maybe_unused]] uint64_t num_unique_clusters =
           Base::template RenumberClustersContiguously<CurrentCommunityID>(
               &graph_curr);
@@ -539,7 +561,7 @@ public:
         }
 
         katana::NUMAArray<uint64_t> original_comm_ass;
-        katana::NUMAArray<uint64_t> cluster_node_wt;
+        katana::NUMAArray<std::atomic<uint64_t>> cluster_node_wt;
 
         original_comm_ass.allocateBlocked(num_unique_subclusters + 1);
         cluster_node_wt.allocateBlocked(num_unique_subclusters + 1);
@@ -554,12 +576,12 @@ public:
           auto& n_curr_comm =
               graph_curr.template GetData<CurrentCommunityID>(n);
           auto& n_node_wt = graph_curr.template GetData<NodeWeight>(n);
-          if (n_curr_comm != Base::UNASSIGNED) {
+          if (n_curr_comm == Base::UNASSIGNED) {
             original_comm_ass[n_curr_sub_comm] = n;
           } else {
             original_comm_ass[n_curr_sub_comm] = n_curr_comm;
           }
-          cluster_node_wt[n_curr_sub_comm] = n_node_wt;
+          katana::atomicAdd(cluster_node_wt[n_curr_sub_comm], n_node_wt);
         });
 
         auto coarsened_graph_result = Base::template GraphCoarsening<

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -321,7 +321,6 @@ struct LeidenClusteringImplementation
 
               } else {
                 local_target[n] = Base::UNASSIGNED;
-                katana::gPrint("\n unassigned");
               }
 
               /* Update cluster info */

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -84,7 +84,6 @@ struct LeidenClusteringImplementation
     constant_for_second_term =
         Base::template CalConstantForSecondTerm<EdgeWeightType>(graph);
 
-    katana::gPrint("\n constant_for_second_term : ", constant_for_second_term);
     if (iter >= 1) {
       katana::do_all(katana::iterate(graph), [&](GNode n) {
         c_info[n].size = 0;


### PR DESCRIPTION
This PR makes the following fix to our shared-memory leiden application:
1. Ensure that modularity is not decreasing suddenly in successive iterations (previously for the Intel input, it dropped from 0.70 to 0.30).
2. Ensure that less number of communities are formed (reduced from 79 to 39).