### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # no tool generated files
 .clang-complete
 .clangd
+.cache
 compile_commands.json
 cscope.out
 /GPATH


### PR DESCRIPTION
clangd-12 changed the directory structure of its index files - they are
now stored in ${REPO_ROOT}/.cache/clangd/index instead of
${REPO_ROOT}/.clangd