### PR TITLE
Pin fmt to <8.1.

### DIFF
--- a/conda_recipe/conda_build_config.yaml
+++ b/conda_recipe/conda_build_config.yaml
@@ -23,7 +23,7 @@ pin_run_as_build:
     min_pin: x # This means that we accept OLDER versions of elfutils at runtime. This may not be correct.
     max_pin: x
   fmt:
-    max_pin: x
+    max_pin: x.x
   libcurl:
     max_pin: x
   libxml2:

--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -29,7 +29,7 @@ dependencies:
  - doxygen>=1.8
  - eigen>=3.3.7,<4a0
  - elfutils>=0.176
- - fmt>=6.2.1,<9a0
+ - fmt>=6.2.1,<8.1a0
  - gcc_linux-64>=9.3
  - gxx_linux-64>=9.3
  - isort>=5.9.3,<5.10a0

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -88,7 +88,6 @@ outputs:
       run:
         - boost-cpp
         - arrow-cpp
-        - fmt
         - nlohmann_json
         - libcurl
         - backward-cpp
@@ -132,6 +131,7 @@ outputs:
         - numpy {{ numpy }}
         - python {{ python }}
         - pandas {{ pandas }}
+        - fmt {{ fmt }}
       run:
         - {{ pin_subpackage('katana-cpp', exact=True) }}
         - numba
@@ -170,6 +170,7 @@ outputs:
         - {{ cdt('numactl-devel') }}
       host:
         - {{ pin_subpackage('katana-cpp', exact=True) }}
+        - fmt {{ fmt }}
       run:
         - {{ pin_subpackage('katana-cpp', exact=True) }}
         - llvm

--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -158,7 +158,10 @@ elfutils:
     - apt
   version: [ 0.176, null ]
 fmt:
-  version: [ 6.2.1, 9 ]
+  # 8.1 fixes a bug/misfeature which implicitly converted enum class values into ints for formatting.
+  # We rely on this all over.
+  # TODO(amp, https://katanagraph.atlassian.net/browse/KAT-3182): Allow more recent fmt once we eliminate reliance on the above implicit conversion.
+  version: [ 6.2.1, 8.1 ]
   labels:
     - conan
     - conda


### PR DESCRIPTION
8.1 fixes a bug/misfeature which implicitly converted enum class values into ints for formatting. We rely on this bad behavior all over the place.

See: KAT-3182