### PR TITLE
upgrade the nlohmann_json from 3.7.3 to 3.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ At the minimum, Katana depends on the following software:
 - libxml2 (>=  2.9.1)
 - libarrow (>= 4.0)
 - libuuid (>= 2.31.1)
-- [nlohmann/json](https://github.com/nlohmann/json) (>= 3.7.3)
+- [nlohmann/json](https://github.com/nlohmann/json) (>= 3.10.4)
 
 Here are the dependencies for the optional features:
 

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -50,7 +50,7 @@ dependencies:
  - nbsphinx>=0.8
  - ncurses>=6.1,<7a0
  - ninja>=1.10
- - nlohmann_json>=3.7.3,<4a0
+ - nlohmann_json>=3.10.4,<4a0
  - numba>=0.53.1,<0.54a0
  - numpy>=1.17,<2a0
  - openblas>=0.3.12

--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -265,7 +265,7 @@ ninja:
   labels:
     - conda
 nlohmann_json:
-  version: [ 3.7.3, 4 ]
+  version: [ 3.10.4, 4 ]
   labels:
     - conda
     - conan

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -48,7 +48,7 @@ set_common_katana_library_options(katana_support ALWAYS_SHARED)
 target_link_libraries(katana_support PUBLIC arrow::arrow arrow::parquet)
 
 
-find_package(nlohmann_json 3.7.3 REQUIRED)
+find_package(nlohmann_json 3.10.4 REQUIRED)
 target_link_libraries(katana_support PUBLIC nlohmann_json::nlohmann_json)
 
 find_package(libcurl QUIET)


### PR DESCRIPTION
to avoid variable conflict btw antlr-runtime 4.9.3 and nlohmann_json
due to underspecified EOF without namespace

After switching to the 4.9.3 runtime, encounter this conflict with our json parser.  
details below:
https://github.com/KatanaGraph/katana-enterprise/pull/2681#issuecomment-996016030

```
/root/.conan/data/nlohmann_json/3.7.3/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/nlohmann/detail/input/binary_reader.hpp:17:
2021-12-16T16:53:42.4746873Z [1m/root/.conan/data/nlohmann_json/3.7.3/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/nlohmann/detail/input/input_adapters.hpp:117:20: [0m[0;1;31merror: [0m[1muse of undeclared identifier 'EOF'; did you mean 'XPathLexer::EOF'?[0m
2021-12-16T16:53:42.4754024Z         if (res == EOF)
2021-12-16T16:53:42.4760480Z [0;1;32m                   ^
2021-12-16T16:53:42.4768646Z [0m[1m/root/.conan/data/antlr4-cppruntime/4.9.3/_/_/package/ed4c50cce248f963b530d644f4c27bd3c33aa7ed/include/antlr4-runtime/Recognizer.h:16:29: [0m[0;1;30mnote: [0m'XPathLexer::EOF' declared here[0m
2021-12-16T16:53:42.4775961Z     static constexpr size_t EOF = std::numeric_limits<size_t>::max();
2021-12-16T16:53:42.4782322Z [0;1;32m                            ^
2021-12-16T16:53:42.4787849Z [0m1 error generated.
2021-12-16T16:53:42.4817761Z make[2]: *** [libquery/test/CMakeFiles/antlr-parser-test.dir/build.make:76: libquery/test/CMakeFiles/antlr-parser-test.dir/antlr-test.cpp.o] Error 1
2021-12-16T16:53:42.4829423Z make[1]: *** [CMakeFiles/Makefile2:8418: libquery/test/CMakeFiles/antlr-parser-test.dir/all] Error 2
```

https://github.com/nlohmann/json/blob/v3.7.3/include/nlohmann/detail/input/input_adapters.hpp#L117

Looks like it is fixed in latest(3.10.4) json parser:
https://github.com/nlohmann/json/blob/v3.10.4/include/nlohmann/detail/input/input_adapters.hpp#L112