### PR TITLE
Rename view method continued [KAT-3083]

### DIFF
--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -140,8 +140,8 @@ public:
     return static_cast<Node>(d);
   }
 
-  ///@param node node to get degree for
-  ///@returns Degree of node N
+  /// @param node node to get degree for
+  /// @returns Degree of node N
   size_t OutDegree(Node node) const noexcept { return OutEdges(node).size(); }
 
   nodes_range Nodes() const noexcept {
@@ -161,7 +161,8 @@ public:
 
   // TODO(yan): This will become GetEdgePropertyIndex(OutEdgeHandle) once we
   // introduce new opaque indexing types.
-  PropertyIndex GetOutEdgePropertyIndex(const Edge& eid) const noexcept {
+  PropertyIndex GetEdgePropertyIndexFromOutEdge(
+      const Edge& eid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(eid < NumEdges());
     return edge_prop_indices_[eid];
   }
@@ -176,8 +177,8 @@ public:
     return static_cast<Node>(GetNodePropertyIndex(nid));
   }
 
-  Edge GetLocalOutEdgeID(const Edge& eid) const noexcept {
-    return GetOutEdgePropertyIndex(eid);
+  Edge GetLocalEdgeIDFromOutEdge(const Edge& eid) const noexcept {
+    return GetEdgePropertyIndexFromOutEdge(eid);
   }
 
   // We promote these methods to the base topology to make it easier to search among all
@@ -272,7 +273,7 @@ public:
            (kind == edge_sort_state());
   }
 
-  using Base::GetLocalOutEdgeID;
+  using Base::GetLocalEdgeIDFromOutEdge;
 
   static std::shared_ptr<EdgeShuffleTopology> MakeTransposeCopy(
       const PropertyGraph* pg);
@@ -486,7 +487,7 @@ private:
 
             // copy over edge_property_index mapping from old edge to new edge
             edge_prop_indices[new_edge_id] =
-                seed_topo.GetOutEdgePropertyIndex(e);
+                seed_topo.GetEdgePropertyIndexFromOutEdge(e);
           }
           KATANA_LOG_DEBUG_ASSERT(new_out_index == degrees[new_srd_id]);
         },
@@ -605,8 +606,8 @@ public:
     return static_cast<Node>(d);
   }
 
-  ///@param node node to get degree for
-  ///@returns Degree of node N
+  /// @param node node to get degree for
+  /// @returns Degree of node N
   size_t OutDegree(Node node) const noexcept { return OutEdges(node).size(); }
 
   nodes_range Nodes() const noexcept {
@@ -624,14 +625,15 @@ public:
 
   bool empty() const noexcept { return NumNodes() == 0; }
 
-  PropertyIndex GetOutEdgePropertyIndex(const Edge& eid) const noexcept {
+  PropertyIndex GetEdgePropertyIndexFromOutEdge(
+      const Edge& eid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(eid < NumEdges());
     return projected_to_original_edges_mapping_[eid];
   }
 
   /// @param eid the input eid (must be projected edge id)
   Edge projected_to_original_edge_id(const Edge& eid) const noexcept {
-    return GetOutEdgePropertyIndex(eid);
+    return GetEdgePropertyIndexFromOutEdge(eid);
   }
 
   /// @param eid the input eid (must be original edge id)
@@ -956,7 +958,7 @@ public:
   /// @param dst destination node of the edge
   /// @param edge_type edge_type of the edge
   /// @returns true iff the edge exists
-  bool IsConnected(Node src, Node dst, const EntityTypeID& edge_type) const {
+  bool HasEdge(Node src, Node dst, const EntityTypeID& edge_type) const {
     auto e_range = OutEdges(src, edge_type);
     if (e_range.empty()) {
       return false;
@@ -1014,7 +1016,7 @@ public:
   /// @param src source node of the edge
   /// @param dst destination node of the edge
   /// @returns true iff the edge exists
-  bool IsConnected(Node src, Node dst) const {
+  bool HasEdge(Node src, Node dst) const {
     // trivial check; can't be connected if degree is 0
 
     if (OutDegree(src) == 0ul) {
@@ -1022,7 +1024,7 @@ public:
     }
 
     for (const auto& edge_type : GetDistinctEdgeTypes()) {
-      if (IsConnected(src, dst, edge_type)) {
+      if (HasEdge(src, dst, edge_type)) {
         return true;
       }
     }
@@ -1107,8 +1109,8 @@ public:
 
   auto empty() const noexcept { return topo().empty(); }
 
-  auto GetOutEdgePropertyIndex(const Edge& e) const noexcept {
-    return topo().GetOutEdgePropertyIndex(e);
+  auto GetEdgePropertyIndexFromOutEdge(const Edge& e) const noexcept {
+    return topo().GetEdgePropertyIndexFromOutEdge(e);
   }
 
   auto GetNodePropertyIndex(const Node& nid) const noexcept {
@@ -1118,8 +1120,8 @@ public:
     return topo().GetLocalNodeID(nid);
   }
 
-  auto GetLocalOutEdgeID(const Edge& eid) const noexcept {
-    return topo().GetLocalOutEdgeID(eid);
+  auto GetLocalEdgeIDFromOutEdge(const Edge& eid) const noexcept {
+    return topo().GetLocalEdgeIDFromOutEdge(eid);
   }
   void Print() const noexcept { topo_ptr_->Print(); }
 
@@ -1177,8 +1179,8 @@ public:
 
   auto empty() const noexcept { return topo().empty(); }
 
-  auto GetOutEdgePropertyIndex(const Edge& e) const noexcept {
-    return topo().GetOutEdgePropertyIndex(e);
+  auto GetEdgePropertyIndexFromOutEdge(const Edge& e) const noexcept {
+    return topo().GetEdgePropertyIndexFromOutEdge(e);
   }
 
   auto GetNodePropertyIndex(const Node& nid) const noexcept {
@@ -1249,13 +1251,14 @@ public:
 
   // TODO(yan): This will become GetEdgePropertyIndex(InEdgeHandle) once we
   // introduce new opaque indexing types.
-  auto GetInEdgePropertyIndex(
+  auto GetEdgePropertyIndexFromInEdge(
       const GraphTopologyTypes::Edge& eid) const noexcept {
-    return in().GetOutEdgePropertyIndex(eid);
+    return in().GetEdgePropertyIndexFromOutEdge(eid);
   }
 
-  auto GetLocalInEdgeID(const GraphTopologyTypes::Edge& eid) const noexcept {
-    return in().GetLocalOutEdgeID(eid);
+  auto GetLocalEdgeIDFromInEdge(
+      const GraphTopologyTypes::Edge& eid) const noexcept {
+    return in().GetLocalEdgeIDFromOutEdge(eid);
   }
 
 protected:
@@ -1323,19 +1326,20 @@ public:
 
   bool empty() const noexcept { return NumNodes() == 0; }
 
-  ///@param node node to get degree for
-  ///@returns Degree of node N
+  /// @param node node to get degree for
+  /// @returns Degree of node N
   size_t UndirectedDegree(Node node) const noexcept {
     return UndirectedEdges(node).size();
   }
 
   // TODO(yan): This will become GetEdgePropertyIndex(UndirectedEdgeHandle) once we
   // introduce new opaque indexing types.
-  PropertyIndex GetUndirectedEdgePropertyIndex(const Edge& eid) const noexcept {
+  PropertyIndex GetEdgePropertyIndexFromUndirectedEdge(
+      const Edge& eid) const noexcept {
     if (is_in_edge(eid)) {
-      return in().GetOutEdgePropertyIndex(real_in_edge_id(eid));
+      return in().GetEdgePropertyIndexFromOutEdge(real_in_edge_id(eid));
     }
-    return out().GetOutEdgePropertyIndex(eid);
+    return out().GetEdgePropertyIndexFromOutEdge(eid);
   }
 
   PropertyIndex GetNodePropertyIndex(const Node& nid) const noexcept {
@@ -1350,8 +1354,8 @@ public:
     return static_cast<Node>(GetNodePropertyIndex(nid));
   }
 
-  Edge GetLocalUndirectedEdgeID(const Edge& eid) const noexcept {
-    return GetUndirectedEdgePropertyIndex(eid);
+  Edge GetLocalEdgeIDFromUndirectedEdge(const Edge& eid) const noexcept {
+    return GetEdgePropertyIndexFromUndirectedEdge(eid);
   }
 
 protected:
@@ -1497,7 +1501,7 @@ public:
   /// @param dst destination node of the edge
   /// @param edge_type edge_type of the edge
   /// @returns true iff the edge exists
-  bool IsConnected(Node src, Node dst, const EntityTypeID& edge_type) const {
+  bool HasEdge(Node src, Node dst, const EntityTypeID& edge_type) const {
     const auto d_out = OutDegree(src, edge_type);
     const auto d_in = InDegree(dst, edge_type);
     if (d_out == 0 || d_in == 0) {
@@ -1505,9 +1509,9 @@ public:
     }
 
     if (d_out < d_in) {
-      return Base::out().IsConnected(src, dst, edge_type);
+      return Base::out().HasEdge(src, dst, edge_type);
     } else {
-      return Base::in().IsConnected(dst, src, edge_type);
+      return Base::in().HasEdge(dst, src, edge_type);
     }
   }
 
@@ -1569,7 +1573,7 @@ public:
   /// @param src source node of the edge
   /// @param dst destination node of the edge
   /// @returns true iff the edge exists
-  bool IsConnected(Node src, Node dst) const {
+  bool HasEdge(Node src, Node dst) const {
     const auto d_out = OutDegree(src);
     const auto d_in = InDegree(dst);
     if (d_out == 0 || d_in == 0) {
@@ -1577,9 +1581,9 @@ public:
     }
 
     if (d_out < d_in) {
-      return Base::out().IsConnected(src, dst);
+      return Base::out().HasEdge(src, dst);
     } else {
-      return Base::in().IsConnected(dst, src);
+      return Base::in().HasEdge(dst, src);
     }
   }
 };

--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -140,12 +140,13 @@ public:
     return static_cast<Node>(d);
   }
 
-  nodes_range nodes(Node begin, Node end) const noexcept {
-    return MakeStandardRange<node_iterator>(begin, end);
-  }
+  ///@param node node to get degree for
+  ///@returns Degree of node N
+  size_t OutDegree(Node node) const noexcept { return OutEdges(node).size(); }
 
-  nodes_range all_nodes() const noexcept {
-    return nodes(Node{0}, static_cast<Node>(NumNodes()));
+  nodes_range Nodes() const noexcept {
+    return MakeStandardRange<node_iterator>(
+        Node{0}, static_cast<Node>(NumNodes()));
   }
 
   // Standard container concepts
@@ -158,27 +159,25 @@ public:
 
   bool empty() const noexcept { return NumNodes() == 0; }
 
-  ///@param node node to get degree for
-  ///@returns Degree of node N
-  size_t degree(Node node) const noexcept { return OutEdges(node).size(); }
-
-  PropertyIndex edge_property_index(const Edge& eid) const noexcept {
+  // TODO(yan): This will become GetEdgePropertyIndex(OutEdgeHandle) once we
+  // introduce new opaque indexing types.
+  PropertyIndex GetOutEdgePropertyIndex(const Edge& eid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(eid < NumEdges());
     return edge_prop_indices_[eid];
   }
 
-  PropertyIndex node_property_index(const Node& nid) const noexcept {
+  PropertyIndex GetNodePropertyIndex(const Node& nid) const noexcept {
     return nid;
   }
 
   // TODO(amber): These two methods are a short term fix. The nature of
   // PropertyIndex is expected to change post grouping of properties.
-  Node original_node_id(const Node& nid) const noexcept {
-    return static_cast<Node>(node_property_index(nid));
+  Node GetLocalNodeID(const Node& nid) const noexcept {
+    return static_cast<Node>(GetNodePropertyIndex(nid));
   }
 
-  Edge original_edge_id(const Edge& eid) const noexcept {
-    return edge_property_index(eid);
+  Edge GetLocalOutEdgeID(const Edge& eid) const noexcept {
+    return GetOutEdgePropertyIndex(eid);
   }
 
   // We promote these methods to the base topology to make it easier to search among all
@@ -273,7 +272,7 @@ public:
            (kind == edge_sort_state());
   }
 
-  using Base::original_edge_id;
+  using Base::GetLocalOutEdgeID;
 
   static std::shared_ptr<EdgeShuffleTopology> MakeTransposeCopy(
       const PropertyGraph* pg);
@@ -304,12 +303,12 @@ public:
 
   katana::Result<katana::RDGTopology> ToRDGTopology() const;
 
-  edge_iterator find_edge(const Node& src, const Node& dst) const noexcept;
+  edge_iterator FindEdge(const Node& src, const Node& dst) const noexcept;
 
-  edges_range find_edges(const Node& src, const Node& dst) const noexcept;
+  edges_range FindAllEdges(const Node& src, const Node& dst) const noexcept;
 
-  bool has_edge(const Node& src, const Node& dst) const noexcept {
-    return find_edge(src, dst) != OutEdges(src).end();
+  bool HasEdge(const Node& src, const Node& dst) const noexcept {
+    return FindEdge(src, dst) != OutEdges(src).end();
   }
 
 protected:
@@ -370,7 +369,7 @@ public:
 
   virtual ~ShuffleTopology();
 
-  PropertyIndex node_property_index(const Node& nid) const noexcept {
+  PropertyIndex GetNodePropertyIndex(const Node& nid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(nid < NumNodes());
     return node_prop_indices_[nid];
   }
@@ -453,7 +452,7 @@ private:
         [&](auto i) {
           // node_prop_indices[i] gives old node id
           old_to_new_map[node_prop_indices[i]] = i;
-          degrees[i] = seed_topo.degree(node_prop_indices[i]);
+          degrees[i] = seed_topo.OutDegree(node_prop_indices[i]);
         },
         katana::no_stats());
 
@@ -470,7 +469,7 @@ private:
     edge_prop_indices.allocateInterleaved(seed_topo.NumEdges());
 
     katana::do_all(
-        katana::iterate(seed_topo.all_nodes()),
+        katana::iterate(seed_topo.Nodes()),
         [&](auto old_src_id) {
           auto new_srd_id = old_to_new_map[old_src_id];
           auto new_out_index = new_srd_id > 0 ? degrees[new_srd_id - 1] : 0;
@@ -486,7 +485,8 @@ private:
             new_dest_vec[new_edge_id] = new_edge_dest;
 
             // copy over edge_property_index mapping from old edge to new edge
-            edge_prop_indices[new_edge_id] = seed_topo.edge_property_index(e);
+            edge_prop_indices[new_edge_id] =
+                seed_topo.GetOutEdgePropertyIndex(e);
           }
           KATANA_LOG_DEBUG_ASSERT(new_out_index == degrees[new_srd_id]);
         },
@@ -605,12 +605,13 @@ public:
     return static_cast<Node>(d);
   }
 
-  nodes_range nodes(Node begin, Node end) const noexcept {
-    return MakeStandardRange<node_iterator>(begin, end);
-  }
+  ///@param node node to get degree for
+  ///@returns Degree of node N
+  size_t OutDegree(Node node) const noexcept { return OutEdges(node).size(); }
 
-  nodes_range all_nodes() const noexcept {
-    return nodes(Node{0}, static_cast<Node>(NumNodes()));
+  nodes_range Nodes() const noexcept {
+    return MakeStandardRange<node_iterator>(
+        Node{0}, static_cast<Node>(NumNodes()));
   }
 
   // Standard container concepts
@@ -623,18 +624,14 @@ public:
 
   bool empty() const noexcept { return NumNodes() == 0; }
 
-  ///@param node node to get degree for
-  ///@returns Degree of node N
-  size_t degree(Node node) const noexcept { return OutEdges(node).size(); }
-
-  PropertyIndex edge_property_index(const Edge& eid) const noexcept {
+  PropertyIndex GetOutEdgePropertyIndex(const Edge& eid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(eid < NumEdges());
     return projected_to_original_edges_mapping_[eid];
   }
 
   /// @param eid the input eid (must be projected edge id)
   Edge projected_to_original_edge_id(const Edge& eid) const noexcept {
-    return edge_property_index(eid);
+    return GetOutEdgePropertyIndex(eid);
   }
 
   /// @param eid the input eid (must be original edge id)
@@ -642,14 +639,14 @@ public:
     return original_to_projected_edges_mapping_[eid];
   }
 
-  PropertyIndex node_property_index(const Node& nid) const noexcept {
+  PropertyIndex GetNodePropertyIndex(const Node& nid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(nid < NumNodes());
     return projected_to_original_nodes_mapping_[nid];
   }
 
   /// @param nid the input node id (must be projected node id)
   Node projected_to_original_node_id(const Node& nid) const noexcept {
-    return node_property_index(nid);
+    return GetNodePropertyIndex(nid);
   }
 
   /// @param nid the input node id (must be original node id)
@@ -855,12 +852,12 @@ public:
       std::shared_ptr<const CondensedTypeIDMap> edge_type_index,
       EdgeShuffleTopology&& e_topo);
 
-  using Base::degree;
   using Base::edge_sort_state;
   using Base::has_transpose_state;
   using Base::invalidate;
   using Base::is_transposed;
   using Base::is_valid;
+  using Base::OutDegree;
   using Base::OutEdges;
   using Base::transpose_state;
 
@@ -888,7 +885,7 @@ public:
   /// @param N node to get degree for
   /// @param edge_type edge_type to get degree of
   /// @returns Degree of node N
-  size_t degree(Node N, const EntityTypeID& edge_type) const noexcept {
+  size_t OutDegree(Node N, const EntityTypeID& edge_type) const noexcept {
     return OutEdges(N, edge_type).size();
   }
 
@@ -902,7 +899,7 @@ public:
 
   /// Returns all edges from src to dst with some edge_type.  If not found, returns
   /// empty range.
-  edges_range FindAllEdgesWithType(
+  edges_range FindAllEdges(
       Node node, Node key, const EntityTypeID& edge_type) const noexcept {
     auto e_range = OutEdges(node, edge_type);
     if (e_range.empty()) {
@@ -930,18 +927,18 @@ public:
   /// If not found, returns nothing.
   // TODO(amber): Assess the usefulness of this method. This method cannot return
   // edges of all types. Only the first found type. We should however support
-  // find_edges(src, dst) or find_edge(src, dst) that doesn't care about edge type
-  edges_range FindAllEdgesSingleType(Node src, Node dst) const {
+  // FindAllEdges(src, dst) or FindEdge(src, dst) that doesn't care about edge type
+  edges_range FindAllEdges(Node src, Node dst) const {
     // trivial check; can't be connected if degree is 0
     auto empty_range = MakeStandardRange<edge_iterator>(Edge{0}, Edge{0});
-    if (degree(src) == 0) {
+    if (OutDegree(src) == 0) {
       return empty_range;
     }
 
     // loop through all type_ids
     for (const EntityTypeID& edge_type : GetDistinctEdgeTypes()) {
       // always use out edges (we want an id to the out edge returned)
-      edges_range r = FindAllEdgesWithType(src, dst, edge_type);
+      edges_range r = FindAllEdges(src, dst, edge_type);
 
       // return if something was found
       if (r) {
@@ -959,8 +956,7 @@ public:
   /// @param dst destination node of the edge
   /// @param edge_type edge_type of the edge
   /// @returns true iff the edge exists
-  bool IsConnectedWithEdgeType(
-      Node src, Node dst, const EntityTypeID& edge_type) const {
+  bool IsConnected(Node src, Node dst, const EntityTypeID& edge_type) const {
     auto e_range = OutEdges(src, edge_type);
     if (e_range.empty()) {
       return false;
@@ -983,7 +979,7 @@ public:
     static_assert(std::is_same_v<std::invoke_result_t<TestFunc, Edge>, bool>);
 
     for (const auto& edge_type : GetDistinctEdgeTypes()) {
-      for (auto e : FindAllEdgesWithType(src, dst, edge_type)) {
+      for (auto e : FindAllEdges(src, dst, edge_type)) {
         if (func(e)) {
           return true;
         }
@@ -1021,12 +1017,12 @@ public:
   bool IsConnected(Node src, Node dst) const {
     // trivial check; can't be connected if degree is 0
 
-    if (degree(src) == 0ul) {
+    if (OutDegree(src) == 0ul) {
       return false;
     }
 
     for (const auto& edge_type : GetDistinctEdgeTypes()) {
-      if (IsConnectedWithEdgeType(src, dst, edge_type)) {
+      if (IsConnected(src, dst, edge_type)) {
         return true;
       }
     }
@@ -1095,13 +1091,11 @@ public:
 
   /// @param node node to get degree for
   /// @returns Degree of node N
-  auto degree(const Node& node) const noexcept { return topo().degree(node); }
-
-  auto nodes(const Node& begin, const Node& end) const noexcept {
-    return topo().nodes(begin, end);
+  auto OutDegree(const Node& node) const noexcept {
+    return topo().OutDegree(node);
   }
 
-  auto all_nodes() const noexcept { return topo().all_nodes(); }
+  auto Nodes() const noexcept { return topo().Nodes(); }
 
   // Standard container concepts
 
@@ -1113,19 +1107,19 @@ public:
 
   auto empty() const noexcept { return topo().empty(); }
 
-  auto edge_property_index(const Edge& e) const noexcept {
-    return topo().edge_property_index(e);
+  auto GetOutEdgePropertyIndex(const Edge& e) const noexcept {
+    return topo().GetOutEdgePropertyIndex(e);
   }
 
-  auto node_property_index(const Node& nid) const noexcept {
-    return topo().node_property_index(nid);
+  auto GetNodePropertyIndex(const Node& nid) const noexcept {
+    return topo().GetNodePropertyIndex(nid);
   }
-  auto original_node_id(const Node& nid) const noexcept {
-    return topo().original_node_id(nid);
+  auto GetLocalNodeID(const Node& nid) const noexcept {
+    return topo().GetLocalNodeID(nid);
   }
 
-  auto original_edge_id(const Edge& eid) const noexcept {
-    return topo().original_edge_id(eid);
+  auto GetLocalOutEdgeID(const Edge& eid) const noexcept {
+    return topo().GetLocalOutEdgeID(eid);
   }
   void Print() const noexcept { topo_ptr_->Print(); }
 
@@ -1165,13 +1159,11 @@ public:
 
   /// @param node node to get degree for
   /// @returns Degree of node N
-  auto degree(const Node& node) const noexcept { return topo().degree(node); }
-
-  auto nodes(const Node& begin, const Node& end) const noexcept {
-    return topo().nodes(begin, end);
+  auto OutDegree(const Node& node) const noexcept {
+    return topo().OutDegree(node);
   }
 
-  auto all_nodes() const noexcept { return topo().all_nodes(); }
+  auto Nodes() const noexcept { return topo().Nodes(); }
 
   auto OutEdges() const noexcept { return topo().OutEdges(); }
 
@@ -1185,12 +1177,12 @@ public:
 
   auto empty() const noexcept { return topo().empty(); }
 
-  auto edge_property_index(const Edge& e) const noexcept {
-    return topo().edge_property_index(e);
+  auto GetOutEdgePropertyIndex(const Edge& e) const noexcept {
+    return topo().GetOutEdgePropertyIndex(e);
   }
 
-  auto node_property_index(const Node& nid) const noexcept {
-    return topo().node_property_index(nid);
+  auto GetNodePropertyIndex(const Node& nid) const noexcept {
+    return topo().GetNodePropertyIndex(nid);
   }
   auto projected_to_original_node_id(const Node& nid) const noexcept {
     return topo().projected_to_original_node_id(nid);
@@ -1247,21 +1239,23 @@ public:
     return in().OutEdges(node);
   }
 
-  auto in_degree(const GraphTopologyTypes::Node& node) const noexcept {
-    return in().degree(node);
+  auto InDegree(const GraphTopologyTypes::Node& node) const noexcept {
+    return in().OutDegree(node);
   }
 
   auto InEdgeSrc(const GraphTopologyTypes::Edge& edge_id) const noexcept {
     return in().OutEdgeDst(edge_id);
   }
 
-  auto in_edge_property_index(
+  // TODO(yan): This will become GetEdgePropertyIndex(InEdgeHandle) once we
+  // introduce new opaque indexing types.
+  auto GetInEdgePropertyIndex(
       const GraphTopologyTypes::Edge& eid) const noexcept {
-    return in().edge_property_index(eid);
+    return in().GetOutEdgePropertyIndex(eid);
   }
 
-  auto original_in_edge_id(const GraphTopologyTypes::Edge& eid) const noexcept {
-    return in().original_edge_id(eid);
+  auto GetLocalInEdgeID(const GraphTopologyTypes::Edge& eid) const noexcept {
+    return in().GetLocalOutEdgeID(eid);
   }
 
 protected:
@@ -1301,11 +1295,6 @@ public:
     return MakeDisjointEdgesRange(out().OutEdges(node), in().OutEdges(node));
   }
 
-  bool is_in_edge(const Edge& eid) const noexcept {
-    KATANA_LOG_DEBUG_ASSERT(out().NumEdges() > 0);
-    return eid >= fake_id_offset();
-  }
-
   Node UndirectedEdgeNeighbor(Edge eid) const noexcept {
     if (is_in_edge(eid)) {
       return in().OutEdgeDst(real_in_edge_id(eid));
@@ -1313,12 +1302,9 @@ public:
     return out().OutEdgeDst(eid);
   }
 
-  nodes_range nodes(Node begin, Node end) const noexcept {
-    return MakeStandardRange<node_iterator>(begin, end);
-  }
-
-  nodes_range all_nodes() const noexcept {
-    return nodes(Node{0}, static_cast<Node>(NumNodes()));
+  nodes_range Nodes() const noexcept {
+    return MakeStandardRange<node_iterator>(
+        Node{0}, static_cast<Node>(NumNodes()));
   }
 
   auto OutEdges() const noexcept {
@@ -1339,31 +1325,33 @@ public:
 
   ///@param node node to get degree for
   ///@returns Degree of node N
-  size_t degree(Node node) const noexcept {
+  size_t UndirectedDegree(Node node) const noexcept {
     return UndirectedEdges(node).size();
   }
 
-  PropertyIndex edge_property_index(const Edge& eid) const noexcept {
+  // TODO(yan): This will become GetEdgePropertyIndex(UndirectedEdgeHandle) once we
+  // introduce new opaque indexing types.
+  PropertyIndex GetUndirectedEdgePropertyIndex(const Edge& eid) const noexcept {
     if (is_in_edge(eid)) {
-      return in().edge_property_index(real_in_edge_id(eid));
+      return in().GetOutEdgePropertyIndex(real_in_edge_id(eid));
     }
-    return out().edge_property_index(eid);
+    return out().GetOutEdgePropertyIndex(eid);
   }
 
-  PropertyIndex node_property_index(const Node& nid) const noexcept {
+  PropertyIndex GetNodePropertyIndex(const Node& nid) const noexcept {
     KATANA_LOG_DEBUG_ASSERT(
-        out().node_property_index(nid) == in().node_property_index(nid));
-    return out().node_property_index(nid);
+        out().GetNodePropertyIndex(nid) == in().GetNodePropertyIndex(nid));
+    return out().GetNodePropertyIndex(nid);
   }
 
   // TODO(amber): These two methods are a short term fix. The nature of
   // PropertyIndex is expected to change post grouping of properties.
-  Node original_node_id(const Node& nid) const noexcept {
-    return static_cast<Node>(node_property_index(nid));
+  Node GetLocalNodeID(const Node& nid) const noexcept {
+    return static_cast<Node>(GetNodePropertyIndex(nid));
   }
 
-  Edge original_edge_id(const Edge& eid) const noexcept {
-    return edge_property_index(eid);
+  Edge GetLocalUndirectedEdgeID(const Edge& eid) const noexcept {
+    return GetUndirectedEdgePropertyIndex(eid);
   }
 
 protected:
@@ -1371,6 +1359,11 @@ protected:
   const InTopo& in() const noexcept { return *in_topo_; }
 
 private:
+  bool is_in_edge(const Edge& eid) const noexcept {
+    KATANA_LOG_DEBUG_ASSERT(out().NumEdges() > 0);
+    return eid >= fake_id_offset();
+  }
+
   Edge fake_id_offset() const noexcept {
     return out().NumEdges() +
            1;  // +1 so that last edge iterator of out() is different from first edge of in()
@@ -1418,16 +1411,16 @@ public:
         katana::RDGTopology::EdgeSortKind::kSortedByDestID));
   }
 
-  auto find_edge(const Node& src, const Node& dst) const noexcept {
-    return Base::topo().find_edge(src, dst);
+  auto FindEdge(const Node& src, const Node& dst) const noexcept {
+    return Base::topo().FindEdge(src, dst);
   }
 
-  auto has_edge(const Node& src, const Node& dst) const noexcept {
-    return Base::topo().has_edge(src, dst);
+  auto HasEdge(const Node& src, const Node& dst) const noexcept {
+    return Base::topo().HasEdge(src, dst);
   }
 
-  auto find_edges(const Node& src, const Node& dst) const noexcept {
-    return Base::topo().find_edges(src, dst);
+  auto FindAllEdges(const Node& src, const Node& dst) const noexcept {
+    return Base::topo().FindAllEdges(src, dst);
   }
 };
 
@@ -1465,43 +1458,37 @@ public:
 
   auto InEdges(Node N) const noexcept { return Base::in().OutEdges(N); }
 
-  auto degree(Node N, const EntityTypeID& edge_type) const noexcept {
-    return Base::out().degree(N, edge_type);
+  auto OutDegree(Node N, const EntityTypeID& edge_type) const noexcept {
+    return Base::out().OutDegree(N, edge_type);
   }
 
-  auto degree(Node N) const noexcept { return Base::out().degree(N); }
+  auto OutDegree(Node N) const noexcept { return Base::out().OutDegree(N); }
 
-  auto in_degree(Node N, const EntityTypeID& edge_type) const noexcept {
-    return Base::in().degree(N, edge_type);
+  auto InDegree(Node N, const EntityTypeID& edge_type) const noexcept {
+    return Base::in().OutDegree(N, edge_type);
   }
 
-  auto in_degree(Node N) const noexcept { return Base::in().degree(N); }
+  auto InDegree(Node N) const noexcept { return Base::in().OutDegree(N); }
 
-  auto FindAllEdgesWithType(
+  auto FindAllEdges(
       const Node& src, const Node& dst,
       const EntityTypeID& edge_type) const noexcept {
-    return Base::out().FindAllEdgesWithType(src, dst, edge_type);
-  }
-
-  auto FindAllInEdgesWithType(
-      const Node& src, const Node& dst,
-      const EntityTypeID& edge_type) const noexcept {
-    return Base::in().FindAllEdgesWithType(src, dst, edge_type);
+    return Base::out().FindAllEdges(src, dst, edge_type);
   }
 
   /// Returns an edge iterator to an edge with some node and key by
   /// searching for the key via the node's outgoing or incoming edges.
   /// If not found, returns nothing.
-  edges_range FindAllEdgesSingleType(Node src, Node dst) const {
+  edges_range FindAllEdges(Node src, Node dst) const {
     // TODO(amber): Similar to IsConnectedWithEdgeType, we should be able to switch
-    // between searching out going topology or incoming topology. However, incoming
+    // between searching outgoing topology or incoming topology. However, incoming
     // topology will return a different range of incoming edges instead of outgoing
     // edges. Can we convert easily between outing and incoming edge range
-    if (Base::out().degree(src) == 0 || Base::in().degree(dst) == 0) {
+    if (Base::out().OutDegree(src) == 0 || Base::in().OutDegree(dst) == 0) {
       return MakeStandardRange<edge_iterator>(Edge{0}, Edge{0});
     }
 
-    return Base::out().FindAllEdgesSingleType(src, dst);
+    return Base::out().FindAllEdges(src, dst);
   }
 
   /// Check if vertex src is connected to vertex dst with the given edge edge_type
@@ -1510,18 +1497,17 @@ public:
   /// @param dst destination node of the edge
   /// @param edge_type edge_type of the edge
   /// @returns true iff the edge exists
-  bool IsConnectedWithEdgeType(
-      Node src, Node dst, const EntityTypeID& edge_type) const {
-    const auto d_out = Base::out().degree(src, edge_type);
-    const auto d_in = Base::in().degree(dst, edge_type);
+  bool IsConnected(Node src, Node dst, const EntityTypeID& edge_type) const {
+    const auto d_out = OutDegree(src, edge_type);
+    const auto d_in = InDegree(dst, edge_type);
     if (d_out == 0 || d_in == 0) {
       return false;
     }
 
     if (d_out < d_in) {
-      return Base::out().IsConnectedWithEdgeType(src, dst, edge_type);
+      return Base::out().IsConnected(src, dst, edge_type);
     } else {
-      return Base::in().IsConnectedWithEdgeType(dst, src, edge_type);
+      return Base::in().IsConnected(dst, src, edge_type);
     }
   }
 
@@ -1534,8 +1520,8 @@ public:
   template <typename TestFunc>
   bool HasEdgeSatisfyingPredicate(
       Node src, Node dst, const TestFunc& func) const {
-    const auto d_out = Base::out().degree(src);
-    const auto d_in = Base::in().degree(dst);
+    const auto d_out = OutDegree(src);
+    const auto d_in = InDegree(dst);
     if (d_out == 0 || d_in == 0) {
       return false;
     }
@@ -1584,8 +1570,8 @@ public:
   /// @param dst destination node of the edge
   /// @returns true iff the edge exists
   bool IsConnected(Node src, Node dst) const {
-    const auto d_out = Base::out().degree(src);
-    const auto d_in = Base::in().degree(dst);
+    const auto d_out = OutDegree(src);
+    const auto d_in = InDegree(dst);
     if (d_out == 0 || d_in == 0) {
       return false;
     }
@@ -1602,9 +1588,9 @@ template <typename Graph>
 using has_undirected_t =
     decltype(std::declval<Graph>().UndirectedEdges(typename Graph::Node()));
 
-template <typename Graph, typename GNode = typename Graph::Node>
+template <typename Graph>
 auto
-Edges(const Graph& graph, GNode node) {
+Edges(const Graph& graph, typename Graph::Node node) {
   if constexpr (katana::is_detected_v<has_undirected_t, Graph>) {
     return graph.UndirectedEdges(node);
   } else {
@@ -1612,13 +1598,23 @@ Edges(const Graph& graph, GNode node) {
   }
 }
 
-template <typename Graph, typename GEdge>
+template <typename Graph>
 auto
-EdgeDst(const Graph& graph, GEdge edge) {
+EdgeDst(const Graph& graph, typename Graph::Edge edge) {
   if constexpr (katana::is_detected_v<has_undirected_t, Graph>) {
     return graph.UndirectedEdgeNeighbor(edge);
   } else {
     return graph.OutEdgeDst(edge);
+  }
+}
+
+template <typename Graph>
+auto
+Degree(const Graph& graph, typename Graph::Node node) {
+  if constexpr (katana::is_detected_v<has_undirected_t, Graph>) {
+    return graph.UndirectedDegree(node);
+  } else {
+    return graph.OutDegree(node);
   }
 }
 

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -531,13 +531,13 @@ public:
 
   /// \return returns the most specific node entity type for @param node
   EntityTypeID GetTypeOfNode(Node node) const {
-    auto idx = node_property_index(node);
+    auto idx = GetNodePropertyIndex(node);
     return node_entity_type_ids_[idx];
   }
 
   /// \return returns the most specific edge entity type for @param edge
   EntityTypeID GetTypeOfEdgeFromTopoIndex(Edge edge) const {
-    auto idx = edge_property_index(edge);
+    auto idx = GetOutEdgePropertyIndex(edge);
     return GetTypeOfEdgeFromPropertyIndex(idx);
   }
 
@@ -697,14 +697,14 @@ public:
     return edge_entity_type_manager_;
   }
 
-  GraphTopology::PropertyIndex edge_property_index(
+  GraphTopology::PropertyIndex GetOutEdgePropertyIndex(
       const Edge& eid) const noexcept {
-    return topology().edge_property_index(eid);
+    return topology().GetOutEdgePropertyIndex(eid);
   }
 
-  GraphTopology::PropertyIndex node_property_index(
+  GraphTopology::PropertyIndex GetNodePropertyIndex(
       const Node& nid) const noexcept {
-    return topology().node_property_index(nid);
+    return topology().GetNodePropertyIndex(nid);
   }
 
   /// Add Node properties that do not exist in the current graph
@@ -840,7 +840,7 @@ public:
 
   node_iterator end() const { return topology().end(); }
 
-  nodes_range all_nodes() const noexcept { return topology().all_nodes(); }
+  nodes_range Nodes() const noexcept { return topology().Nodes(); }
 
   edges_range OutEdges() const noexcept { return topology().OutEdges(); }
 

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -537,7 +537,7 @@ public:
 
   /// \return returns the most specific edge entity type for @param edge
   EntityTypeID GetTypeOfEdgeFromTopoIndex(Edge edge) const {
-    auto idx = GetOutEdgePropertyIndex(edge);
+    auto idx = GetEdgePropertyIndexFromOutEdge(edge);
     return GetTypeOfEdgeFromPropertyIndex(idx);
   }
 
@@ -697,9 +697,9 @@ public:
     return edge_entity_type_manager_;
   }
 
-  GraphTopology::PropertyIndex GetOutEdgePropertyIndex(
+  GraphTopology::PropertyIndex GetEdgePropertyIndexFromOutEdge(
       const Edge& eid) const noexcept {
-    return topology().GetOutEdgePropertyIndex(eid);
+    return topology().GetEdgePropertyIndexFromOutEdge(eid);
   }
 
   GraphTopology::PropertyIndex GetNodePropertyIndex(

--- a/libgraph/include/katana/TopologyGeneration.h
+++ b/libgraph/include/katana/TopologyGeneration.h
@@ -120,7 +120,7 @@ AddGraphProperties(
     auto builder = generator.MakeBuilder();
     if constexpr (is_node) {
       KATANA_CHECKED(builder->Reserve(pg->NumNodes()));
-      for (Node n : pg->all_nodes()) {
+      for (Node n : pg->Nodes()) {
         KATANA_CHECKED(builder->Append(generator(n)));
       }
     } else {

--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -112,7 +112,7 @@ public:
   PropertyReferenceType<EdgeIndex> GetEdgeData(const edge_iterator& edge) {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
     return std::get<prop_col_index>(edge_view_)
-        .GetValue(pg_->GetOutEdgePropertyIndex(*edge));
+        .GetValue(pg_->GetEdgePropertyIndexFromOutEdge(*edge));
   }
 
   /**
@@ -126,7 +126,7 @@ public:
       const edge_iterator& edge) const {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
     return std::get<prop_col_index>(edge_view_)
-        .GetValue(pg_->GetOutEdgePropertyIndex(*edge));
+        .GetValue(pg_->GetEdgePropertyIndexFromOutEdge(*edge));
   }
 
   /**
@@ -239,10 +239,10 @@ public:
 
     if constexpr (katana::is_detected_v<has_undirected_t, PGView>) {
       return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetUndirectedEdgePropertyIndex(edge));
+          .GetValue(PGView::GetEdgePropertyIndexFromUndirectedEdge(edge));
     } else {
       return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetOutEdgePropertyIndex(edge));
+          .GetValue(PGView::GetEdgePropertyIndexFromOutEdge(edge));
     }
   }
 
@@ -258,10 +258,10 @@ public:
 
     if constexpr (katana::is_detected_v<has_undirected_t, PGView>) {
       return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetUndirectedEdgePropertyIndex(edge));
+          .GetValue(PGView::GetEdgePropertyIndexFromUndirectedEdge(edge));
     } else {
       return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetOutEdgePropertyIndex(edge));
+          .GetValue(PGView::GetEdgePropertyIndexFromOutEdge(edge));
     }
   }
 

--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -77,7 +77,7 @@ public:
   PropertyReferenceType<NodeIndex> GetData(const Node& node) {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
     return std::get<prop_col_index>(node_view_)
-        .GetValue(pg_->node_property_index(node));
+        .GetValue(pg_->GetNodePropertyIndex(node));
   }
   template <typename NodeIndex>
   PropertyReferenceType<NodeIndex> GetData(const node_iterator& node) {
@@ -94,7 +94,7 @@ public:
   PropertyConstReferenceType<NodeIndex> GetData(const Node& node) const {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
     return std::get<prop_col_index>(node_view_)
-        .GetValue(pg_->node_property_index(node));
+        .GetValue(pg_->GetNodePropertyIndex(node));
   }
   template <typename NodeIndex>
   PropertyConstReferenceType<NodeIndex> GetData(
@@ -112,7 +112,7 @@ public:
   PropertyReferenceType<EdgeIndex> GetEdgeData(const edge_iterator& edge) {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
     return std::get<prop_col_index>(edge_view_)
-        .GetValue(pg_->edge_property_index(*edge));
+        .GetValue(pg_->GetOutEdgePropertyIndex(*edge));
   }
 
   /**
@@ -126,7 +126,7 @@ public:
       const edge_iterator& edge) const {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
     return std::get<prop_col_index>(edge_view_)
-        .GetValue(pg_->edge_property_index(*edge));
+        .GetValue(pg_->GetOutEdgePropertyIndex(*edge));
   }
 
   /**
@@ -139,7 +139,9 @@ public:
     return pg_->topology().OutEdgeDst(e);
   }
 
-  size_t degree(Node n) const noexcept { return pg_->topology().degree(n); }
+  size_t OutDegree(Node n) const noexcept {
+    return pg_->topology().OutDegree(n);
+  }
 
   uint64_t NumNodes() const { return pg_->NumNodes(); }
   uint64_t NumEdges() const { return pg_->NumEdges(); }
@@ -159,7 +161,7 @@ public:
    */
   edges_range OutEdges(Node node) const { return pg_->OutEdges(node); }
 
-  nodes_range all_nodes() const noexcept { return pg_->topology().all_nodes(); }
+  nodes_range Nodes() const noexcept { return pg_->topology().Nodes(); }
   /**
    * Accessor for the underlying PropertyGraph.
    *
@@ -209,7 +211,7 @@ public:
   PropertyReferenceType<NodeIndex> GetData(const Node& node) {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
     return std::get<prop_col_index>(node_view_)
-        .GetValue(PGView::node_property_index(node));
+        .GetValue(PGView::GetNodePropertyIndex(node));
   }
 
   /**
@@ -222,7 +224,7 @@ public:
   PropertyConstReferenceType<NodeIndex> GetData(const Node& node) const {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
     return std::get<prop_col_index>(node_view_)
-        .GetValue(PGView::node_property_index(node));
+        .GetValue(PGView::GetNodePropertyIndex(node));
   }
 
   /**
@@ -234,8 +236,14 @@ public:
   template <typename EdgeIndex>
   PropertyReferenceType<EdgeIndex> GetEdgeData(const Edge& edge) {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
-    return std::get<prop_col_index>(edge_view_)
-        .GetValue(PGView::edge_property_index(edge));
+
+    if constexpr (katana::is_detected_v<has_undirected_t, PGView>) {
+      return std::get<prop_col_index>(edge_view_)
+          .GetValue(PGView::GetUndirectedEdgePropertyIndex(edge));
+    } else {
+      return std::get<prop_col_index>(edge_view_)
+          .GetValue(PGView::GetOutEdgePropertyIndex(edge));
+    }
   }
 
   /**
@@ -247,8 +255,14 @@ public:
   template <typename EdgeIndex>
   PropertyConstReferenceType<EdgeIndex> GetEdgeData(const Edge& edge) const {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
-    return std::get<prop_col_index>(edge_view_)
-        .GetValue(PGView::edge_property_index(edge));
+
+    if constexpr (katana::is_detected_v<has_undirected_t, PGView>) {
+      return std::get<prop_col_index>(edge_view_)
+          .GetValue(PGView::GetUndirectedEdgePropertyIndex(edge));
+    } else {
+      return std::get<prop_col_index>(edge_view_)
+          .GetValue(PGView::GetOutEdgePropertyIndex(edge));
+    }
   }
 
   static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -139,7 +139,7 @@ struct ClusteringImplementationBase {
     katana::do_all(katana::iterate(*graph), [&](GNode n) {
       auto& n_data_curr_comm_id =
           graph->template GetData<CurrentCommunityID>(n);
-      uint64_t degree = graph->degree(n);
+      uint64_t degree = Degree(*graph, n);
       if (degree == 0) {
         isolated_nodes += 1;
         n_data_curr_comm_id = UNASSIGNED;
@@ -148,7 +148,7 @@ struct ClusteringImplementationBase {
           // Check if the destination has degree greater than one
           auto edge = Edges(*graph, n).begin();
           auto dst = EdgeDst(*graph, *edge);
-          uint64_t dst_degree = graph->degree(dst);
+          uint64_t dst_degree = Degree(*graph, dst);
           if ((dst_degree > 1 || (n > dst))) {
             isolated_nodes += 1;
             n_data_curr_comm_id =
@@ -440,7 +440,7 @@ struct ClusteringImplementationBase {
     uint64_t num_unique_clusters = 0;
 
     // TODO(amber): parallelize
-    for (GNode n : graph->all_nodes()) {
+    for (GNode n : graph->Nodes()) {
       auto& n_data_curr_comm_id = graph->template GetData<CommunityIDType>(n);
       if (n_data_curr_comm_id != UNASSIGNED) {
         auto stored_already = cluster_local_map.find(n_data_curr_comm_id);

--- a/libgraph/src/GraphTopology.cpp
+++ b/libgraph/src/GraphTopology.cpp
@@ -539,7 +539,7 @@ katana::EdgeTypeAwareTopology::CreatePerEdgeTypeAdjacencyIndex(
           // Since we sort the edges, we must use the
           // edge_property_index because EdgeShuffleTopology rearranges the edges
           const auto type = pg.GetTypeOfEdgeFromPropertyIndex(
-              e_topo.GetOutEdgePropertyIndex(e));
+              e_topo.GetEdgePropertyIndexFromOutEdge(e));
           while (type != edge_type_index.GetType(index)) {
             adj_indices[offset + index] = e;
             index++;

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -978,7 +978,7 @@ katana::SortAllEdgesByDest(katana::PropertyGraph* pg) {
   auto* out_dests_data = const_cast<GraphTopology::Node*>(topo.DestData());
 
   katana::do_all(
-      katana::iterate(pg->topology().all_nodes()),
+      katana::iterate(pg->topology().Nodes()),
       [&](GraphTopology::Node n) {
         const auto e_beg = *pg->topology().OutEdges(n).begin();
         const auto e_end = *pg->topology().OutEdges(n).end();
@@ -1044,8 +1044,8 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
   katana::NUMAArray<DegreeNodePair> dn_pairs;
   dn_pairs.allocateInterleaved(num_nodes);
 
-  katana::do_all(katana::iterate(topo.all_nodes()), [&](auto node) {
-    size_t node_degree = topo.degree(node);
+  katana::do_all(katana::iterate(topo.Nodes()), [&](auto node) {
+    size_t node_degree = topo.OutDegree(node);
     dn_pairs[node] = DegreeNodePair(node_degree, node);
   });
 
@@ -1077,7 +1077,7 @@ katana::SortNodesByDegree(katana::PropertyGraph* pg) {
   auto* out_indices_data = const_cast<GraphTopology::Edge*>(topo.AdjData());
 
   katana::do_all(
-      katana::iterate(topo.all_nodes()),
+      katana::iterate(topo.Nodes()),
       [&](auto old_node_id) {
         uint32_t new_node_id = old_to_new_mapping[old_node_id];
 
@@ -1127,12 +1127,12 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
 
   out_indices.allocateInterleaved(topology.NumNodes());
   // Store the out-degree of nodes from original graph
-  katana::do_all(katana::iterate(topology.all_nodes()), [&](auto n) {
-    out_indices[n] = topology.degree(n);
+  katana::do_all(katana::iterate(topology.Nodes()), [&](auto n) {
+    out_indices[n] = topology.OutDegree(n);
   });
 
   katana::do_all(
-      katana::iterate(topology.all_nodes()),
+      katana::iterate(topology.Nodes()),
       [&](auto n) {
         // update the out_indices for the symmetric topology
         for (auto e : topology.OutEdges(n)) {
@@ -1164,7 +1164,7 @@ katana::CreateSymmetricGraph(katana::PropertyGraph* pg) {
   out_dests.allocateInterleaved(num_edges_symmetric);
   // Update graph topology with the original edges + reverse edges
   katana::do_all(
-      katana::iterate(topology.all_nodes()),
+      katana::iterate(topology.Nodes()),
       [&](auto src) {
         // get all outgoing edges (excluding self edges) of a particular
         // node and add reverse edges.
@@ -1238,7 +1238,7 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
   // Update out_dests with the new destination ids
   // of the transposed graphs
   katana::do_all(
-      katana::iterate(topology.all_nodes()),
+      katana::iterate(topology.Nodes()),
       [&](auto src) {
         // get all outgoing edges of a particular
         // node and reverse the edges.

--- a/libgraph/src/analytics/bfs/bfs.cpp
+++ b/libgraph/src/analytics/bfs/bfs.cpp
@@ -250,7 +250,7 @@ SynchronousDirectOpt(
   work_items += 1;
 
   int64_t edges_to_check = num_edges;
-  int64_t scout_count = bidir_view.degree(source);
+  int64_t scout_count = bidir_view.OutDegree(source);
   uint64_t old_num_work_items{0};
 
   katana::GAccumulator<uint64_t> writes_pull;
@@ -309,7 +309,7 @@ SynchronousDirectOpt(
                 GNode old_parent = ddata;
                 if (__sync_bool_compare_and_swap(&ddata, old_parent, src)) {
                   next_frontier->push(dst);
-                  work_items += bidir_view.degree(dst);
+                  work_items += bidir_view.OutDegree(dst);
                 }
               }
             }
@@ -343,7 +343,7 @@ ComputeParentFromDistance(
     const katana::NUMAArray<Dist>& node_dist, const GNode source) {
   (*node_parent)[source] = source;
   katana::do_all(
-      katana::iterate(bidir_view.all_nodes()),
+      katana::iterate(bidir_view.Nodes()),
       [&](const GNode v) {
         GNode& v_parent = (*node_parent)[v];
         Dist v_dist = node_dist[v];

--- a/libgraph/src/analytics/independent_set/independent_set.cpp
+++ b/libgraph/src/analytics/independent_set/independent_set.cpp
@@ -451,7 +451,7 @@ struct EdgeTiledPrioAlgo {
           auto beg = rng.begin();
           const auto end = rng.end();
 
-          float degree = float(graph->degree(src));
+          float degree = float(graph->OutDegree(src));
           float x = degree - hash(src) * kHashScale;
           int res = round(scale_avg / (avg_degree + x));
           uint8_t val = (res + res) | 0x03;

--- a/libgraph/src/analytics/jaccard/jaccard.cpp
+++ b/libgraph/src/analytics/jaccard/jaccard.cpp
@@ -110,14 +110,14 @@ JaccardImpl(Graph& graph, size_t compare_node, JaccardPlan /*plan*/) {
   std::advance(it, compare_node);
   Graph::Node base = *it;
 
-  uint32_t base_size = graph.degree(base);
+  uint32_t base_size = graph.OutDegree(base);
 
   IntersectAlgorithm intersect_with_base{graph, base};
 
   // Compute the similarity for each node
   katana::do_all(katana::iterate(graph), [&](const GNode& n2) {
     double& n2_data = graph.GetData<JaccardSimilarity>(n2);
-    uint32_t n2_size = graph.degree(n2);
+    uint32_t n2_size = graph.OutDegree(n2);
     // Count the number of neighbors of n2 and the number that are shared
     // with base
     uint32_t intersection_size = intersect_with_base(n2);

--- a/libgraph/src/analytics/k_core/k_core.cpp
+++ b/libgraph/src/analytics/k_core/k_core.cpp
@@ -54,7 +54,7 @@ DegreeCounting(GraphTy* graph) {
       [&](const GNode& node) {
         auto& node_current_degree =
             graph->template GetData<KCoreNodeCurrentDegree>(node);
-        node_current_degree.store(graph->degree(node));
+        node_current_degree.store(Degree(*graph, node));
       },
       katana::loopname("DegreeCounting"), katana::no_stats());
 }

--- a/libgraph/src/analytics/k_truss/k_truss.cpp
+++ b/libgraph/src/analytics/k_truss/k_truss.cpp
@@ -185,11 +185,11 @@ BSPTrussJacobiAlgo(SortedGraphView* g, uint32_t k) {
     katana::do_all(
         katana::iterate(unsupported),
         [&](Edge e) {
-          KATANA_LOG_DEBUG_ASSERT(g->has_edge(e.first, e.second));
-          KATANA_LOG_DEBUG_ASSERT(g->has_edge(e.second, e.first));
-          g->template GetEdgeData<EdgeFlag>(*g->find_edge(e.first, e.second)) =
+          KATANA_LOG_DEBUG_ASSERT(g->HasEdge(e.first, e.second));
+          KATANA_LOG_DEBUG_ASSERT(g->HasEdge(e.second, e.first));
+          g->template GetEdgeData<EdgeFlag>(*g->FindEdge(e.first, e.second)) =
               removed;
-          g->template GetEdgeData<EdgeFlag>(*g->find_edge(e.second, e.first)) =
+          g->template GetEdgeData<EdgeFlag>(*g->FindEdge(e.second, e.first)) =
               removed;
         },
         katana::steal());
@@ -210,11 +210,11 @@ struct KeepSupportedEdges {
     if (IsSupportNoLessThanJ(*g, e.first, e.second, j)) {
       s.push_back(e);
     } else {
-      KATANA_LOG_DEBUG_ASSERT(g->has_edge(e.first, e.second));
-      KATANA_LOG_DEBUG_ASSERT(g->has_edge(e.second, e.first));
-      g->template GetEdgeData<EdgeFlag>(*g->find_edge(e.first, e.second)) =
+      KATANA_LOG_DEBUG_ASSERT(g->HasEdge(e.first, e.second));
+      KATANA_LOG_DEBUG_ASSERT(g->HasEdge(e.second, e.first));
+      g->template GetEdgeData<EdgeFlag>(*g->FindEdge(e.first, e.second)) =
           removed;
-      g->template GetEdgeData<EdgeFlag>(*g->find_edge(e.second, e.first)) =
+      g->template GetEdgeData<EdgeFlag>(*g->FindEdge(e.second, e.first)) =
           removed;
     }
   }
@@ -279,11 +279,11 @@ struct KeepValidNodes {
     } else {
       for (auto e : g->OutEdges(n)) {
         auto dest = g->OutEdgeDst(e);
-        KATANA_LOG_DEBUG_ASSERT(g->has_edge(n, dest));
-        KATANA_LOG_DEBUG_ASSERT(g->has_edge(dest, n));
+        KATANA_LOG_DEBUG_ASSERT(g->HasEdge(n, dest));
+        KATANA_LOG_DEBUG_ASSERT(g->HasEdge(dest, n));
 
-        g->template GetEdgeData<EdgeFlag>(*g->find_edge(n, dest)) = removed;
-        g->template GetEdgeData<EdgeFlag>(*g->find_edge(dest, n)) = removed;
+        g->template GetEdgeData<EdgeFlag>(*g->FindEdge(n, dest)) = removed;
+        g->template GetEdgeData<EdgeFlag>(*g->FindEdge(dest, n)) = removed;
       }
     }
   }

--- a/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
+++ b/libgraph/src/analytics/leiden_clustering/leiden_clustering.cpp
@@ -112,7 +112,7 @@ struct LeidenClusteringImplementation
                 graph->template GetData<DegreeWeight<EdgeWeightType>>(n);
             auto& n_data_node_wt = graph->template GetData<NodeWeight>(n);
 
-            uint64_t degree = graph->degree(n);
+            uint64_t degree = Degree(*graph, n);
             uint64_t local_target = Base::UNASSIGNED;
             std::map<uint64_t, uint64_t>
                 cluster_local_map;  // Map each neighbor's cluster to local number:
@@ -273,7 +273,7 @@ struct LeidenClusteringImplementation
                   graph->template GetData<DegreeWeight<EdgeWeightType>>(n);
               auto& n_data_node_wt = graph->template GetData<NodeWeight>(n);
 
-              uint64_t degree = graph->degree(n);
+              uint64_t degree = Degree(*graph, n);
 
               std::map<uint64_t, uint64_t>
                   cluster_local_map;  // Map each neighbor's cluster to local number:

--- a/libgraph/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
+++ b/libgraph/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
@@ -92,7 +92,7 @@ struct LocalClusteringCoefficientAtomics {
     katana::do_all(
         katana::iterate(*graph),
         [&](Node n) {
-          auto degree = graph->degree(n);
+          auto degree = graph->OutDegree(n);
 
           graph->template GetData<NodeClusteringCoefficient>(n) =
               static_cast<double>(2 * per_node_triangles[n]) /
@@ -205,7 +205,7 @@ struct LocalClusteringCoefficientPerThread {
 
   void ComputeLocalClusteringCoefficient(SortedGraphView* graph) {
     katana::do_all(katana::iterate(*graph), [&](Node n) {
-      auto degree = graph->degree(n);
+      auto degree = graph->OutDegree(n);
       if (degree > 1) {
         graph->template GetData<NodeClusteringCoefficient>(n) =
             static_cast<double>(2 * node_triangle_count_[n]) /

--- a/libgraph/src/analytics/louvain_clustering/louvain_clustering.cpp
+++ b/libgraph/src/analytics/louvain_clustering/louvain_clustering.cpp
@@ -108,7 +108,7 @@ struct LouvainClusteringImplementation
             auto& n_data_degree_wt =
                 graph->template GetData<DegreeWeight<EdgeWeightType>>(n);
 
-            uint64_t degree = graph->degree(n);
+            uint64_t degree = Degree(*graph, n);
             uint64_t local_target = Base::UNASSIGNED;
             // TODO(amber): use scalable allocator with these containers
             std::map<uint64_t, uint64_t>
@@ -259,7 +259,7 @@ struct LouvainClusteringImplementation
               auto& n_data_degree_wt =
                   graph->template GetData<DegreeWeight<EdgeWeightType>>(n);
 
-              uint64_t degree = graph->degree(n);
+              uint64_t degree = Degree(*graph, n);
 
               // TODO(amber): use scalable allocators
               std::map<uint64_t, uint64_t>

--- a/libgraph/src/analytics/matrix_completion/matrix_completion.cpp
+++ b/libgraph/src/analytics/matrix_completion/matrix_completion.cpp
@@ -235,7 +235,7 @@ struct MatrixCompletionImplementation
 
       largest_node_id_per_thread[tid] = 0;
       for (GNode i = start; i < end; ++i) {
-        if (graph.degree(i)) {
+        if (graph.OutDegree(i)) {
           if (largest_node_id_per_thread[tid] < i)
             largest_node_id_per_thread[tid] = i;
         }

--- a/libgraph/src/analytics/pagerank/pagerank-push.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank-push.cpp
@@ -84,7 +84,7 @@ PagerankPushAsynchronous(
           PRTy old_residual = src_residual.exchange(0.0);
           auto& src_value = graph.GetData<NodeValue>(src);
           src_value += old_residual;
-          int src_nout = graph.degree(src);
+          int src_nout = graph.OutDegree(src);
           if (src_nout > 0) {
             PRTy delta = old_residual * plan.alpha() / src_nout;
             //! For each out-going neighbors.

--- a/libgraph/src/analytics/random_walks/random_walks.cpp
+++ b/libgraph/src/analytics/random_walks/random_walks.cpp
@@ -139,7 +139,7 @@ struct Node2VecAlgo {
                 if (nbr == prev) {
                   alpha = prob_backward;
                 }  //check if nbr is also a neighbor of the previous node on this walk
-                else if (graph.has_edge(prev, nbr)) {
+                else if (graph.HasEdge(prev, nbr)) {
                   alpha = 1.0;
                 } else {
                   alpha = prob_forward;
@@ -298,7 +298,7 @@ struct Edge2VecAlgo {
               if (nbr == prev) {
                 alpha = prob_backward;
               }  //check if nbr is also a neighbor of the previous node on this walk
-              else if (graph.has_edge(prev, nbr)) {
+              else if (graph.HasEdge(prev, nbr)) {
                 alpha = 1.0;
               } else {
                 alpha = prob_forward;
@@ -473,7 +473,7 @@ InitializeDegrees(const Graph& graph, katana::NUMAArray<uint64_t>* degree) {
   katana::do_all(katana::iterate(graph), [&](typename Graph::Node n) {
     // Treat this as O(1) time because subtracting iterators is just pointer
     // or number subtraction. So don't use steal().
-    (*degree)[n] = graph.degree(n);
+    (*degree)[n] = graph.OutDegree(n);
   });
 }
 

--- a/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
+++ b/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
@@ -54,7 +54,7 @@ SubGraphNodeSet(
         for (Node m = 0; m < num_nodes; ++m) {
           auto dest = node_set[m];
           // Binary search on the edges sorted by destination id
-          for (auto edge_it = graph.find_edge(src, dest);
+          for (auto edge_it = graph.FindEdge(src, dest);
                edge_it != last && graph.OutEdgeDst(*edge_it) == dest;
                ++edge_it) {
             subgraph_edges[n].push_back(m);

--- a/libgraph/test/property-graph-in-memory-props.cpp
+++ b/libgraph/test/property-graph-in-memory-props.cpp
@@ -35,7 +35,7 @@ TestNodeProps(std::unique_ptr<katana::PropertyGraph>&& pg) {
       std::static_pointer_cast<arrow::StringArray>(names->chunk(0));
 
   size_t i = 0;
-  for (Node n : pg->all_nodes()) {
+  for (Node n : pg->Nodes()) {
     int32_t expected_age = static_cast<int32_t>(n) * 2;
     std::string expected_name = fmt::format("Node {}", n);
 

--- a/libgraph/test/property-graph-topology.cpp
+++ b/libgraph/test/property-graph-topology.cpp
@@ -4,7 +4,7 @@
 
 void
 TestEdgeSource(const katana::GraphTopology& topo) noexcept {
-  for (auto node : topo.all_nodes()) {
+  for (auto node : topo.Nodes()) {
     for (auto e : topo.OutEdges(node)) {
       auto s = topo.GetEdgeSrc(e);
       KATANA_LOG_ASSERT(s == node);

--- a/libgraph/test/property-graph-undirected-view.cpp
+++ b/libgraph/test/property-graph-undirected-view.cpp
@@ -35,7 +35,7 @@ TestDegreeSum(std::unique_ptr<katana::PropertyGraph>&& pg) noexcept {
 
   auto graph = view_res.value();
 
-  for (Node src : graph.all_nodes()) {
+  for (Node src : graph.Nodes()) {
     uint32_t deg_sum = 0u;
     for (Edge e : graph.UndirectedEdges(src)) {
       Node dst = graph.UndirectedEdgeNeighbor(e);
@@ -43,12 +43,13 @@ TestDegreeSum(std::unique_ptr<katana::PropertyGraph>&& pg) noexcept {
     }
 
     graph.GetData<DegreeSum>(src) = deg_sum;
-    KATANA_LOG_VASSERT(deg_sum == graph.degree(src), "Sum should equal degree");
+    KATANA_LOG_VASSERT(
+        deg_sum == graph.UndirectedDegree(src), "Sum should equal degree");
   }
 
   uint32_t tot_deg_sum = 0u;
 
-  for (Node n : graph.all_nodes()) {
+  for (Node n : graph.Nodes()) {
     tot_deg_sum += graph.GetData<DegreeSum>(n);
   }
 

--- a/libgraph/test/storage-format-version-optional-topologies.h
+++ b/libgraph/test/storage-format-version-optional-topologies.h
@@ -21,9 +21,9 @@ verify_view(View generated_view, View loaded_view) {
   }
 
   auto beg_node = katana::make_zip_iterator(
-      generated_view.all_nodes().begin(), loaded_view.all_nodes().begin());
+      generated_view.Nodes().begin(), loaded_view.Nodes().begin());
   auto end_node = katana::make_zip_iterator(
-      generated_view.all_nodes().end(), loaded_view.all_nodes().end());
+      generated_view.Nodes().end(), loaded_view.Nodes().end());
 
   for (auto i = beg_node; i != end_node; i++) {
     KATANA_LOG_ASSERT(std::get<0>(*i) == std::get<1>(*i));


### PR DESCRIPTION
Renames the remaining topology and view methods in accordance with RFC-114:

- degree(Node) -> OutDegree(Node) / UndirectedDegree(Node)
- in_degree(Node) -> InDegree(Node)
- all_nodes() -> Nodes()
- edge_property_index(Edge) -> GetEdgePropertyIndexFromOutEdge(Edge) / GetEdgePropertyIndexFromUndirectedEdge(Edge)
- in_edge_property_index(Edge) -> GetEdgePropertyIndexFromInEdge(Edge)
- node_property_index() -> GetNodePropertyIndex(Node)
- original_node_id(Node) -> GetLocalNodeID(Node)
- original_edge_id(Edge) -> GetLocalEdgeIDFromOutEdge(Edge) / GetLocalEdgeIDFromUndirectedEdge(Edge)
- original_in_edge_id(Edge) -> GetLocalEdgeIDFromInEdge(Edge)
- find_edge(Node src, Node dst) -> FindEdge(Node src, Node dst)
- find_edges(Node src, Node dst) -> FindAllEdges(Node src, Node dst)
- has_edge(Node src, Node dst) -> HasEdge(Node src, Node dst)
- IsConnectedWithEdgeType(Node src, Node dst, EdgeType) -> HasEdge(Node src, Node dst, EdgeType)
- FindAllEdgesWithType(Node src, Node dst, EdgeType) -> FindAllEdges(Node src, Node dst, EdgeType)
