### PR TITLE
tracer: clearly mark tracer text output [KAT-1849]

### DIFF
--- a/libsupport/src/TextTracer.cpp
+++ b/libsupport/src/TextTracer.cpp
@@ -57,7 +57,8 @@ BuildText(
 
   fmt::format_to(
       std::back_inserter(buf),
-      "INFO: host={} ms={} max_mem_gb={:.3f} mem_gb={:.3f} arrow_mem_gb={:.3f}",
+      "TRACE: host={} ms={} max_mem_gb={:.3f} mem_gb={:.3f} "
+      "arrow_mem_gb={:.3f}",
       host_id, msec_since_begin,
       katana::ProgressTracer::GetMaxMem() / 1024.0 / 1024.0,
       katana::ProgressTracer::ParseProcSelfRssBytes() / 1024.0 / 1024.0 /


### PR DESCRIPTION
The hint for disabling the tracer will print once at the start of the first operation