### PR TITLE
add unstable_storage_format_version support KAT-2778

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -15,3 +15,4 @@ Contributing
    documentation
    releases
    tips-tricks
+   rdg-storage-format

--- a/docs/contributing/rdg-storage-format.rst
+++ b/docs/contributing/rdg-storage-format.rst
@@ -1,0 +1,70 @@
+=========================
+Katana RDG Storage Format
+=========================
+
+Katana persists its graphs on disk in a format called `RDG: Resilient Distributed Graph`. This `RDG` is a directory filled with files that define the graph.
+The `storage_format_version` of an RDG determines the layout of the RDG
+An example of an RDG can be found here
+https://github.com/KatanaGraph/test-datasets/tree/master/rdg_datasets/ldbc_003/storage_format_version_3
+
+Katana software uses the `storage_format_version` of a loaded RDG to determine some of the features it supports
+
+Katana software always stores the RDG as the latest `storage_format_version`, sometimes with the `unstable_storage_format` modifier (covered below)
+RDGs stored in a newer `storage_format_versions` are incompatible with older software.
+All versions of Katana after a `storage_format_version` is introduced should support loading/reading RDGs stores as that `storage_format_version`.
+
+Early RDGs from before `storage_format_version` was introduced are assumed to be `storage_format_version=1`
+
+Rarely, `storage_format_versions` can be deprecated. When this occurs tooling will be provided to convert all RDGs stored in that `storage_format_version` to the next supported `storage_format_version`.
+
+Unstable RDG Storage Format
+===========================
+
+Developers should use the unstable storage format while developing features for Katana software which alter, add, or remove, RDG data structures to avoid disturbing everyone else that relies on the RDG format to be stable. 
+
+Katana software executed *with* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable supports loading/storing RDGs in the unstable RDG storage format.
+Katana software executed *without* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable *does not* support loading/storing RDGs in the unstable RDG storage format.
+
+Katana software uses the boolean flag `unstable_storage_format` in the RDGs part header to identify unstable format RDGs
+
+If Katana software is executed *with* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable:
+#. katana software stores RDGs:
+ 
+   #. with `storage_format_version = latest_storage_format_version`
+   #. with `unstable_storage_format = true`
+
+#. RDGs with the "unstable_storage_format" are loaded
+
+
+If Katana software is executed *without* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable:
+#. katana software stores RDGs:
+   #. with `storage_format_version = latest_storage_format_version`
+   #. with `unstable_storage_format = false`
+
+#. RDGs with the "unstable_storage_format" are not loaded, and an error is thrown
+
+
+In Katana software the feature flag can be checked by using
+```
+KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);
+```
+
+Developing a new revision of the RDG Storage Format
+===================================================
+
+This process will be largely determined by what new data structures are being persisted in the RDG, but the following are some guidelines.
+
+#. Figure out the in-memory representation of the feature. Figure out how the in-memory representation will be generated from when an RDG without the new data structures is loaded.
+#. Add support for persisting the in-memory representation on disk in the RDG. Gate persisting these new data structures behind `KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);`. When `UnstableRDGStorageFormat` is not set, the persisted RDG should look exactly like an RDG without support for the new data structures.
+#. Add support for loading the new data structures. Gate loading these new data structures behind `KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);`. When `UnstableRDGStorageFormat` is not set, the code should behave like it loaded an RDG without the new data structures.
+#. Write tests for storing/load the new feature.
+#. Stabilize the features in-memory representation
+#. Stabilize the features on-disk representation
+#. When the representations are sufficiently stable
+
+   #. increase the `kLatestPartitionStorageFormatVersion` in `RDGStorageFormatVersion.h`.
+   #. Mirror this change for `KATANA_RDG_STORAGE_FORMAT_VERSION` in `TestDatasets.cmake`
+   #. uprev the rdgs in the `test-datasets` repo https://github.com/KatanaGraph/test-datasets
+   #. update the version of `test-datasets` used by Katana
+   #. update the `DATASETS_SHA` with the newest master sha from `test-datasets` in `example_data.py`
+

--- a/docs/contributing/rdg-storage-format.rst
+++ b/docs/contributing/rdg-storage-format.rst
@@ -38,6 +38,7 @@ If Katana software is executed *with* the `KATANA_ENABLE_EXPERIMENTAL="UnstableR
 
 If Katana software is executed *without* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable:
 #. katana software stores RDGs:
+
    #. with `storage_format_version = latest_storage_format_version`
    #. with `unstable_storage_format = false`
 

--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -67,6 +67,12 @@ public:
   /// What size are EntityTypeIDs on storage
   bool IsUint16tEntityTypeIDs() const;
 
+  /// Is this RDG stored in an unstable format
+  bool IsUnstableStorageFormat() const;
+
+  /// Mark the RDG as being in an unstable format
+  void SetUnstableStorageFormat();
+
   /// Perform some checks on assumed invariants
   katana::Result<void> Validate() const;
 

--- a/libtsuba/include/katana/RDGStorageFormatVersion.h
+++ b/libtsuba/include/katana/RDGStorageFormatVersion.h
@@ -3,6 +3,8 @@
 
 #include <string_view>
 
+#include "katana/Experimental.h"
+
 namespace katana {
 
 /// list of known storage format version
@@ -16,5 +18,24 @@ static const uint32_t kLatestPartitionStorageFormatVersion =
     kPartitionStorageFormatVersion3;
 
 };  // namespace katana
+
+/// The feature flag determines the capabilities of the software,
+/// while the unstable_storage_format_ flag determines the state of the RDG
+/// If "UnstableRDGStorageFormat" is found in the envar "KATANA_ENABLE_EXPERIMENTAL":
+///   1) katana software will store RDGs
+///     - as "latest_storage_format_version"
+///     - with the "unstable_storage_format" part header flag set
+///   2) RDGs with the "unstable_storage_format" flag will be allowed to be loaded
+/// When "UnstableRDGStorageFormat" is not found:
+///   1) RDGs will be stored as the "latest_storage_format_version"
+///   2) RDGs with the "unstable_storage_format" flag will not be allowed to be loaded
+///
+/// This feature flag can be set in the environment:
+/// KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"
+///
+/// This feature flag can be checked by using
+/// KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);
+///
+KATANA_EXPERIMENTAL_FEATURE(UnstableRDGStorageFormat);
 
 #endif

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -531,6 +531,16 @@ katana::RDG::IsUint16tEntityTypeIDs() const {
   return core_->part_header().IsUint16tEntityTypeIDs();
 }
 
+bool
+katana::RDG::IsUnstableStorageFormat() const {
+  return core_->part_header().unstable_storage_format();
+}
+
+void
+katana::RDG::SetUnstableStorageFormat() {
+  core_->part_header().set_unstable_storage_format();
+}
+
 katana::Result<void>
 katana::RDG::Validate() const {
   KATANA_CHECKED(core_->part_header().Validate());

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -316,6 +316,20 @@ public:
   const PartitionMetadata& metadata() const { return metadata_; }
   void set_metadata(const PartitionMetadata& metadata) { metadata_ = metadata; }
 
+  bool unstable_storage_format() const { return unstable_storage_format_; }
+
+  /// Any feature which results in changes to the storage format version
+  /// but has not yet stabilized should ensure this is called
+  /// The feature can then be developed by setting the
+  /// KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"
+  /// env var. See RDGStorageFormatVersion.h for more details
+  void set_unstable_storage_format() {
+    // Callers should ensure the UnstableRDGStorageFormat flag is set before calling
+    // this function.
+    KATANA_LOG_ASSERT(KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat));
+    unstable_storage_format_ = true;
+  }
+
   uint32_t storage_format_version() const { return storage_format_version_; }
   void update_storage_format_version() {
     storage_format_version_ = kLatestPartitionStorageFormatVersion;
@@ -592,6 +606,12 @@ private:
   /// When a graph is loaded from file, this is overwritten with the loaded value
   /// When a graph is created in memory, this is updated on store
   uint32_t storage_format_version_ = 0;
+
+  /// if true, marks that the RDG has an unstable, unsupported storage format
+  /// unstable_storage_format RDGs can only be loaded if
+  /// the env variable "KATANA_ENABLE_EXPERIMENTAL=UnstableRDGStorageFormat" is set
+  /// See RDGStorageFormatVersion.h for additional information
+  bool unstable_storage_format_ = false;
 
   PartitionTopologyMetadata topology_metadata_;
 

--- a/libtsuba/test/CMakeLists.txt
+++ b/libtsuba/test/CMakeLists.txt
@@ -43,6 +43,29 @@ set_tests_properties(${name} PROPERTIES FIXTURES_REQUIRED parquet-ready LABELS q
 add_test(NAME ${clean_name} COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/parquet-test-wd")
 set_tests_properties(${clean_name} PROPERTIES FIXTURES_SETUP parquet-ready LABELS quick)
 
+## Storage Format Version Unstable Flag tests
+set(unstable_rdg_path ${PROJECT_BINARY_DIR}/Testing/Temporary/unstable_rdg)
+set(group ${name}-fixture)
+set(name unstable-storage-format-version-flag-on)
+set(test_name ${name}-test)
+add_executable(${test_name} storage-format-version/unstable-storage-format-version-flag-on.cpp)
+target_link_libraries(${test_name} katana_tsuba)
+target_include_directories(${test_name} PRIVATE ../src)
+add_test(NAME ${name} COMMAND ${test_name} ${RDG_LDBC_003} ${unstable_rdg_path})
+set_tests_properties(${name} PROPERTIES
+  ENVIRONMENT KATANA_ENABLE_EXPERIMENTAL=UnstableRDGStorageFormat)
+set_tests_properties(${name} PROPERTIES FIXTURES_SETUP ${group})
+set_property(TEST ${name} APPEND PROPERTY LABELS quick)
+
+# depends on the flag-on test to create a valid unstable RDG
+set(name unstable-storage-format-version-flag-off)
+set(test_name ${name}-test)
+add_executable(${test_name} storage-format-version/unstable-storage-format-version-flag-off.cpp)
+target_link_libraries(${test_name} katana_tsuba)
+target_include_directories(${test_name} PRIVATE ../src)
+add_test(NAME ${name} COMMAND ${test_name} ${RDG_LDBC_003} ${unstable_rdg_path})
+set_property(TEST ${name} APPEND PROPERTY FIXTURES_REQUIRED ${group})
+set_property(TEST ${name} APPEND PROPERTY LABELS quick)
 
 ## Storage Format Version backwards compatibility tests ##
 
@@ -63,7 +86,6 @@ target_include_directories(${test_name} PRIVATE ../src)
 add_test(NAME ${name} COMMAND ${test_name} ${RDG_LDBC_003_V3})
 set_property(TEST ${name} APPEND PROPERTY LABELS quick)
 set_tests_properties(${name} PROPERTIES LABELS quick)
-
 
 # Test entity type id loading/storing cycle on v3 input
 set(name storage-format-version-v3-v3-uint16-entity-type-ids)

--- a/libtsuba/test/storage-format-version/unstable-storage-format-version-flag-off.cpp
+++ b/libtsuba/test/storage-format-version/unstable-storage-format-version-flag-off.cpp
@@ -1,0 +1,78 @@
+#include <filesystem>
+
+#include <boost/filesystem.hpp>
+
+#include "../test-rdg.h"
+#include "katana/Experimental.h"
+#include "katana/Logging.h"
+#include "katana/RDG.h"
+#include "katana/RDGManifest.h"
+#include "katana/RDGStorageFormatVersion.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+
+namespace fs = boost::filesystem;
+
+/// Tests the following while the feature flag is disabled:
+/// 1) loading and storing a stable RDG
+katana::Result<void>
+TestStable(const std::string& stable_rdg) {
+  KATANA_LOG_ASSERT(!stable_rdg.empty());
+
+  // load a stable rdg
+  katana::RDG rdg = KATANA_CHECKED(LoadRDG(stable_rdg));
+  KATANA_LOG_ASSERT(!rdg.IsUnstableStorageFormat());
+
+  // store the stable rdg
+  std::string rdg_dir1 = KATANA_CHECKED(WriteRDG(std::move(rdg)));
+  KATANA_LOG_ASSERT(!rdg_dir1.empty());
+
+  return katana::ResultSuccess();
+}
+
+/// Tests the following while the feature flag is disabled:
+/// 1) loading an unstable RDG
+katana::Result<void>
+TestLoadUnstable(const std::string& unstable_rdg) {
+  KATANA_LOG_ASSERT(!unstable_rdg.empty());
+
+  // this should fail
+  // Can't use KATANA_CHECKED since we want failure
+  auto res = LoadRDG(unstable_rdg);
+  KATANA_LOG_ASSERT(!res);
+
+  return katana::ResultSuccess();
+}
+
+int
+main(int argc, char* argv[]) {
+  if (auto init_good = katana::InitTsuba(); !init_good) {
+    KATANA_LOG_FATAL("katana::InitTsuba: {}", init_good.error());
+  }
+
+  if (argc <= 2) {
+    KATANA_LOG_FATAL("missing rdg file directory");
+  }
+
+  // Ensure the feature flag is not set
+  KATANA_LOG_ASSERT(!KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat));
+
+  const std::string& stable_rdg = argv[1];
+  const std::string& unstable_rdg = argv[2];
+
+  auto res = TestStable(stable_rdg);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  res = TestLoadUnstable(unstable_rdg);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  if (auto fini_good = katana::FiniTsuba(); !fini_good) {
+    KATANA_LOG_FATAL("katana::FiniTsuba: {}", fini_good.error());
+  }
+
+  return 0;
+}

--- a/libtsuba/test/storage-format-version/unstable-storage-format-version-flag-on.cpp
+++ b/libtsuba/test/storage-format-version/unstable-storage-format-version-flag-on.cpp
@@ -1,0 +1,89 @@
+#include <filesystem>
+
+#include <boost/filesystem.hpp>
+
+#include "../test-rdg.h"
+#include "katana/Experimental.h"
+#include "katana/Logging.h"
+#include "katana/RDG.h"
+#include "katana/RDGManifest.h"
+#include "katana/RDGStorageFormatVersion.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+
+namespace fs = boost::filesystem;
+
+/// Generate a version of the provided stable rdg, marked as unstable for testing
+/// the unstable RDG can vary wildly from the stable RDG at test time since features may
+/// be under development
+/// Because of this, it is possible that this test catches bugs in storage which are related
+/// to unstable features, in addition to bugs related to the unstable storage format
+/// feature flag itself
+///
+/// Tests the following while the feature flag is enabled:
+/// 1) loading a stable RDG
+/// 2) loading a stable RDG and storing it as unstable
+/// 3) loading an unstable RDG and storing it as unstable
+katana::Result<void>
+TestRoundtripUnstable(
+    const std::string& stable_rdg, const std::string& unstable_rdg) {
+  KATANA_LOG_ASSERT(!stable_rdg.empty());
+  KATANA_LOG_ASSERT(!unstable_rdg.empty());
+
+  // clean up whatever temporary unstable rdg might already be present
+  std::filesystem::remove_all(unstable_rdg);
+
+  // load a stable rdg
+  katana::RDG rdg = KATANA_CHECKED(LoadRDG(stable_rdg));
+  KATANA_LOG_ASSERT(!rdg.IsUnstableStorageFormat());
+
+  // make our in memory rdg unstable
+  rdg.SetUnstableStorageFormat();
+  KATANA_LOG_ASSERT(rdg.IsUnstableStorageFormat());
+
+  // store the unstable rdg
+  std::string rdg_dir1 = KATANA_CHECKED(WriteRDG(std::move(rdg), unstable_rdg));
+  KATANA_LOG_ASSERT(!rdg_dir1.empty());
+  // ensure where we stored it matches the unstable_rdg path so that the flag-off test can use it
+  KATANA_LOG_ASSERT(rdg_dir1 == unstable_rdg);
+
+  // load the unstable rdg
+  katana::RDG rdg1 = KATANA_CHECKED(LoadRDG(rdg_dir1));
+  KATANA_LOG_ASSERT(rdg1.IsUnstableStorageFormat());
+
+  // RoundTrip it again to ensure we can load an unstable RDG and store it
+  std::string rdg_dir2 = KATANA_CHECKED(WriteRDG(std::move(rdg1)));
+  KATANA_LOG_ASSERT(!rdg_dir2.empty());
+  katana::RDG rdg2 = KATANA_CHECKED(LoadRDG(rdg_dir2));
+  KATANA_LOG_ASSERT(rdg2.IsUnstableStorageFormat());
+
+  return katana::ResultSuccess();
+}
+
+int
+main(int argc, char* argv[]) {
+  if (auto init_good = katana::InitTsuba(); !init_good) {
+    KATANA_LOG_FATAL("katana::InitTsuba: {}", init_good.error());
+  }
+
+  if (argc <= 2) {
+    KATANA_LOG_FATAL("missing rdg file directory");
+  }
+
+  // Ensure the feature flag is actually set
+  KATANA_LOG_ASSERT(KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat));
+
+  const std::string& stable_rdg = argv[1];
+  const std::string& unstable_rdg = argv[2];
+
+  auto res = TestRoundtripUnstable(stable_rdg, unstable_rdg);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  if (auto fini_good = katana::FiniTsuba(); !fini_good) {
+    KATANA_LOG_FATAL("katana::FiniTsuba: {}", fini_good.error());
+  }
+
+  return 0;
+}

--- a/libtsuba/test/test-rdg.h
+++ b/libtsuba/test/test-rdg.h
@@ -12,10 +12,8 @@
 katana::Result<std::string>
 WriteRDG(
     katana::RDG&& rdg_, katana::EntityTypeManager node_entity_type_manager,
-    katana::EntityTypeManager edge_entity_type_manager) {
-  auto uri_res = katana::Uri::MakeRand("/tmp/propertyfilegraph");
-  KATANA_LOG_ASSERT(uri_res);
-  std::string tmp_rdg_dir(uri_res.value().path());  // path() because local
+    katana::EntityTypeManager edge_entity_type_manager,
+    std::string tmp_rdg_dir) {
   std::string command_line;
 
   // Store graph. If there is a new storage format then storing it is enough to bump the version up.
@@ -45,10 +43,30 @@ WriteRDG(
 }
 
 katana::Result<std::string>
+WriteRDG(
+    katana::RDG&& rdg_, katana::EntityTypeManager node_entity_type_manager,
+    katana::EntityTypeManager edge_entity_type_manager) {
+  auto uri_res = katana::Uri::MakeRand("/tmp/propertyfilegraph");
+  KATANA_LOG_ASSERT(uri_res);
+  std::string tmp_rdg_dir(uri_res.value().path());  // path() because local
+
+  return WriteRDG(
+      std::move(rdg_), std::move(node_entity_type_manager),
+      std::move(edge_entity_type_manager), tmp_rdg_dir);
+}
+
+katana::Result<std::string>
 WriteRDG(katana::RDG&& rdg_) {
   return WriteRDG(
       std::move(rdg_), KATANA_CHECKED(rdg_.node_entity_type_manager()),
       KATANA_CHECKED(rdg_.edge_entity_type_manager()));
+}
+
+katana::Result<std::string>
+WriteRDG(katana::RDG&& rdg_, std::string out_dir) {
+  return WriteRDG(
+      std::move(rdg_), KATANA_CHECKED(rdg_.node_entity_type_manager()),
+      KATANA_CHECKED(rdg_.edge_entity_type_manager()), out_dir);
 }
 
 katana::Result<katana::RDG>


### PR DESCRIPTION
Adds UnstableRDGStorageFormat flag to enable storing/loading unstable
storage format RDGs

Developers should use the unstable storage format while developing features for Katana software which alter, add, or remove, RDG data structures to avoid disturbing everyone else that relies on the RDG format to be stable.

Katana software executed *with* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable supports loading/storing RDGs in the unstable RDG storage format.
Katana software executed *without* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable *does not* support loading/storing RDGs in the unstable RDG storage format.

Katana software uses the boolean flag `unstable_storage_format` in the RDGs part header to identify unstable format RDGs

If Katana software is executed *with* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable:
1. katana software stores RDGs:
   - with `storage_format_version = latest_storage_format_version`
   - with `unstable_storage_format = true`
2. RDGs with the "unstable_storage_format" are loaded

If Katana software is executed *without* the `KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"` environment variable:
1. katana software stores RDGs:
   - with `storage_format_version = latest_storage_format_version`
   - with `unstable_storage_format = false`
2. RDGs with the "unstable_storage_format" are not loaded, and an error is thrown

In Katana software the feature flag can be checked by using
```
KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);
```