### PR TITLE
support: Encode URIs

### DIFF
--- a/libsupport/include/katana/URI.h
+++ b/libsupport/include/katana/URI.h
@@ -24,10 +24,12 @@ public:
   static Result<Uri> MakeFromFile(const std::string& str);
   /// Append a '-' and then a random string to input
   static Result<Uri> MakeRand(const std::string& str);
+
   static std::string JoinPath(const std::string& dir, const std::string& file);
 
-  /// Return the base64 (url variant) encoded version of this uri
-  std::string Encode() const;
+  // Decode returns the raw bytes represented by a URI encoded string.
+  static std::string Decode(const std::string& uri);
+
   /// Hash URI
   struct Hash {
     std::size_t operator()(const Uri& uri) const {
@@ -36,8 +38,15 @@ public:
   };
 
   const std::string& scheme() const { return scheme_; }
+
+  /// path returns the portion of a URI after the scheme. This a concatenation
+  /// of the traditional URI host and path components. Unlike string(), the
+  /// returned value are raw bytes and there is no encoding of special
+  /// characters.
   const std::string& path() const { return path_; }
-  const std::string& string() const { return string_; }
+
+  /// string returns the URI as a URI-encoded string.
+  const std::string& string() const { return encoded_; }
 
   bool empty() const;
 
@@ -60,7 +69,7 @@ private:
 
   std::string scheme_;
   std::string path_;
-  std::string string_;
+  std::string encoded_;
 };
 
 KATANA_EXPORT bool operator==(const Uri& lhs, const Uri& rhs);

--- a/libsupport/test/uri.cpp
+++ b/libsupport/test/uri.cpp
@@ -4,6 +4,8 @@
 
 #include "katana/Logging.h"
 
+namespace {
+
 katana::Uri
 Str2Uri(const std::string& str) {
   auto path_res = katana::Uri::Make(str);
@@ -11,8 +13,8 @@ Str2Uri(const std::string& str) {
   return path_res.value();
 }
 
-int
-main() {
+void
+TestMake() {
   KATANA_LOG_ASSERT(Str2Uri("/some/path/").path() == "/some/path");
   // We only eat one slash by default to support mangled (but valid) paths like
   // this
@@ -21,7 +23,10 @@ main() {
 
   KATANA_LOG_ASSERT(Str2Uri("path").BaseName() == "path");
   KATANA_LOG_ASSERT(Str2Uri("path///////").StripSep().path() == "path");
+}
 
+void
+TestJoinPath() {
   KATANA_LOG_ASSERT(
       katana::Uri::JoinPath("/some/long", "path") == "/some/long/path");
   KATANA_LOG_ASSERT(
@@ -36,6 +41,44 @@ main() {
       katana::Uri::JoinPath("/some/long///", "/path") == "/some/long/path");
   KATANA_LOG_ASSERT(
       katana::Uri::JoinPath("/some/long///", "//path") == "/some/long/path");
+}
+
+void
+TestEncode() {
+  // Test that path is not encoded
+  KATANA_LOG_ASSERT(Str2Uri("/ with/ spaces").path() == "/ with/ spaces");
+  KATANA_LOG_ASSERT(
+      Str2Uri("file:///%20with/%20spaces").path() == "/ with/ spaces");
+
+  // Test roundtrip is still a proper URI
+  KATANA_LOG_ASSERT(
+      Str2Uri("file:///%20with/%20spaces").string() ==
+      "file:///%20with/%20spaces");
+
+  // Test that string is encoded
+  KATANA_LOG_ASSERT(
+      Str2Uri("/ with/ spaces").string() == "file:///%20with/%20spaces");
+}
+
+void
+TestDecode() {
+  KATANA_LOG_ASSERT(katana::Uri::Decode("/ with/ spaces") == "/ with/ spaces");
+
+  KATANA_LOG_ASSERT(
+      katana::Uri::Decode("/%20with/%20spaces") == "/ with/ spaces");
+}
+
+}  // namespace
+
+int
+main() {
+  TestMake();
+
+  TestJoinPath();
+
+  TestEncode();
+
+  TestDecode();
 
   return 0;
 }

--- a/libtsuba/src/LocalStorage.h
+++ b/libtsuba/src/LocalStorage.h
@@ -16,21 +16,20 @@ namespace katana {
 /// Store byte arrays to the local file system; Provided as a convenience for
 /// testing only (un-optimized)
 class LocalStorage : public FileStorage {
-  void CleanUri(std::string* uri);
   katana::Result<void> WriteFile(
-      std::string, const uint8_t* data, uint64_t size);
+      const std::string&, const uint8_t* data, uint64_t size);
   katana::Result<void> ReadFile(
-      std::string uri, uint64_t start, uint64_t size, uint8_t* data);
+      const std::string& uri, uint64_t start, uint64_t size, uint8_t* data);
   katana::Result<void> RemoteCopyFile(
-      std::string source_uri, std::string dest_uri, uint64_t begin,
-      uint64_t size);
+      const std::string& source_uri, const std::string& dest_uri,
+      uint64_t begin, uint64_t size);
 
 public:
   LocalStorage() : FileStorage("file://") {}
 
   katana::Result<void> Init() override { return katana::ResultSuccess(); }
   katana::Result<void> Fini() override { return katana::ResultSuccess(); }
-  katana::Result<void> Stat(const std::string& uri, StatBuf* size) override;
+  katana::Result<void> Stat(const std::string& uri, StatBuf* s_buf) override;
 
   uint32_t Priority() const override { return 1; }
 

--- a/libtsuba/src/RDGHandleImpl.h
+++ b/libtsuba/src/RDGHandleImpl.h
@@ -26,7 +26,7 @@ public:
   void set_rdg_manifest(RDGManifest&& rdg_manifest) {
     rdg_manifest_ = std::move(rdg_manifest);
   }
-  void set_viewtype(const std::string v) { rdg_manifest_.set_viewtype(v); }
+  void set_viewtype(const std::string& v) { rdg_manifest_.set_viewtype(v); }
 
 private:
   uint32_t flags_;


### PR DESCRIPTION
Non-alphanumeric characters are usually percent-escaped in URIs. Escape
these characters when converting a URI into a string.

Uri::path() continues to return raw bytes under the assumption that
callers expect it to behave like a standard filesystem path (with no
special escaping).

Along the way remove Uri::Encode, which base64-encodes a URI. This is a
non-standard thing to do to URIs specifically and is not currently used
by any code.