### PR TITLE
python: Added URL class

### DIFF
--- a/python/katana/url.py
+++ b/python/katana/url.py
@@ -8,15 +8,11 @@ class URL:
     the class in the following ways:
 
     - URL("file:///home/") / "a" / "b" => URL("file:///home/a/b")
-    - URL("file:///home/", "a", "b") => URL("file:///home/a/b")
     - "file:///home/" / URL("a") => URL("file:///home/a")
     """
 
-    def __init__(self, *args):
-        if len(args) > 1:
-            self.url = self._join_path(args[0], *args[1:])
-        else:
-            self.url = args[0]
+    def __init__(self, url: str):
+        self.url = url
 
     def __truediv__(self, other):
         return URL(self._join_path(self.url, other))

--- a/python/katana/url.py
+++ b/python/katana/url.py
@@ -1,0 +1,61 @@
+from urllib import parse
+
+
+class URL:
+    """
+    URL class that maintains semantics similar to pathlib. This class does not
+    intend to act as a universal class for all path related things! Users can use
+    the class in the following ways:
+
+    - URL("file:///home/") / "a" / "b" => URL("file:///home/a/b")
+    - URL("file:///home/", "a", "b") => URL("file:///home/a/b")
+    - "file:///home/" / URL("a") => URL("file:///home/a")
+    """
+
+    def __init__(self, *args):
+        if len(args) > 1:
+            self.url = self._join_path(args[0], *args[1:])
+        else:
+            self.url = args[0]
+
+    def __truediv__(self, other):
+        return URL(self._join_path(self.url, other))
+
+    def __rtruediv__(self, other):
+        return URL(self._join_path(other, self.url))
+
+    def __str__(self):
+        return self.url
+
+    def __eq__(self, other):
+        return self.url == other.url
+
+    @staticmethod
+    def _join_path(url: str, *args) -> str:
+        """
+        _join_path joins a URL with some number of path components.
+
+        In the returned URL, the path will be the path of the input URL joined with
+        the additional path components. Each component will be separated by a "/".
+        If the input URL already ends with a "/", no additional "/" will be added
+        before the first path addition.
+
+        All non-path components will be taken from the input URL.
+
+        Examples:
+
+        - _join_path("file:///home/", "a", "b") => "file:///home/a/b"
+        - _join_path("file:///home?query=string", "a") => "file:///home/a?query=string"
+        - _join_path("file:///home", "a") == join_path("file:///home/", "a")
+        - _join_path("file:///home/") => "file:///home/"
+        """
+        if len(args) == 0:
+            return url
+
+        u = parse.urlparse(url)
+        path = u.path
+        if u.path.endswith("/"):
+            path = u.path[:-1]
+        paths = [path, *args]
+        u = u._replace(path="/".join(paths))
+        return u.geturl()

--- a/python/test/test_url.py
+++ b/python/test/test_url.py
@@ -1,0 +1,22 @@
+from katana import url
+
+
+def test_url_join_path():
+    assert url.URL._join_path("file:///home/", "a", "b") == "file:///home/a/b"
+    assert url.URL._join_path("file:///home?query=string", "a") == "file:///home/a?query=string"
+    assert url.URL._join_path("file:///home", "a") == "file:///home/a"
+    assert url.URL._join_path("file:///home/", "a") == "file:///home/a"
+    assert url.URL._join_path("file:///home/", "a/") == "file:///home/a/"
+    assert url.URL._join_path("file:///home/") == "file:///home/"
+
+
+def test_url_div_op():
+    assert str(url.URL("file:///home/") / "a" / "b") == "file:///home/a/b"
+    assert str(url.URL("file:///home/") / "a/b") == "file:///home/a/b"
+    assert str(url.URL("file:///home/", "a", "b")) == "file:///home/a/b"
+    assert str(url.URL("file:///home?query=string") / "a") == "file:///home/a?query=string"
+    assert url.URL("file:///home") / "a" == url.URL("file:///home/a")
+    assert url.URL("file:///home/") / "a" == url.URL("file:///home/a")
+    assert str("file:///home/" / url.URL("a/")) == "file:///home/a/"
+    assert str(url.URL("file:///home/")) == "file:///home/"
+    assert str(url.URL("a") / "b.txt") == "a/b.txt"

--- a/python/test/test_url.py
+++ b/python/test/test_url.py
@@ -13,7 +13,6 @@ def test_url_join_path():
 def test_url_div_op():
     assert str(url.URL("file:///home/") / "a" / "b") == "file:///home/a/b"
     assert str(url.URL("file:///home/") / "a/b") == "file:///home/a/b"
-    assert str(url.URL("file:///home/", "a", "b")) == "file:///home/a/b"
     assert str(url.URL("file:///home?query=string") / "a") == "file:///home/a?query=string"
     assert url.URL("file:///home") / "a" == url.URL("file:///home/a")
     assert url.URL("file:///home/") / "a" == url.URL("file:///home/a")


### PR DESCRIPTION
This PR adds a URL class that maintains `pathlib`-like semantics to manage paths and such. 