### PR TITLE
remove redundant header from entity_type_id_array files KAT-2562

### DIFF
--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -92,9 +92,7 @@ WriteEntityTypeIDsArray(
     const katana::NUMAArray<katana::EntityTypeID>& entity_type_id_array) {
   auto ff = std::make_unique<katana::FileFrame>();
 
-  if (auto res = ff->Init(); !res) {
-    return res.error();
-  }
+  KATANA_CHECKED(ff->Init());
 
   katana::EntityTypeIDArrayHeader data[1] = {
       {.size = entity_type_id_array.size()}};

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -64,8 +64,8 @@ CheckTopology(
 /// favor of this method.
 katana::Result<katana::PropertyGraph::EntityTypeIDArray>
 MapEntityTypeIDsArray(
-                      const katana::FileView& file_view, size_t num_entries, bool rdg_unstable_format) {
-
+    const katana::FileView& file_view, size_t num_entries,
+    bool rdg_unstable_format) {
   if (file_view.size() == 0) {
     return katana::ErrorCode::InvalidArgument;
   }
@@ -76,15 +76,13 @@ MapEntityTypeIDsArray(
 
   const katana::EntityTypeID* type_IDs_array = nullptr;
 
-  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat) && rdg_unstable_format) {
+  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat) &&
+      rdg_unstable_format) {
     type_IDs_array = file_view.ptr<katana::EntityTypeID>();
-  }
-  else{
+  } else {
     const auto* data = file_view.ptr<katana::EntityTypeIDArrayHeader>();
-    type_IDs_array =
-        reinterpret_cast<const katana::EntityTypeID*>(&data[1]);
+    type_IDs_array = reinterpret_cast<const katana::EntityTypeID*>(&data[1]);
   }
-
 
   KATANA_LOG_DEBUG_ASSERT(type_IDs_array != nullptr);
 
@@ -102,7 +100,7 @@ WriteEntityTypeIDsArray(
 
   KATANA_CHECKED(ff->Init());
 
-  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)){
+  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)) {
     if (entity_type_id_array.size()) {
       const katana::EntityTypeID* raw = entity_type_id_array.data();
       auto buf = arrow::Buffer::Wrap(raw, entity_type_id_array.size());
@@ -111,8 +109,7 @@ WriteEntityTypeIDsArray(
         return katana::ArrowToKatana(aro_sts.code());
       }
     }
-  }
-  else{
+  } else {
     katana::EntityTypeIDArrayHeader data[1] = {
         {.size = entity_type_id_array.size()}};
     arrow::Status aro_sts =

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -23,6 +23,7 @@
 #include "katana/RDG.h"
 #include "katana/RDGManifest.h"
 #include "katana/RDGPrefix.h"
+#include "katana/RDGStorageFormatVersion.h"
 #include "katana/RDGTopology.h"
 #include "katana/Result.h"
 #include "katana/tsuba.h"
@@ -63,9 +64,7 @@ CheckTopology(
 /// favor of this method.
 katana::Result<katana::PropertyGraph::EntityTypeIDArray>
 MapEntityTypeIDsArray(
-    const katana::FileView& file_view) {
-  const auto* data = file_view.ptr<katana::EntityTypeIDArrayHeader>();
-  const auto header = data[0];
+                      const katana::FileView& file_view, size_t num_entries, bool rdg_unstable_format) {
 
   if (file_view.size() == 0) {
     return katana::ErrorCode::InvalidArgument;
@@ -73,16 +72,25 @@ MapEntityTypeIDsArray(
 
   // allocate type IDs array
   katana::PropertyGraph::EntityTypeIDArray entity_type_id_array;
-  entity_type_id_array.allocateInterleaved(header.size);
+  entity_type_id_array.allocateInterleaved(num_entries);
 
-  const katana::EntityTypeID* type_IDs_array =
-    reinterpret_cast<const katana::EntityTypeID*>(&data[1]);
+  const katana::EntityTypeID* type_IDs_array = nullptr;
+
+  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat) && rdg_unstable_format) {
+    type_IDs_array = file_view.ptr<katana::EntityTypeID>();
+  }
+  else{
+    const auto* data = file_view.ptr<katana::EntityTypeIDArrayHeader>();
+    type_IDs_array =
+        reinterpret_cast<const katana::EntityTypeID*>(&data[1]);
+  }
+
 
   KATANA_LOG_DEBUG_ASSERT(type_IDs_array != nullptr);
 
   katana::ParallelSTL::copy(
-                            &type_IDs_array[0], &type_IDs_array[header.size],
-                            entity_type_id_array.begin());
+      &type_IDs_array[0], &type_IDs_array[num_entries],
+      entity_type_id_array.begin());
 
   return katana::MakeResult(std::move(entity_type_id_array));
 }
@@ -94,23 +102,36 @@ WriteEntityTypeIDsArray(
 
   KATANA_CHECKED(ff->Init());
 
-  katana::EntityTypeIDArrayHeader data[1] = {
-      {.size = entity_type_id_array.size()}};
-  arrow::Status aro_sts =
-      ff->Write(&data, sizeof(katana::EntityTypeIDArrayHeader));
-
-  if (!aro_sts.ok()) {
-    return katana::ArrowToKatana(aro_sts.code());
+  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)){
+    if (entity_type_id_array.size()) {
+      const katana::EntityTypeID* raw = entity_type_id_array.data();
+      auto buf = arrow::Buffer::Wrap(raw, entity_type_id_array.size());
+      arrow::Status aro_sts = ff->Write(buf);
+      if (!aro_sts.ok()) {
+        return katana::ArrowToKatana(aro_sts.code());
+      }
+    }
   }
+  else{
+    katana::EntityTypeIDArrayHeader data[1] = {
+        {.size = entity_type_id_array.size()}};
+    arrow::Status aro_sts =
+        ff->Write(&data, sizeof(katana::EntityTypeIDArrayHeader));
 
-  if (entity_type_id_array.size()) {
-    const katana::EntityTypeID* raw = entity_type_id_array.data();
-    auto buf = arrow::Buffer::Wrap(raw, entity_type_id_array.size());
-    aro_sts = ff->Write(buf);
     if (!aro_sts.ok()) {
       return katana::ArrowToKatana(aro_sts.code());
     }
+
+    if (entity_type_id_array.size()) {
+      const katana::EntityTypeID* raw = entity_type_id_array.data();
+      auto buf = arrow::Buffer::Wrap(raw, entity_type_id_array.size());
+      aro_sts = ff->Write(buf);
+      if (!aro_sts.ok()) {
+        return katana::ArrowToKatana(aro_sts.code());
+      }
+    }
   }
+
   return std::unique_ptr<katana::FileFrame>(std::move(ff));
 }
 
@@ -149,10 +170,12 @@ katana::PropertyGraph::Make(
     KATANA_LOG_DEBUG("loading EntityType data from outside properties");
 
     EntityTypeIDArray node_type_ids = KATANA_CHECKED(MapEntityTypeIDsArray(
-                                                                           rdg.node_entity_type_id_array_file_storage()));
+        rdg.node_entity_type_id_array_file_storage(), topo.NumNodes(),
+        rdg.IsUnstableStorageFormat()));
 
     EntityTypeIDArray edge_type_ids = KATANA_CHECKED(MapEntityTypeIDsArray(
-                                                                           rdg.edge_entity_type_id_array_file_storage()));
+        rdg.edge_entity_type_id_array_file_storage(), topo.NumEdges(),
+        rdg.IsUnstableStorageFormat()));
 
     KATANA_ASSERT(topo.NumNodes() == node_type_ids.size());
     KATANA_ASSERT(topo.NumEdges() == edge_type_ids.size());
@@ -401,7 +424,8 @@ katana::PropertyGraph::DoWrite(
 
   std::unique_ptr<katana::FileFrame> node_entity_type_id_array_res =
       !rdg_.node_entity_type_id_array_file_storage().Valid() ||
-              !rdg_.IsUint16tEntityTypeIDs()
+              (!rdg_.IsUnstableStorageFormat() &&
+               KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat))
           ? KATANA_CHECKED(WriteEntityTypeIDsArray(node_entity_type_ids_))
           : nullptr;
 
@@ -411,7 +435,8 @@ katana::PropertyGraph::DoWrite(
 
   std::unique_ptr<katana::FileFrame> edge_entity_type_id_array_res =
       !rdg_.edge_entity_type_id_array_file_storage().Valid() ||
-              !rdg_.IsUint16tEntityTypeIDs()
+              (!rdg_.IsUnstableStorageFormat() &&
+               KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat))
           ? KATANA_CHECKED(WriteEntityTypeIDsArray(edge_entity_type_ids_))
           : nullptr;
 

--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -77,9 +77,6 @@ public:
   /// Is this RDG stored in an unstable format
   bool IsUnstableStorageFormat() const;
 
-  /// Mark the RDG as being in an unstable format
-  void SetUnstableStorageFormat();
-
   /// Perform some checks on assumed invariants
   katana::Result<void> Validate() const;
 

--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -18,6 +18,7 @@
 #include "katana/FileView.h"
 #include "katana/PartitionMetadata.h"
 #include "katana/RDGLineage.h"
+#include "katana/RDGStorageFormatVersion.h"
 #include "katana/RDGTopology.h"
 #include "katana/ReadGroup.h"
 #include "katana/Result.h"

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -311,7 +311,7 @@ katana::RDG::DoStore(
 
   // all rdgs stored while the unstable rdg storage format flag is set
   // are considered to be in the unstable rdg storage format
-  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)){
+  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)) {
     core_->part_header().set_unstable_storage_format();
   }
 

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -309,6 +309,12 @@ katana::RDG::DoStore(
   // bump the storage format version to the latest
   core_->part_header().update_storage_format_version();
 
+  // all rdgs stored while the unstable rdg storage format flag is set
+  // are considered to be in the unstable rdg storage format
+  if (KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)){
+    core_->part_header().set_unstable_storage_format();
+  }
+
   std::vector<std::string> node_prop_names;
   for (const auto& field : core_->node_properties()->fields()) {
     node_prop_names.emplace_back(field->name());
@@ -534,11 +540,6 @@ katana::RDG::IsUint16tEntityTypeIDs() const {
 bool
 katana::RDG::IsUnstableStorageFormat() const {
   return core_->part_header().unstable_storage_format();
-}
-
-void
-katana::RDG::SetUnstableStorageFormat() {
-  core_->part_header().set_unstable_storage_format();
 }
 
 katana::Result<void>

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -318,11 +318,8 @@ public:
 
   bool unstable_storage_format() const { return unstable_storage_format_; }
 
-  /// Any feature which results in changes to the storage format version
-  /// but has not yet stabilized should ensure this is called
-  /// The feature can then be developed by setting the
-  /// KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"
-  /// env var. See RDGStorageFormatVersion.h for more details
+  /// To be set on store when the UnstableRDGStorageFormat flag is set
+  /// See RDGStorageFormatVersion.h for more details
   void set_unstable_storage_format() {
     // Callers should ensure the UnstableRDGStorageFormat flag is set before calling
     // this function.

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -190,8 +190,7 @@ katana::RDGSlice::DoMake(
     // the uses are different enough between RDG and RDGSlice that it probably
     // doesn't make sense
     // The most recent storage_format removes this header,
-    size_t entity_type_id_array_header_offset =
-      sizeof(EntityTypeIDArrayHeader);
+    size_t entity_type_id_array_header_offset = sizeof(EntityTypeIDArrayHeader);
     if (core_->part_header().unstable_storage_format()) {
       entity_type_id_array_header_offset = 0;
     }

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -189,36 +189,35 @@ katana::RDGSlice::DoMake(
     // it would be nice if RDGCore could handle this format complication, but
     // the uses are different enough between RDG and RDGSlice that it probably
     // doesn't make sense
-
-    size_t storage_entity_type_id_size = 0;
-    if (core_->part_header().IsUint16tEntityTypeIDs()) {
-      storage_entity_type_id_size = sizeof(katana::EntityTypeID);
-    } else {
-      storage_entity_type_id_size = sizeof(uint8_t);
+    // The most recent storage_format removes this header,
+    size_t entity_type_id_array_header_offset =
+      sizeof(EntityTypeIDArrayHeader);
+    if (core_->part_header().unstable_storage_format()) {
+      entity_type_id_array_header_offset = 0;
     }
 
     KATANA_CHECKED_CONTEXT(
         core_->node_entity_type_id_array_file_storage().Bind(
             node_types_path.string(),
-            sizeof(EntityTypeIDArrayHeader) +
-                slice.node_range.first * storage_entity_type_id_size,
-            sizeof(EntityTypeIDArrayHeader) +
-                slice.node_range.second * storage_entity_type_id_size,
+            entity_type_id_array_header_offset +
+                slice.node_range.first * sizeof(katana::EntityTypeID),
+            entity_type_id_array_header_offset +
+                slice.node_range.second * sizeof(katana::EntityTypeID),
             true),
         "loading node type id array; begin: {}, end: {}",
-        slice.node_range.first * storage_entity_type_id_size,
-        slice.node_range.second * storage_entity_type_id_size);
+        slice.node_range.first * sizeof(katana::EntityTypeID),
+        slice.node_range.second * sizeof(katana::EntityTypeID));
     KATANA_CHECKED_CONTEXT(
         core_->edge_entity_type_id_array_file_storage().Bind(
             edge_types_path.string(),
-            sizeof(EntityTypeIDArrayHeader) +
-                slice.edge_range.first * storage_entity_type_id_size,
-            sizeof(EntityTypeIDArrayHeader) +
-                slice.edge_range.second * storage_entity_type_id_size,
+            entity_type_id_array_header_offset +
+                slice.edge_range.first * sizeof(katana::EntityTypeID),
+            entity_type_id_array_header_offset +
+                slice.edge_range.second * sizeof(katana::EntityTypeID),
             true),
         "loading edge type id array; begin: {}, end: {}",
-        slice.edge_range.first * storage_entity_type_id_size,
-        slice.edge_range.second * storage_entity_type_id_size);
+        slice.edge_range.first * sizeof(katana::EntityTypeID),
+        slice.edge_range.second * sizeof(katana::EntityTypeID));
   }
   core_->set_rdg_dir(metadata_dir);
   // all of the properties

--- a/libtsuba/test/storage-format-version/unstable-storage-format-version-flag-on.cpp
+++ b/libtsuba/test/storage-format-version/unstable-storage-format-version-flag-on.cpp
@@ -35,11 +35,8 @@ TestRoundtripUnstable(
 
   // load a stable rdg
   katana::RDG rdg = KATANA_CHECKED(LoadRDG(stable_rdg));
+  // The rdg should not become unstable until it is stored, no matter the state of the `UnstableRDGStorageFormat` flag
   KATANA_LOG_ASSERT(!rdg.IsUnstableStorageFormat());
-
-  // make our in memory rdg unstable
-  rdg.SetUnstableStorageFormat();
-  KATANA_LOG_ASSERT(rdg.IsUnstableStorageFormat());
 
   // store the unstable rdg
   std::string rdg_dir1 = KATANA_CHECKED(WriteRDG(std::move(rdg), unstable_rdg));


### PR DESCRIPTION
also use this opportunity to:
- remove some left over uint8_t EntityTypeID support
- test out the unstable_storage_format tooling




KAT-2562