### PR TITLE
allow nlohmann::ordered_json in JsonDump KAT-1157 (#799)

### DIFF
--- a/libsupport/include/katana/JSON.h
+++ b/libsupport/include/katana/JSON.h
@@ -37,6 +37,8 @@ JsonParse(U& obj, T* val) {
 
 /// Dump to string, but catch errors
 KATANA_EXPORT katana::Result<std::string> JsonDump(const nlohmann::json& obj);
+KATANA_EXPORT katana::Result<std::string> JsonDump(
+    const nlohmann::ordered_json& obj);
 
 template <typename T>
 katana::Result<std::string>

--- a/libsupport/src/JSON.cpp
+++ b/libsupport/src/JSON.cpp
@@ -5,7 +5,19 @@ katana::JsonDump(const nlohmann::json& obj) {
   try {
     return obj.dump();
   } catch (const std::exception& exp) {
-    KATANA_LOG_DEBUG("nlohmann::json::dump exception: {}", exp.what());
+    return KATANA_ERROR(
+        katana::ErrorCode::JSONDumpFailed, "nlohmann::json::dump exception: {}",
+        exp.what());
   }
-  return katana::ErrorCode::JSONDumpFailed;
+}
+
+katana::Result<std::string>
+katana::JsonDump(const nlohmann::ordered_json& obj) {
+  try {
+    return obj.dump();
+  } catch (const std::exception& exp) {
+    return KATANA_ERROR(
+        katana::ErrorCode::JSONDumpFailed,
+        "nlohmann::ordered_json::dump exception: {}", exp.what());
+  }
 }


### PR DESCRIPTION
allow nlohmann::ordered_json to use the same DumpJSON interface as nlohmann::json
required for the (nonstandard json) ordering of keys in query result according to return order

KAT-1157