### PR TITLE
[KAT-2899] Merge DynamicBitsetCUDA and DynamicBitset, allocating Unified Virtual Memory when in CUDA

### DIFF
--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -43,7 +43,11 @@ namespace katana {
  * Concurrent dynamically allocated bitset
  **/
 class KATANA_EXPORT DynamicBitset {
-  katana::PODVector<katana::CopyableAtomic<uint64_t>> bitvec_;
+public:  // types
+  using TItem = katana::CopyableAtomic<uint64_t>;
+
+private:  // variables
+  katana::PODVector<TItem> bitvec_;
   size_t num_bits_{0};
 
 public:

--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -67,6 +67,11 @@ public:
     return *this;
   }
 
+  void SetAllocator(
+      const HostAllocator<katana::CopyableAtomic<uint64_t>>& host_alloc) {
+    bitvec_.SetAllocator(host_alloc);
+  }
+
   /**
    * Returns the underlying bitset representation to the user
    *

--- a/libsupport/include/katana/HostAllocator.h
+++ b/libsupport/include/katana/HostAllocator.h
@@ -139,4 +139,9 @@ public:
   }
 };
 
+inline HostAllocator<char>
+GetSwappableAllocator() {
+  return HostAllocator<char>(GetSwappableHostHeap());
+}
+
 }  // namespace katana

--- a/libsupport/include/katana/PODVector.h
+++ b/libsupport/include/katana/PODVector.h
@@ -129,6 +129,11 @@ public:
 
   ~PODVector() { host_alloc_.Free(data_); }
 
+  void SetAllocator(const HostAllocator<_Tp>& host_alloc) {
+    KATANA_LOG_ASSERT(capacity_ == 0);
+    host_alloc_ = host_alloc;
+  }
+
   // iterators:
   iterator begin() { return iterator(&data_[0]); }
   const_iterator begin() const { return const_iterator(&data_[0]); }


### PR DESCRIPTION
Enterprise PR: https://github.com/KatanaGraph/katana-enterprise/pull/2802