### PR TITLE
scripts: make ifdefs consistent

### DIFF
--- a/libgalois/include/katana/AtomicHelpers.h
+++ b/libgalois/include/katana/AtomicHelpers.h
@@ -17,7 +17,8 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#pragma once
+#ifndef KATANA_LIBGALOIS_KATANA_ATOMICHELPERS_H_
+#define KATANA_LIBGALOIS_KATANA_ATOMICHELPERS_H_
 
 #include <atomic>
 #include <type_traits>
@@ -101,3 +102,5 @@ atomicSub(
 #endif
 
 }  // end namespace katana
+
+#endif

--- a/libgalois/include/katana/CopyableTuple.h
+++ b/libgalois/include/katana/CopyableTuple.h
@@ -22,7 +22,8 @@
  *
  * Contains copyable tuple classes whose elements are contiguous in memory
  */
-#pragma once
+#ifndef KATANA_LIBGALOIS_KATANA_COPYABLETUPLE_H_
+#define KATANA_LIBGALOIS_KATANA_COPYABLETUPLE_H_
 
 #include "katana/config.h"
 
@@ -81,3 +82,5 @@ struct TupleOfThree {
 };
 
 }  // namespace katana
+
+#endif

--- a/libgraph/include/katana/LC_CSR_CSC_Labeled_Graph.h
+++ b/libgraph/include/katana/LC_CSR_CSC_Labeled_Graph.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef KATANA_LIBGRAPH_KATANA_LCCSRCSCLABELEDGRAPH_H_
+#define KATANA_LIBGRAPH_KATANA_LCCSRCSCLABELEDGRAPH_H_
 
 #include "katana/LC_CSR_CSC_Graph.h"
 
@@ -629,3 +630,5 @@ private:
 };
 
 }  // namespace katana
+
+#endif

--- a/libsupport/include/katana/EntityTypeManager.h
+++ b/libsupport/include/katana/EntityTypeManager.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef KATANA_LIBSUPPORT_KATANA_ENTITYTYPEMANAGER_H_
+#define KATANA_LIBSUPPORT_KATANA_ENTITYTYPEMANAGER_H_
 
 #include <bitset>
 #include <cstddef>
@@ -564,3 +565,5 @@ struct KATANA_EXPORT fmt::formatter<katana::TypeNameSet>
     return format_to(ctx.out(), "{}", fmt::join(tns, ":"));
   }
 };
+
+#endif

--- a/libsupport/include/katana/HostAllocator.h
+++ b/libsupport/include/katana/HostAllocator.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef KATANA_LIBSUPPORT_KATANA_HOSTALLOCATOR_H_
+#define KATANA_LIBSUPPORT_KATANA_HOSTALLOCATOR_H_
 
 #include <cstddef>
 #include <cstdlib>
@@ -145,3 +146,5 @@ GetSwappableAllocator() {
 }
 
 }  // namespace katana
+
+#endif

--- a/libsupport/include/katana/OpaqueID.h
+++ b/libsupport/include/katana/OpaqueID.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef KATANA_LIBSUPPORT_KATANA_OPAQUEID_H_
+#define KATANA_LIBSUPPORT_KATANA_OPAQUEID_H_
 
 #include <cstdint>
 #include <iostream>
@@ -292,3 +293,5 @@ struct OpaqueIDLess : private std::less<opaque_id_value_type<T>> {
 };
 
 }  // namespace katana
+
+#endif


### PR DESCRIPTION
Maybe a pedantic point but it's better to be consistent:

This change extends our ifndef checking script to check and fix
`#pragma once` style headers

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>