### PR TITLE
support: add a new id type for indexing (supports prefix sum)

### DIFF
--- a/libgalois/include/katana/ParallelSTL.h
+++ b/libgalois/include/katana/ParallelSTL.h
@@ -355,7 +355,7 @@ partial_sum(InputIt first, InputIt last, OutputIt d_first) {
           if (blockEnd > 0) {
             localSums[block] = *(d_first + blockEnd - 1);
           } else {
-            localSums[block] = 0;
+            localSums[block] = ValueType{0};
           }
         });
 
@@ -365,7 +365,7 @@ partial_sum(InputIt first, InputIt last, OutputIt d_first) {
     // set of indices
     // Not using std::exclusive_scan because apparently it doesn't work for
     // some compilers
-    ValueType runningSum = 0;
+    ValueType runningSum = ValueType{0};
     for (size_t i = 0; i < numBlocks; i++) {
       bulkPrefix[i] = runningSum;
       runningSum += localSums[i];

--- a/libsupport/include/katana/IndexID.h
+++ b/libsupport/include/katana/IndexID.h
@@ -1,0 +1,78 @@
+#ifndef KATANA_LIBSUPPORT_KATANA_INDEXID_H_
+#define KATANA_LIBSUPPORT_KATANA_INDEXID_H_
+
+#include "katana/OpaqueID.h"
+
+namespace katana {
+
+/// A numeric ID type suitable for indexing. IndexIDs support:
+///
+/// - Addition and subtraction of other IDs (the result of which is an ID)
+/// - Increment and decrement
+/// - Dereference
+///
+/// NB: IndexID is less safe in general than `OpaqueID` and `OpaqueLinearID`.
+///     Use those stricter variants whenever possible.
+template <typename _IDType, typename _Value>
+struct IndexID : public OpaqueIDOrderedWithValue<_IDType, _Value> {
+public:
+  using OpaqueIDOrderedWithValue<_IDType, _Value>::OpaqueIDOrderedWithValue;
+
+  // iterator traits
+  using difference_type = _IDType;
+  using value_type = _IDType;
+  using pointer = _IDType*;
+  using reference = _IDType&;
+  using iterator_category = std::random_access_iterator_tag;
+
+  // must provide a dereference to be an iterator
+  reference operator*() { return *static_cast<_IDType*>(this); }
+
+  _IDType& operator++() {
+    ++this->value_;
+    return *static_cast<_IDType*>(this);
+  }
+
+  _IDType& operator--() {
+    --this->value_;
+    return *static_cast<_IDType*>(this);
+  }
+
+  _IDType operator++(int) {
+    _IDType ret{*static_cast<_IDType*>(this)};
+    this->value_++;
+    return ret;
+  }
+
+  _IDType operator--(int) {
+    _IDType ret{*static_cast<_IDType*>(this)};
+    this->value_--;
+    return ret;
+  }
+
+  _IDType& operator+=(const _IDType& rhs) { return *this += rhs.value(); }
+
+  _IDType& operator+=(_Value val) {
+    this->value_ += val;
+    return *static_cast<_IDType*>(this);
+  }
+
+  _IDType& operator-=(const _IDType& rhs) { return *this -= rhs.value(); }
+
+  _IDType& operator-=(_Value val) {
+    this->value_ -= val;
+    return *static_cast<_IDType*>(this);
+  }
+
+  _IDType operator+(const _IDType& rhs) const { return *this + rhs.value(); }
+
+  _IDType operator+(_Value val) const { return _IDType(this->value() + val); }
+
+  _IDType operator-(const _IDType& rhs) const { return *this - rhs.value(); }
+
+  _IDType operator-(_Value val) const { return _IDType(this->value() - val); }
+};
+
+}  // namespace katana
+
+#endif


### PR DESCRIPTION
This is a coercion resistant wrapper for an index. They support index-y
things like being added together an subtracted, but their type keeps
you from using them in the wrong place.

The protections against misuse aren't as strong as the other Opaque
types. IndexIDs are mainly useful for cases when the keys are literally
indexes to something dense like an array, in these cases it's convenient
to do prefix sums over indexes (for instance) when assigning things in
blocks.

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>