### PR TITLE
tsuba: Parallelize CopyRDG

### DIFF
--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(tsuba PUBLIC
 )
 set_common_katana_library_options(tsuba ALWAYS_SHARED)
 
-target_link_libraries(tsuba PUBLIC katana_support)
+target_link_libraries(tsuba PUBLIC katana_galois katana_support)
 
 if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
   add_subdirectory(test)

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -273,26 +273,26 @@ katana::Result<void>
 tsuba::CopyRDG(std::vector<std::pair<katana::Uri, katana::Uri>> src_dst_files) {
   katana::DynamicBitset manifest_uri_idxs;
   katana::do_all(
-    katana::iterate(size_t{0}, src_dst_files.size()),
-        [&](size_t i) {
-      auto [src_file_uri, dst_file_uri] = src_dst_files[i];
-      // We save the names of all the manifest files and we write them out at the end.
-      if (tsuba::RDGManifest::IsManifestUri(src_file_uri)) {
-        manifest_uri_idxs.set(i);
-        return;
-      }
-      // NB: can't use KATANA_CHECKED here because of the do_all, so we keep track of the 
-      // error for now and then return it later
-      tsuba::FileView fv;
-      auto fv_res = fv.Bind(src_file_uri.string(), true);
-      if (!fv_res) {
-        KATANA_LOG_FATAL("Failed to bind {}", src_file_uri.string());
-      }
-      auto fs_res = tsuba::FileStore(dst_file_uri.string(), fv.ptr<char>(), fv.size());
-      if (!fs_res) {
-        KATANA_LOG_FATAL("Failed to store to {}", dst_file_uri.string());
-      }
-    });
+      katana::iterate(size_t{0}, src_dst_files.size()), [&](size_t i) {
+        auto [src_file_uri, dst_file_uri] = src_dst_files[i];
+        // We save the names of all the manifest files and we write them out at the end.
+        if (tsuba::RDGManifest::IsManifestUri(src_file_uri)) {
+          manifest_uri_idxs.set(i);
+          return;
+        }
+        // NB: can't use KATANA_CHECKED here because of the do_all, so we keep track of the
+        // error for now and then return it later
+        tsuba::FileView fv;
+        auto fv_res = fv.Bind(src_file_uri.string(), true);
+        if (!fv_res) {
+          KATANA_LOG_FATAL("Failed to bind {}", src_file_uri.string());
+        }
+        auto fs_res =
+            tsuba::FileStore(dst_file_uri.string(), fv.ptr<char>(), fv.size());
+        if (!fs_res) {
+          KATANA_LOG_FATAL("Failed to store to {}", dst_file_uri.string());
+        }
+      });
 
   // Process all the manifest files, write them out.
   // We want to write this last so that we know whether a write fully finished or not.


### PR DESCRIPTION
This PR adds a `do_all` loop to parallelize the CopyRDG operation in tsuba. The code previously made all the copies serially, so this is a minor optimization in issuing the copy requests in parallel. 

JIRA: https://katanagraph.atlassian.net/browse/KAT-1558