### PR TITLE
Add parallel reading / writing for Sphinx [KAT-2621]

### DIFF
--- a/cmake/Modules/BuildCommon.cmake
+++ b/cmake/Modules/BuildCommon.cmake
@@ -463,6 +463,8 @@ function(add_katana_sphinx_target target_name)
   if (BUILD_DOCS STREQUAL "internal")
     set(sphinx_options "-W;${sphinx_options}")
   endif ()
+  # Enable parallel reading / writing, 4 workers gave optimal time reduction
+  set(sphinx_options "-j 4;${sphinx_options}")
 
   add_custom_target(
       ${target_name}_sphinx_docs

--- a/cmake/Modules/BuildCommon.cmake
+++ b/cmake/Modules/BuildCommon.cmake
@@ -63,6 +63,7 @@ set(KATANA_NUM_TEST_GPUS "" CACHE STRING "Number of test GPUs to use (on a singl
 set(KATANA_USE_LCI OFF CACHE BOOL "Use LCI network runtime instead of MPI")
 set(KATANA_NUM_TEST_THREADS "" CACHE STRING "Maximum number of threads to use when running tests (default: min(number of physical cores, 8))")
 set(KATANA_AUTO_CONAN OFF CACHE BOOL "Automatically call conan from cmake rather than manually (experimental)")
+set(KATANA_NUM_DOC_THREADS "" CACHE STRING "Maximum number of threads to use when reading / writing with Sphinx (default: min(number of physical cores, 4))")
 
 ###### Configure (users don't need to go beyond here) ######
 
@@ -83,6 +84,18 @@ if (KATANA_NUM_TEST_THREADS GREATER ${KATANA_NUM_PHYSICAL_CORES})
   message(WARNING "KATANA_NUM_TEST_THREADS more than the physical cores; please set it to ${KATANA_NUM_PHYSICAL_CORES} to avoid oversubscription.")
 elseif (KATANA_NUM_TEST_THREADS LESS_EQUAL 0)
   set(KATANA_NUM_TEST_THREADS 1)
+endif ()
+
+if (NOT KATANA_NUM_DOC_THREADS)
+  set(KATANA_NUM_DOC_THREADS ${KATANA_NUM_PHYSICAL_CORES})
+  if (KATANA_NUM_DOC_THREADS GREATER 4)
+    set(KATANA_NUM_DOC_THREADS 4)
+  endif ()
+endif ()
+if (KATANA_NUM_DOC_THREADS GREATER ${KATANA_NUM_PHYSICAL_CORES})
+  message(WARNING "KATANA_NUM_DOC_THREADS more than the physical cores; please set it to ${KATANA_NUM_PHYSICAL_CORES} to avoid oversubscription.")
+elseif (KATANA_NUM_DOC_THREADS LESS_EQUAL 0)
+  set(KATANA_NUM_DOC_THREADS 1)
 endif ()
 
 if (NOT KATANA_NUM_TEST_GPUS)
@@ -463,8 +476,8 @@ function(add_katana_sphinx_target target_name)
   if (BUILD_DOCS STREQUAL "internal")
     set(sphinx_options "-W;${sphinx_options}")
   endif ()
-  # Enable parallel reading / writing, 4 workers gave optimal time reduction
-  set(sphinx_options "-j 4;${sphinx_options}")
+  # Enable parallel reading / writing, 4 workers gave optimal time reduction in testing
+  set(sphinx_options "-j;${KATANA_NUM_DOC_THREADS};${sphinx_options}")
 
   add_custom_target(
       ${target_name}_sphinx_docs


### PR DESCRIPTION
I reduced the `sphinx-build` time from it's upper bound at 157s (on my machine). The lower bound of 52s without Breathe / C++ API docs. In this commit, I got the time reduced to 137s using parallel reading / writing.

**Alternatives approaches tried:**

- I looked into the [slow building](https://github.com/michaeljones/breathe/issues/439) associated with the `Breathe` extension. The solution seems to be editing the `Breathe` package itself so that it doesn't rely on `xml.dom` and uses `lxml`. The project has not implemented this change since 2019 when discovered. This does sound like a good avenue for Developer Relations to contribute to an  open source project and make improvements that benefit Katana Graph. **Does this stay as a bug or be transformed into planned work?** 
- I looked at the performance of removing DOT from Doxygen, but that increased the time by 2 minutes.
- Using parallel processing reduced the time modestly but was also dependent on the number of workers, with 4 workers appearing optimal. (Using `auto` did not provide a performance increase.)

  - `-j 2` yielded 138s
  - `-j 4` yielded 137s
  - `-j 6` yielded 142s
  - `-j 8` yielded 157s

JIRA: KAT-2621