### PR TITLE
entity manager: relax equality check

### DIFF
--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -494,11 +494,13 @@ katana::PropertyGraph::Equals(const PropertyGraph* other) const {
     return false;
   }
 
-  if (!node_entity_type_manager_.Equals(other->node_entity_type_manager())) {
+  if (!node_entity_type_manager_.IsIsomorphicTo(
+          other->node_entity_type_manager())) {
     return false;
   }
 
-  if (!edge_entity_type_manager_.Equals(other->edge_entity_type_manager())) {
+  if (!edge_entity_type_manager_.IsIsomorphicTo(
+          other->edge_entity_type_manager())) {
     return false;
   }
 

--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -17,10 +17,27 @@
 
 namespace katana {
 
-/// EntityTypeID uniquely identifies an entity (node or edge) type
-/// EntityTypeID for nodes is distinct from EntityTypeID for edges
-/// This type may either be an atomic type or an intersection of atomic types
-/// EntityTypeID is represented using 8 bits
+/// EntityTypeID uniquely identifies an entity (node or edge) type, which is
+/// a set of user-defined strings.
+/// Types may either be an atomic type or an intersection of atomic types,
+/// where an atomic type is a unique user-defined string and
+/// an intersection of atomic types is a set of corresponding user-defined strings.
+/// The EntityTypeID space for nodes is distinct from EntityTypeID for edges.
+///
+/// Types are sets of strings; all other representations are optimizations.  Clients
+/// should never compare EntityTypeIDs across different managers.  Only comparison of
+/// the string representations are valid.
+///
+/// The type manager should guarantee that two entity type ids never map to the same
+/// set of strings, but the current implementation does not guarantee it for
+/// performance reasons.
+/// The GetOrAdd* functions only add a type if it isn't already present.
+/// There are two Add* functions: AddAtomicEntityType and AddNonAtomicEntityType.
+/// AddAtomicEntityType returns an error if the type is already present.
+/// AddNonAtomicEntityType has a debug assert but does not return an error if the type
+/// is already present because that check is too costly.
+///
+/// EntityTypeID is represented using 16 bits
 using EntityTypeID = uint16_t;
 static constexpr EntityTypeID kUnknownEntityType = EntityTypeID{0};
 static constexpr EntityTypeID kInvalidEntityType =
@@ -239,6 +256,8 @@ public:
   }
 
   /// Get the intersection of the types named in \p names
+  /// Note that AtomicEntityTypeIds map to their "NonAtomic" identity set
+  /// so this function will return EntityTypeIDs for atomic types.
   ///
   /// \returns the EntityTypeID of the intersection type.
   template <typename Container>
@@ -459,7 +478,7 @@ public:
   static size_t CalculateSetOfEntityTypeIDsSize(EntityTypeID max_id);
 
   /// bool Equals() IS A TESTING ONLY FUNCTION, DO NOT EXPOSE THIS TO THE USER
-  bool Equals(const EntityTypeManager& other) const;
+  bool IsIsomorphicTo(const EntityTypeManager& other) const;
 
   /// std::string ReportDiff() IS A TESTING ONLY FUNCTION, DO NOT EXPOSE THIS TO THE USER
   std::string ReportDiff(const EntityTypeManager& other) const;

--- a/libsupport/test/type-manager.cpp
+++ b/libsupport/test/type-manager.cpp
@@ -61,7 +61,7 @@ ValidateConstructor() {
 
   katana::EntityTypeManager mgr_copy(std::move(name_map), std::move(id_map));
 
-  if (!mgr.Equals(mgr_copy)) {
+  if (!mgr.IsIsomorphicTo(mgr_copy)) {
     KATANA_LOG_WARN("{}", mgr.ReportDiff(mgr_copy));
     KATANA_LOG_ASSERT(false);
   }

--- a/libtsuba/test/storage-format-version/v3-uint16-entity-type-ids.cpp
+++ b/libtsuba/test/storage-format-version/v3-uint16-entity-type-ids.cpp
@@ -56,11 +56,11 @@ TestEntityTypeManagerRoundTrip(const std::string& rdg_name) {
       KATANA_CHECKED(rdg_converted.node_entity_type_manager());
 
   KATANA_LOG_VASSERT(
-      edge_manager_orig.Equals(edge_manager_converted),
+      edge_manager_orig.IsIsomorphicTo(edge_manager_converted),
       "original edge EntityTypeManager does not match the stored converted "
       "edge EntityTypeManager");
   KATANA_LOG_VASSERT(
-      node_manager_orig.Equals(node_manager_converted),
+      node_manager_orig.IsIsomorphicTo(node_manager_converted),
       "original node EntityTypeManager does not match the stored converted "
       "node EntityTypeManager");
 
@@ -194,11 +194,11 @@ TestMaxNumberEntityTypeIDs(const std::string& rdg_name) {
       std::numeric_limits<katana::EntityTypeID>::max());
 
   KATANA_LOG_VASSERT(
-      edge_manager_orig.Equals(edge_manager),
+      edge_manager_orig.IsIsomorphicTo(edge_manager),
       "original edge EntityTypeManager does not match the stored "
       "edge EntityTypeManager");
   KATANA_LOG_VASSERT(
-      node_manager_orig.Equals(node_manager),
+      node_manager_orig.IsIsomorphicTo(node_manager),
       "original node EntityTypeManager does not match the stored "
       "node EntityTypeManager");
 


### PR DESCRIPTION
Two entity type managers are "equal" if they manage the
same number of entities and the set of string representations of
these entities match.  This is a bit weaker than one might
expect.

This code is only used in testing.  I added to the documentation of the EntityTypeManager that the truth is the string representation.

@scober raises the following excellent question: Do we guarantee that two entity type ids never map to the same set of strings?  I think we need this property, but I don't grok the entity type manager and I don't know how we can provide this property or if it will be efficient.  Can anyone help?