### PR TITLE
meta: slightly improve several interfaces

### DIFF
--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -271,6 +271,11 @@ public:
       const std::string& rdg_name, katana::TxnContext* txn_ctx,
       const katana::RDGLoadOptions& opts = katana::RDGLoadOptions());
 
+  /// Make a property graph from an RDG handle
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      std::unique_ptr<RDGFile> rdg_hanlde, katana::TxnContext* txn_ctx,
+      const katana::RDGLoadOptions& opts = katana::RDGLoadOptions());
+
   /// Make a property graph from topology
   static Result<std::unique_ptr<PropertyGraph>> Make(
       GraphTopology&& topo_to_assign);

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -201,26 +201,20 @@ katana::PropertyGraph::Make(
     const std::string& rdg_name, katana::TxnContext* txn_ctx,
     const katana::RDGLoadOptions& opts) {
   katana::RDGManifest manifest = KATANA_CHECKED(katana::FindManifest(rdg_name));
-  katana::RDGFile rdg_file{
-      KATANA_CHECKED(katana::Open(std::move(manifest), katana::kReadWrite))};
-  katana::RDG rdg = KATANA_CHECKED(katana::RDG::Make(rdg_file, opts));
+  auto rdg_handle =
+      KATANA_CHECKED(katana::Open(std::move(manifest), katana::kReadWrite));
+  auto new_file = std::make_unique<katana::RDGFile>(rdg_handle);
 
-  return katana::PropertyGraph::Make(
-      std::make_unique<katana::RDGFile>(std::move(rdg_file)), std::move(rdg),
-      txn_ctx);
+  return Make(std::move(new_file), txn_ctx, opts);
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
-    const katana::RDGManifest& rdg_manifest, const katana::RDGLoadOptions& opts,
-    katana::TxnContext* txn_ctx) {
-  katana::RDGFile rdg_file{KATANA_CHECKED(
-      katana::Open(std::move(rdg_manifest), katana::kReadWrite))};
-  katana::RDG rdg = KATANA_CHECKED(katana::RDG::Make(rdg_file, opts));
-
+    std::unique_ptr<RDGFile> rdg_file, katana::TxnContext* txn_ctx,
+    const katana::RDGLoadOptions& opts) {
+  auto rdg = KATANA_CHECKED(RDG::Make(*rdg_file, opts));
   return katana::PropertyGraph::Make(
-      std::make_unique<katana::RDGFile>(std::move(rdg_file)), std::move(rdg),
-      txn_ctx);
+      std::move(rdg_file), std::move(rdg), txn_ctx);
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>

--- a/libsupport/include/katana/Experimental.h
+++ b/libsupport/include/katana/Experimental.h
@@ -17,7 +17,7 @@ namespace internal {
 /// below
 class KATANA_EXPORT ExperimentalFeature {
 public:
-  static ExperimentalFeature* Register(
+  static const ExperimentalFeature* Register(
       const std::string& feature_name, const std::string& filename,
       int line_number);
 
@@ -31,7 +31,7 @@ public:
   /// report the feature flags that were provided but did not match any registered flag
   static std::vector<std::string> ReportUnrecognized();
 
-  bool IsEnabled() { return is_enabled_; }
+  bool IsEnabled() const { return is_enabled_; }
 
   ExperimentalFeature(const ExperimentalFeature& no_copy) = delete;
   ExperimentalFeature& operator=(const ExperimentalFeature& no_copy) = delete;
@@ -105,7 +105,7 @@ private:
 #define KATANA_EXPERIMENTAL_FEATURE(feature_name)                              \
   namespace katana::internal {                                                 \
   class ExperimentalFeature;                                                   \
-  static auto* katana_experimental_feature_ptr_##feature_name =                \
+  static const auto* const katana_experimental_feature_ptr_##feature_name =    \
       ::katana::internal::ExperimentalFeature::Register(                       \
           #feature_name, __FILE__, __LINE__);                                  \
   }                                                                            \

--- a/libsupport/src/Experimental.cpp
+++ b/libsupport/src/Experimental.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<ExperimentalFeatureEnvState>
 
 }  // namespace
 
-katana::internal::ExperimentalFeature*
+const katana::internal::ExperimentalFeature*
 katana::internal::ExperimentalFeature::Register(
     const std::string& feature_name, const std::string& filename,
     int line_number) {

--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -37,7 +37,7 @@ struct KATANA_EXPORT RDGLoadOptions {
   /// Which partition of the RDG on storage should be loaded
   /// nullopt means the partition associated with the current host's ID will be
   /// loaded
-  std::optional<uint32_t> partition_id_to_load;
+  std::optional<uint32_t> partition_id_to_load{std::nullopt};
   /// List of node properties that should be loaded
   /// nullptr means all node properties will be loaded
   std::optional<std::vector<std::string>> node_properties{std::nullopt};
@@ -48,6 +48,13 @@ struct KATANA_EXPORT RDGLoadOptions {
   // Callback provides a pointer to the RDG so we can evict
   // even before the PropertyGraph is created.
   katana::PropertyCache* prop_cache{nullptr};
+
+  /// Build a default options struct the default behavior is:
+  ///  * load the partition associated with this host
+  ///  * load all node properties
+  ///  * load all edge properties
+  ///  * do not use a property cache
+  static RDGLoadOptions Defaults() { return RDGLoadOptions{}; }
 };
 
 class KATANA_EXPORT RDG {


### PR DESCRIPTION
Odds and ends to support some improvements in the pipeline:
 * PropertyGraph: add interface to load from a file handle. This is
   useful when we're loading distributed graphs because we already do
   a bunch of this work and it's awkward to get back to a URI

 * RDGLoadOptions: add a static `Defaults` constructor. While I think
   just defining structs that behave sanely when default is good. I
   like the way the verbose "Defaults()" call looks, especially when
   part of a default argument. I also thinks it gives callers greater
   confidence that the default struct will do something reasonable.

 * Experimental: My linter complains that this pointer is not constant
   when it's declared; and there is no reason it shouldn't be

Signed-off-by: Tyler Hunt <thunt@katanagraph.com>