### PR TITLE
Rename PropertyIndex to EntityIndex.

### DIFF
--- a/libgraph/CMakeLists.txt
+++ b/libgraph/CMakeLists.txt
@@ -15,7 +15,7 @@ set(sources
         src/Properties.cpp
         src/PropertyGraph.cpp
         src/PropertyGraphRetractor.cpp
-        src/PropertyIndex.cpp
+        src/EntityIndex.cpp
         src/PropertyViews.cpp
         src/SharedMemSys.cpp
         src/TopologyGeneration.cpp

--- a/libgraph/include/katana/EntityIndex.h
+++ b/libgraph/include/katana/EntityIndex.h
@@ -1,5 +1,5 @@
-#ifndef KATANA_LIBGRAPH_KATANA_PROPERTYINDEX_H_
-#define KATANA_LIBGRAPH_KATANA_PROPERTYINDEX_H_
+#ifndef KATANA_LIBGRAPH_KATANA_ENTITYINDEX_H_
+#define KATANA_LIBGRAPH_KATANA_ENTITYINDEX_H_
 
 #include <set>
 #include <string>
@@ -16,10 +16,10 @@
 
 namespace katana {
 
-// PropertyIndex provides an interface similar to an ordered container
+// EntityIndex provides an interface similar to an ordered container
 // over a single property.
 template <typename node_or_edge>
-class KATANA_EXPORT PropertyIndex {
+class KATANA_EXPORT EntityIndex {
 public:
   // Type-safe container for node and edge ids to avoid overlap with the
   // primitive types we are indexing.
@@ -32,7 +32,7 @@ public:
   using set_key_type = typename std::variant<
       IndexID, bool, uint8_t, int64_t, uint64_t, double_t, std::string_view*>;
 
-  // PropertyIndex::iterator returns a sequence of node or edge ids.
+  // EntityIndex::iterator returns a sequence of node or edge ids.
   using base_iterator = typename std::multiset<set_key_type>::iterator;
   class iterator : public base_iterator {
   public:
@@ -43,15 +43,14 @@ public:
     }
   };
 
-  PropertyIndex(std::string column_name)
-      : column_name_(std::move(column_name)) {}
+  EntityIndex(std::string column_name) : column_name_(std::move(column_name)) {}
 
-  PropertyIndex(const PropertyIndex&) = delete;
-  PropertyIndex& operator=(const PropertyIndex&) = delete;
-  PropertyIndex(const PropertyIndex&&) = delete;
-  PropertyIndex& operator=(const PropertyIndex&&) = delete;
+  EntityIndex(const EntityIndex&) = delete;
+  EntityIndex& operator=(const EntityIndex&) = delete;
+  EntityIndex(const EntityIndex&&) = delete;
+  EntityIndex& operator=(const EntityIndex&&) = delete;
 
-  virtual ~PropertyIndex() = default;
+  virtual ~EntityIndex() = default;
 
   // The name of the indexed property.
   std::string column_name() { return column_name_; }
@@ -66,20 +65,19 @@ private:
   std::string column_name_;
 };
 
-// PrimitivePropertyIndex provides a PropertyIndex for primitive types.
+// PrimitiveEntityIndex provides a EntityIndex for primitive types.
 template <typename node_or_edge, typename c_type>
-class KATANA_EXPORT PrimitivePropertyIndex
-    : public PropertyIndex<node_or_edge> {
+class KATANA_EXPORT PrimitiveEntityIndex : public EntityIndex<node_or_edge> {
 public:
   using ArrowArrayType = typename arrow::CTypeTraits<c_type>::ArrayType;
-  using IndexID = typename PropertyIndex<node_or_edge>::IndexID;
-  using iterator = typename PropertyIndex<node_or_edge>::iterator;
-  using set_key_type = typename PropertyIndex<node_or_edge>::set_key_type;
+  using IndexID = typename EntityIndex<node_or_edge>::IndexID;
+  using iterator = typename EntityIndex<node_or_edge>::iterator;
+  using set_key_type = typename EntityIndex<node_or_edge>::set_key_type;
 
-  PrimitivePropertyIndex(
+  PrimitiveEntityIndex(
       const std::string& column, size_t num_entities,
       std::shared_ptr<arrow::Array> property)
-      : PropertyIndex<node_or_edge>(column),
+      : EntityIndex<node_or_edge>(column),
         num_entities_(num_entities),
         property_(std::static_pointer_cast<ArrowArrayType>(property)),
         set_(PropertyCompare(property_)) {}
@@ -142,20 +140,20 @@ private:
   std::multiset<set_key_type, PropertyCompare> set_;
 };
 
-// StringPropertyIndex provides a PropertyIndex for strings.
+// StringEntityIndex provides a EntityIndex for strings.
 template <typename node_or_edge>
-class KATANA_EXPORT StringPropertyIndex : public PropertyIndex<node_or_edge> {
+class KATANA_EXPORT StringEntityIndex : public EntityIndex<node_or_edge> {
 public:
   using ArrowArrayType =
       typename arrow::TypeTraits<arrow::LargeStringType>::ArrayType;
-  using IndexID = typename PropertyIndex<node_or_edge>::IndexID;
-  using iterator = typename PropertyIndex<node_or_edge>::iterator;
-  using set_key_type = typename PropertyIndex<node_or_edge>::set_key_type;
+  using IndexID = typename EntityIndex<node_or_edge>::IndexID;
+  using iterator = typename EntityIndex<node_or_edge>::iterator;
+  using set_key_type = typename EntityIndex<node_or_edge>::set_key_type;
 
-  StringPropertyIndex(
+  StringEntityIndex(
       const std::string& column_name, size_t num_entities,
       const std::shared_ptr<arrow::Array>& property)
-      : PropertyIndex<node_or_edge>(column_name),
+      : EntityIndex<node_or_edge>(column_name),
         num_entities_(num_entities),
         property_(std::static_pointer_cast<arrow::LargeStringArray>(property)),
         set_(StringCompare(property_)) {}
@@ -225,10 +223,10 @@ private:
   std::multiset<set_key_type, StringCompare> set_;
 };  // namespace katana
 
-// Create a PropertyIndex with the apropriate type for 'property'. Does not
+// Create a EntityIndex with the appropriate type for 'property'. Does not
 // build the index.
 template <typename node_or_edge>
-Result<std::unique_ptr<PropertyIndex<node_or_edge>>> MakeTypedIndex(
+Result<std::unique_ptr<EntityIndex<node_or_edge>>> MakeTypedEntityIndex(
     const std::string& column_name, size_t num_entities,
     std::shared_ptr<arrow::Array> property);
 

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -10,13 +10,13 @@
 
 #include "katana/ArrowInterchange.h"
 #include "katana/Details.h"
+#include "katana/EntityIndex.h"
 #include "katana/EntityTypeManager.h"
 #include "katana/ErrorCode.h"
 #include "katana/GraphTopology.h"
 #include "katana/Iterators.h"
 #include "katana/Logging.h"
 #include "katana/NUMAArray.h"
-#include "katana/PropertyIndex.h"
 #include "katana/RDG.h"
 #include "katana/RDGTopology.h"
 #include "katana/Result.h"
@@ -94,8 +94,8 @@ private:
   EntityTypeIDArray edge_entity_type_ids_;
 
   // List of node and edge indexes on this graph.
-  std::vector<std::unique_ptr<PropertyIndex<Node>>> node_indexes_;
-  std::vector<std::unique_ptr<PropertyIndex<Edge>>> edge_indexes_;
+  std::vector<std::unique_ptr<EntityIndex<Node>>> node_indexes_;
+  std::vector<std::unique_ptr<EntityIndex<Edge>>> edge_indexes_;
 
   PGViewCache pg_view_cache_;
 
@@ -883,19 +883,19 @@ public:
   Result<void> DeleteEdgeIndex(const std::string& column_name);
 
   // Returns the list of node indexes.
-  const std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Node>>>&
+  const std::vector<std::unique_ptr<EntityIndex<GraphTopology::Node>>>&
   node_indexes() const {
     return node_indexes_;
   }
 
   // Returns the list of edge indexes.
-  const std::vector<std::unique_ptr<PropertyIndex<GraphTopology::Edge>>>&
+  const std::vector<std::unique_ptr<EntityIndex<GraphTopology::Edge>>>&
   edge_indexes() const {
     return edge_indexes_;
   }
 
   // Returns true of an index exists for the named property
-  bool HasNodePropertyIndex(const std::string& property_name) const {
+  bool HasNodeIndex(const std::string& property_name) const {
     for (const auto& index : node_indexes()) {
       if (index->column_name() == property_name) {
         return true;
@@ -905,8 +905,8 @@ public:
   }
 
   // Returns the property index associated with the named property
-  katana::Result<katana::PropertyIndex<GraphTopology::Node>*>
-  GetNodePropertyIndex(const std::string& property_name) const;
+  katana::Result<katana::EntityIndex<GraphTopology::Node>*> GetNodeIndex(
+      const std::string& property_name) const;
 };
 
 /// SortAllEdgesByDest sorts edges for each node by destination

--- a/libgraph/src/EntityIndex.cpp
+++ b/libgraph/src/EntityIndex.cpp
@@ -1,4 +1,4 @@
-#include "katana/PropertyIndex.h"
+#include "katana/EntityIndex.h"
 
 #include "katana/PropertyGraph.h"
 
@@ -6,35 +6,35 @@ namespace katana {
 
 // Switch statement over creation of per-type indexes.
 template <typename node_or_edge>
-Result<std::unique_ptr<PropertyIndex<node_or_edge>>>
-MakeTypedIndex(
+Result<std::unique_ptr<EntityIndex<node_or_edge>>>
+MakeTypedEntityIndex(
     const std::string& column_name, size_t num_entities,
     std::shared_ptr<arrow::Array> property) {
-  std::unique_ptr<PropertyIndex<node_or_edge>> index;
+  std::unique_ptr<EntityIndex<node_or_edge>> index;
 
   switch (property->type_id()) {
   case arrow::Type::BOOL:
-    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, bool>>(
+    index = std::make_unique<PrimitiveEntityIndex<node_or_edge, bool>>(
         column_name, num_entities, property);
     break;
   case arrow::Type::UINT8:
-    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, uint8_t>>(
+    index = std::make_unique<PrimitiveEntityIndex<node_or_edge, uint8_t>>(
         column_name, num_entities, property);
     break;
   case arrow::Type::INT64:
-    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, int64_t>>(
+    index = std::make_unique<PrimitiveEntityIndex<node_or_edge, int64_t>>(
         column_name, num_entities, property);
     break;
   case arrow::Type::UINT64:
-    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, uint64_t>>(
+    index = std::make_unique<PrimitiveEntityIndex<node_or_edge, uint64_t>>(
         column_name, num_entities, property);
     break;
   case arrow::Type::DOUBLE:
-    index = std::make_unique<PrimitivePropertyIndex<node_or_edge, double_t>>(
+    index = std::make_unique<PrimitiveEntityIndex<node_or_edge, double_t>>(
         column_name, num_entities, property);
     break;
   case arrow::Type::LARGE_STRING:
-    index = std::make_unique<StringPropertyIndex<node_or_edge>>(
+    index = std::make_unique<StringEntityIndex<node_or_edge>>(
         column_name, num_entities, property);
     break;
   default:
@@ -44,12 +44,12 @@ MakeTypedIndex(
   }
 
   // Some compilers seem to have trouble converting to Result here.
-  return Result<std::unique_ptr<PropertyIndex<node_or_edge>>>(std::move(index));
+  return Result<std::unique_ptr<EntityIndex<node_or_edge>>>(std::move(index));
 }
 
 template <typename node_or_edge, typename c_type>
 Result<void>
-PrimitivePropertyIndex<node_or_edge, c_type>::BuildFromProperty() {
+PrimitiveEntityIndex<node_or_edge, c_type>::BuildFromProperty() {
   if (static_cast<uint64_t>(property_->length()) < num_entities_) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "Property does not contain all entities");
@@ -69,7 +69,7 @@ PrimitivePropertyIndex<node_or_edge, c_type>::BuildFromProperty() {
 
 template <typename node_or_edge>
 Result<void>
-StringPropertyIndex<node_or_edge>::BuildFromProperty() {
+StringEntityIndex<node_or_edge>::BuildFromProperty() {
   if (static_cast<uint64_t>(property_->length()) < num_entities_) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "Property does not contain all entities");
@@ -88,26 +88,26 @@ StringPropertyIndex<node_or_edge>::BuildFromProperty() {
 }
 
 // Forward declare template types to allow implementation in .cpp.
-template class PrimitivePropertyIndex<GraphTopology::Node, bool>;
-template class PrimitivePropertyIndex<GraphTopology::Edge, bool>;
-template class PrimitivePropertyIndex<GraphTopology::Node, uint8_t>;
-template class PrimitivePropertyIndex<GraphTopology::Edge, uint8_t>;
-template class PrimitivePropertyIndex<GraphTopology::Node, int64_t>;
-template class PrimitivePropertyIndex<GraphTopology::Edge, int64_t>;
-template class PrimitivePropertyIndex<GraphTopology::Node, uint64_t>;
-template class PrimitivePropertyIndex<GraphTopology::Edge, uint64_t>;
-template class PrimitivePropertyIndex<GraphTopology::Node, double_t>;
-template class PrimitivePropertyIndex<GraphTopology::Edge, double_t>;
+template class PrimitiveEntityIndex<GraphTopology::Node, bool>;
+template class PrimitiveEntityIndex<GraphTopology::Edge, bool>;
+template class PrimitiveEntityIndex<GraphTopology::Node, uint8_t>;
+template class PrimitiveEntityIndex<GraphTopology::Edge, uint8_t>;
+template class PrimitiveEntityIndex<GraphTopology::Node, int64_t>;
+template class PrimitiveEntityIndex<GraphTopology::Edge, int64_t>;
+template class PrimitiveEntityIndex<GraphTopology::Node, uint64_t>;
+template class PrimitiveEntityIndex<GraphTopology::Edge, uint64_t>;
+template class PrimitiveEntityIndex<GraphTopology::Node, double_t>;
+template class PrimitiveEntityIndex<GraphTopology::Edge, double_t>;
 
-template class StringPropertyIndex<GraphTopology::Node>;
-template class StringPropertyIndex<GraphTopology::Edge>;
+template class StringEntityIndex<GraphTopology::Node>;
+template class StringEntityIndex<GraphTopology::Edge>;
 
-template Result<std::unique_ptr<PropertyIndex<GraphTopology::Node>>>
-MakeTypedIndex(
+template Result<std::unique_ptr<EntityIndex<GraphTopology::Node>>>
+MakeTypedEntityIndex(
     const std::string& column_name, size_t num_entities,
     std::shared_ptr<arrow::Array> property);
-template Result<std::unique_ptr<PropertyIndex<GraphTopology::Edge>>>
-MakeTypedIndex(
+template Result<std::unique_ptr<EntityIndex<GraphTopology::Edge>>>
+MakeTypedEntityIndex(
     const std::string& column_name, size_t num_entities,
     std::shared_ptr<arrow::Array> property);
 

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -909,8 +909,8 @@ katana::PropertyGraph::MakeNodeIndex(const std::string& column_name) {
   std::shared_ptr<arrow::Array> property = chunked_property->chunk(0);
 
   // Create an index based on the type of the field.
-  std::unique_ptr<katana::PropertyIndex<GraphTopology::Node>> index =
-      KATANA_CHECKED(katana::MakeTypedIndex<katana::GraphTopology::Node>(
+  std::unique_ptr<katana::EntityIndex<GraphTopology::Node>> index =
+      KATANA_CHECKED(katana::MakeTypedEntityIndex<katana::GraphTopology::Node>(
           column_name, NumNodes(), property));
 
   KATANA_CHECKED(index->BuildFromProperty());
@@ -954,8 +954,8 @@ katana::PropertyGraph::MakeEdgeIndex(const std::string& column_name) {
   std::shared_ptr<arrow::Array> property = chunked_property->chunk(0);
 
   // Create an index based on the type of the field.
-  std::unique_ptr<katana::PropertyIndex<katana::GraphTopology::Edge>> index =
-      KATANA_CHECKED(katana::MakeTypedIndex<katana::GraphTopology::Edge>(
+  std::unique_ptr<katana::EntityIndex<katana::GraphTopology::Edge>> index =
+      KATANA_CHECKED(katana::MakeTypedEntityIndex<katana::GraphTopology::Edge>(
           column_name, NumEdges(), property));
 
   KATANA_CHECKED(index->BuildFromProperty());
@@ -1270,9 +1270,8 @@ katana::CreateTransposeGraphTopology(const GraphTopology& topology) {
   return katana::PropertyGraph::Make(std::move(transpose_topo));
 }
 
-katana::Result<katana::PropertyIndex<katana::GraphTopology::Node>*>
-katana::PropertyGraph::GetNodePropertyIndex(
-    const std::string& property_name) const {
+katana::Result<katana::EntityIndex<katana::GraphTopology::Node>*>
+katana::PropertyGraph::GetNodeIndex(const std::string& property_name) const {
   for (const auto& index : node_indexes()) {
     if (index->column_name() == property_name) {
       return index.get();

--- a/libgraph/test/property-index.cpp
+++ b/libgraph/test/property-index.cpp
@@ -3,14 +3,14 @@
 #include <arrow/type_traits.h>
 
 #include "TestTypedPropertyGraph.h"
+#include "katana/EntityIndex.h"
 #include "katana/Logging.h"
 #include "katana/Properties.h"
-#include "katana/PropertyIndex.h"
 #include "katana/SharedMemSys.h"
 
 template <typename node_or_edge>
 struct NodeOrEdge {
-  static katana::Result<katana::PropertyIndex<node_or_edge>*> MakeIndex(
+  static katana::Result<katana::EntityIndex<node_or_edge>*> MakeIndex(
       katana::PropertyGraph* pg, const std::string& column_name);
   static katana::Result<void> AddProperties(
       katana::PropertyGraph* pg, std::shared_ptr<arrow::Table> properties,
@@ -22,7 +22,7 @@ using Node = NodeOrEdge<katana::GraphTopology::Node>;
 using Edge = NodeOrEdge<katana::GraphTopology::Edge>;
 
 template <>
-katana::Result<katana::PropertyIndex<katana::GraphTopology::Node>*>
+katana::Result<katana::EntityIndex<katana::GraphTopology::Node>*>
 Node::MakeIndex(katana::PropertyGraph* pg, const std::string& column_name) {
   auto result = pg->MakeNodeIndex(column_name);
   if (!result) {
@@ -39,7 +39,7 @@ Node::MakeIndex(katana::PropertyGraph* pg, const std::string& column_name) {
 }
 
 template <>
-katana::Result<katana::PropertyIndex<katana::GraphTopology::Edge>*>
+katana::Result<katana::EntityIndex<katana::GraphTopology::Edge>*>
 Edge::MakeIndex(katana::PropertyGraph* pg, const std::string& column_name) {
   auto result = pg->MakeEdgeIndex(column_name);
   if (!result) {
@@ -136,7 +136,7 @@ CreateStringProperty(const std::string& name, bool uniform, size_t num_rows) {
 template <typename node_or_edge, typename DataType>
 void
 TestPrimitiveIndex(size_t num_nodes, size_t line_width) {
-  using IndexType = katana::PrimitivePropertyIndex<node_or_edge, DataType>;
+  using IndexType = katana::PrimitiveEntityIndex<node_or_edge, DataType>;
   using ArrayType = typename arrow::CTypeTraits<DataType>::ArrayType;
 
   LinePolicy policy{line_width};
@@ -208,7 +208,7 @@ TestPrimitiveIndex(size_t num_nodes, size_t line_width) {
 template <typename node_or_edge>
 void
 TestStringIndex(size_t num_nodes, size_t line_width) {
-  using IndexType = katana::StringPropertyIndex<node_or_edge>;
+  using IndexType = katana::StringEntityIndex<node_or_edge>;
   using ArrayType = arrow::LargeStringArray;
 
   LinePolicy policy{line_width};


### PR DESCRIPTION
With: https://github.com/KatanaGraph/katana-enterprise/pull/3026

This is a mechanical rename PR. There should be no true code changes.