### PR TITLE
Storage format version 4 KAT-2562

### DIFF
--- a/cmake/Modules/TestDatasets.cmake
+++ b/cmake/Modules/TestDatasets.cmake
@@ -6,7 +6,7 @@ set(MISC_TEST_DATASETS ${KATANA_TEST_DATASETS}/misc_datasets)
 
 ## latest supported rdg storage_format_version
 #TODO(emcginnis) get this envar in RDGPartHeader.h instead of having to hard code it here and there
-set(KATANA_RDG_STORAGE_FORMAT_VERSION "3")
+set(KATANA_RDG_STORAGE_FORMAT_VERSION "4")
 
 
 ## returns path to the specified rdg dataset at the specified storage_format_version

--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -75,6 +75,8 @@ public:
   bool IsEntityTypeIDsOutsideProperties() const;
   /// What size are EntityTypeIDs on storage
   bool IsUint16tEntityTypeIDs() const;
+  /// What format is the EntityTypeIDArray in
+  bool IsHeaderlessEntityTypeIDArray() const;
 
   /// Is this RDG stored in an unstable format
   bool IsUnstableStorageFormat() const;

--- a/libtsuba/include/katana/RDGPrefix.h
+++ b/libtsuba/include/katana/RDGPrefix.h
@@ -54,6 +54,9 @@ private:
       const RDGManifest& manifest, uint32_t partition_id);
 };
 
+/// THIS HEADER WAS DEPRECATED AS OF storage_format_version = 4
+/// DO NOT MODIFY THIS HEADER
+/// This header is used only for backwards compatibility with older storage formats
 /// EntityTypeIDArrayHeader describes the header in the on disk representation
 /// of EntityTypeID arrays, it could be probably be rolled into RDGPrefix but it
 /// has slightly different uses so for now it is separate

--- a/libtsuba/include/katana/RDGStorageFormatVersion.h
+++ b/libtsuba/include/katana/RDGStorageFormatVersion.h
@@ -11,11 +11,12 @@ namespace katana {
 static const uint32_t kPartitionStorageFormatVersion1 = 1;
 static const uint32_t kPartitionStorageFormatVersion2 = 2;
 static const uint32_t kPartitionStorageFormatVersion3 = 3;
+static const uint32_t kPartitionStorageFormatVersion4 = 4;
 
 /// kLatestPartitionStorageFormatVersion to be bumped any time
 /// the on disk format of RDGPartHeader changes
 static const uint32_t kLatestPartitionStorageFormatVersion =
-    kPartitionStorageFormatVersion3;
+    kPartitionStorageFormatVersion4;
 
 };  // namespace katana
 

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -538,6 +538,11 @@ katana::RDG::IsUint16tEntityTypeIDs() const {
 }
 
 bool
+katana::RDG::IsHeaderlessEntityTypeIDArray() const {
+  return core_->part_header().IsHeaderlessEntityTypeIDArray();
+}
+
+bool
 katana::RDG::IsUnstableStorageFormat() const {
   return core_->part_header().unstable_storage_format();
 }

--- a/libtsuba/src/RDGPartHeader.cpp
+++ b/libtsuba/src/RDGPartHeader.cpp
@@ -179,6 +179,11 @@ katana::RDGPartHeader::IsMetadataOutsideTopologyFile() const {
   return (storage_format_version_ >= kPartitionStorageFormatVersion3);
 }
 
+bool
+katana::RDGPartHeader::IsHeaderlessEntityTypeIDArray() const {
+  return (storage_format_version_ >= kPartitionStorageFormatVersion4);
+}
+
 katana::Result<void>
 katana::RDGPartHeader::ValidateEntityTypeIDStructures() const {
   if (node_entity_type_id_array_path_.empty()) {

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -154,6 +154,8 @@ public:
   bool IsEntityTypeIDsOutsideProperties() const;
   bool IsUint16tEntityTypeIDs() const;
   bool IsMetadataOutsideTopologyFile() const;
+  bool IsHeaderlessEntityTypeIDArray() const;
+
   //
   // Property manipulation
   //

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -191,7 +191,7 @@ katana::RDGSlice::DoMake(
     // doesn't make sense
     // The most recent storage_format removes this header,
     size_t entity_type_id_array_header_offset = sizeof(EntityTypeIDArrayHeader);
-    if (core_->part_header().unstable_storage_format()) {
+    if (core_->part_header().IsHeaderlessEntityTypeIDArray()) {
       entity_type_id_array_header_offset = 0;
     }
 

--- a/python/katana/example_data.py
+++ b/python/katana/example_data.py
@@ -17,7 +17,7 @@ __all__ = ["get_rdg_dataset_at_version", "get_rdg_dataset", "get_csv_dataset", "
 # git sha of the datasets repo to download/cache if it is not available locally in the source
 # TODO(emcginnis) it would be really really nice if this got updated automatically
 # when the submodule ref held by open katana is updated
-DATASETS_SHA = "650f3e92e6880adab9c0a7afe9b3d0a41306fa99"
+DATASETS_SHA = "ffe9b34169377df384116fdfd94aa842a2141587"
 
 
 def get_rdg_dataset_at_version(rdg_name, storage_format_version, as_url=False):

--- a/python/test/test_storage_format.py
+++ b/python/test/test_storage_format.py
@@ -257,6 +257,9 @@ def cli():
     If the two RDGs are the same exact graph, stored in the same storage_format_version,
     then this script returns true
     If the two RDGs differ, this script returns false
+
+    to run this from the command line, first run a full build then
+    bash build/python_env.sh python3 python/test/test_storage_format.py rdgs -V -O <rdg_1> -N <rdg_2>
     """
 
 

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -2929,34 +2929,25 @@ struct Gr2Kg : public Conversion {
     }
     auto node_types = std::make_unique<katana::FileFrame>();
     size_t node_type_buffer_size =
-        header.num_nodes * sizeof(katana::EntityTypeID) +
-        sizeof(katana::EntityTypeIDArrayHeader);
+        header.num_nodes * sizeof(katana::EntityTypeID);
     KATANA_CHECKED(node_types->Init(node_type_buffer_size));
     KATANA_CHECKED(node_types->SetCursor(node_type_buffer_size));
 
-    auto* node_header =
-        KATANA_CHECKED(node_types->ptr<katana::EntityTypeIDArrayHeader>());
-    node_header->size = header.num_nodes;
     katana::EntityTypeManager node_type_manager;
     std::fill_n(
-        reinterpret_cast<katana::EntityTypeID*>(
-            KATANA_CHECKED(node_types->ptr<uint8_t>()) + sizeof(uint64_t)),
+        KATANA_CHECKED(node_types->ptr<katana::EntityTypeID>()),
         header.num_nodes,
         KATANA_CHECKED(node_type_manager.AddAtomicEntityType("vertex")));
 
     auto edge_types = std::make_unique<katana::FileFrame>();
     size_t edge_type_buffer_size =
-        header.num_edges * sizeof(katana::EntityTypeID) + sizeof(uint64_t);
+        header.num_edges * sizeof(katana::EntityTypeID);
     KATANA_CHECKED(edge_types->Init(edge_type_buffer_size));
     KATANA_CHECKED(edge_types->SetCursor(edge_type_buffer_size));
 
-    auto* edge_header =
-        KATANA_CHECKED(edge_types->ptr<katana::EntityTypeIDArrayHeader>());
-    edge_header->size = header.num_edges;
     katana::EntityTypeManager edge_type_manager;
     std::fill_n(
-        reinterpret_cast<katana::EntityTypeID*>(
-            KATANA_CHECKED(edge_types->ptr<uint8_t>()) + sizeof(uint64_t)),
+        KATANA_CHECKED(edge_types->ptr<katana::EntityTypeID>()),
         header.num_edges,
         KATANA_CHECKED(edge_type_manager.AddAtomicEntityType("edge")));
 


### PR DESCRIPTION
release rdg storage_format_version 4 which contains the following changes:
- removes the redundant header from the node/edge_entity_type_id_arrays

This is the follow up to https://github.com/KatanaGraph/katana/pull/826 and transitions this feature from the unstable storage format to storage_format_version 4

KAT-2562
