### PR TITLE
DynamicBitset: adds a serial count function for use in parallel regions

### DIFF
--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -309,11 +309,20 @@ public:
   void bitwise_xor(const DynamicBitset& other1, const DynamicBitset& other2);
 
   /**
-   * Count how many bits are set in the bitset
+   * Count how many bits are set in the bitset. Do not call in a parallel
+   * region as it uses a parallel loop.
    *
    * @returns number of set bits in the bitset
    */
   size_t count() const;
+
+  /***
+   * Count number of set bits in the bitset serially. Useful if
+   * you need to count different bitsets on different threads.
+   *
+   * @returns number of set bits in the bitset
+   */
+  size_t SerialCount() const;
 
   /**
    * Returns a vector containing the set bits in this bitset in order

--- a/libgalois/src/DynamicBitset.cpp
+++ b/libgalois/src/DynamicBitset.cpp
@@ -108,6 +108,21 @@ katana::DynamicBitset::count() const {
   return ret.reduce();
 }
 
+size_t
+katana::DynamicBitset::SerialCount() const {
+  size_t ret = 0;
+  for (uint64_t n : bitvec_) {
+#ifdef __GNUC__
+    ret += __builtin_popcountll(n);
+#else
+    n = n - ((n >> 1) & 0x5555555555555555UL);
+    n = (n & 0x3333333333333333UL) + ((n >> 2) & 0x3333333333333333UL);
+    ret += (((n + (n >> 4)) & 0xF0F0F0F0F0F0F0FUL) * 0x101010101010101UL) >> 56;
+#endif
+  }
+  return ret;
+}
+
 namespace {
 template <typename Integer>
 void


### PR DESCRIPTION
DynamicBitset's count function cannot be called in a serial region as it
uses do_all. This commit adds a serial version of the count function so
that users can count the number of set bits in the different bitsets
in parallel.