### PR TITLE
RDGSlice: implement version indicators

### DIFF
--- a/libtsuba/include/katana/RDGSlice.h
+++ b/libtsuba/include/katana/RDGSlice.h
@@ -129,6 +129,7 @@ public:
   /// Determine if the EntityTypeIDs are stored in properties, or outside
   /// in their own dedicated structures
   bool IsEntityTypeIDsOutsideProperties() const;
+  bool IsUint16tEntityTypeIDs() const;
   const FileView& node_entity_type_id_array_file_storage() const;
   const FileView& edge_entity_type_id_array_file_storage() const;
   katana::Result<katana::EntityTypeManager> node_entity_type_manager() const;

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -549,6 +549,16 @@ katana::RDGSlice::topology_file_storage() const {
   return topo->file_storage();
 }
 
+bool
+katana::RDGSlice::IsEntityTypeIDsOutsideProperties() const {
+  return core_->part_header().IsEntityTypeIDsOutsideProperties();
+}
+
+bool
+katana::RDGSlice::IsUint16tEntityTypeIDs() const {
+  return core_->part_header().IsUint16tEntityTypeIDs();
+}
+
 const katana::FileView&
 katana::RDGSlice::node_entity_type_id_array_file_storage() const {
   return core_->node_entity_type_id_array_file_storage();


### PR DESCRIPTION
IsEntityTypeIDsOutsideProperties() and IsUint16tEntityTypeIDs() indicate
the format of the RDG on storage. It is important that RDGSlice expose
that information.