### PR TITLE
Docs: fix root privileges comment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,8 +82,11 @@ html_css_files = ["style.css"]
 autodoc_preserve_defaults = True
 autodoc_member_order = "groupwise"
 
-suppress_warning = []
+# the open documentation links to the enterprise documentation in some places
+# let those links be broken in the open-only documentation and don't complain
+suppress_warnings = ["ref.ref"]
 nitpick_ignore = []
+
 
 # Exclude drafts from external documentation
 if tags.has("external"):

--- a/docs/contributing/building.rst
+++ b/docs/contributing/building.rst
@@ -69,7 +69,7 @@ The ``conda env update`` line can be run later to update your environment. Deact
 
 .. warning::
 
-   Not all conda installation scripts are well-behaved. In particular, the default behavior of the ``cudatoolkit-dev`` package's post-installation script is to write a log to the hard-coded path ``/tmp/cuda-installer.log`` and not delete it. Once one user on a system has written this file all other users will fail to install the package because they won't be able to write the log file. The only known workaround is to manually delete the log file. It is best practice to delete your own log file immediately after you have updated your environment. If you are on a system where someone else has written the log file and you can't overwrite it please contact that user to delete it. You may also write to sudoers@katanagraph.com.
+   Not all conda installation scripts are well-behaved. In particular, the default behavior of the ``cudatoolkit-dev`` package's post-installation script is to write a log to the hard-coded path ``/tmp/cuda-installer.log`` and not delete it. Once one user on a system has written this file all other users will fail to install the package because they won't be able to write the log file. The only known workaround is to manually delete the log file. It is best practice to delete your own log file immediately after you have updated your environment. If you are on a system where someone else has written the log file and you can't overwrite it please contact that user to delete it. You may also contact a user with root privileges.
 
 .. code-block:: bash
 

--- a/docs/contributing/building.rst
+++ b/docs/contributing/building.rst
@@ -6,7 +6,7 @@ Building
 
 .. only:: internal
 
-   If you are building katana-enterprise make sure to also read the :doc:`enterprise build addenda <index>`.
+   If you are building katana-enterprise make sure to also read the :ref:`enterprise-building`.
 
 Setting up a Build
 ==================


### PR DESCRIPTION
The docs state that people can contact sudoers@katanagraph.com for
issues requiring root privileges. That is not true for all people
building this code. Reword as a more generic "users with root
privileges".