### PR TITLE
[KAT-1688] [KAT-3051] Add RDG directory as prefix when tracking property names in TxnContext

### DIFF
--- a/libtsuba/include/katana/TxnContext.h
+++ b/libtsuba/include/katana/TxnContext.h
@@ -9,40 +9,48 @@ namespace katana {
 
 class KATANA_EXPORT TxnContext {
 public:
-  void InsertNodePropertyRead(std::string name) {
-    node_properties_read_.insert(name);
+  void InsertNodePropertyRead(std::string rdg_dir, std::string name) {
+    node_properties_read_.insert(ConcatRDGProperty(rdg_dir, name));
   }
 
   template <typename Container>
-  void InsertNodePropertyRead(const Container& names) {
-    node_properties_read_.insert(names.begin(), names.end());
+  void InsertNodePropertyRead(std::string rdg_dir, const Container& names) {
+    for (auto name : names) {
+      node_properties_read_.insert(ConcatRDGProperty(rdg_dir, name));
+    }
   }
 
-  void InsertNodePropertyWrite(std::string name) {
-    node_properties_write_.insert(name);
-  }
-
-  template <typename Container>
-  void InsertNodePropertyWrite(const Container& names) {
-    node_properties_write_.insert(names.begin(), names.end());
-  }
-
-  void InsertEdgePropertyRead(std::string name) {
-    edge_properties_read_.insert(name);
+  void InsertNodePropertyWrite(std::string rdg_dir, std::string name) {
+    node_properties_write_.insert(ConcatRDGProperty(rdg_dir, name));
   }
 
   template <typename Container>
-  void InsertEdgePropertyRead(const Container& names) {
-    edge_properties_read_.insert(names.begin(), names.end());
+  void InsertNodePropertyWrite(std::string rdg_dir, const Container& names) {
+    for (auto name : names) {
+      node_properties_write_.insert(ConcatRDGProperty(rdg_dir, name));
+    }
   }
 
-  void InsertEdgePropertyWrite(std::string name) {
-    edge_properties_write_.insert(name);
+  void InsertEdgePropertyRead(std::string rdg_dir, std::string name) {
+    edge_properties_read_.insert(ConcatRDGProperty(rdg_dir, name));
   }
 
   template <typename Container>
-  void InsertEdgePropertyWrite(const Container& names) {
-    edge_properties_write_.insert(names.begin(), names.end());
+  void InsertEdgePropertyRead(std::string rdg_dir, const Container& names) {
+    for (auto name : names) {
+      edge_properties_read_.insert(ConcatRDGProperty(rdg_dir, name));
+    }
+  }
+
+  void InsertEdgePropertyWrite(std::string rdg_dir, std::string name) {
+    edge_properties_write_.insert(ConcatRDGProperty(rdg_dir, name));
+  }
+
+  template <typename Container>
+  void InsertEdgePropertyWrite(std::string rdg_dir, const Container& names) {
+    for (auto name : names) {
+      edge_properties_write_.insert(ConcatRDGProperty(rdg_dir, name));
+    }
   }
 
   void SetAllPropertiesRead() { all_properties_read_ = true; }
@@ -78,6 +86,12 @@ public:
   bool GetTopologyWrite() const { return topology_write_; }
 
 private:
+  std::string ConcatRDGProperty(std::string rdg_dir, std::string prop) {
+    return rdg_dir + kPropSeparator + prop;
+  }
+
+  static constexpr char kPropSeparator[] = "/propertyseparator/";
+
   std::set<std::string> node_properties_read_;
   std::set<std::string> node_properties_write_;
   std::set<std::string> edge_properties_read_;

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -185,7 +185,8 @@ katana::RDGCore::AddNodeProperties(
   auto written_prop_names = KATANA_CHECKED(AddProperties(
       props, &node_properties_, &part_header_.node_prop_info_list()));
   // store write properties into transaction context
-  txn_ctx->InsertNodePropertyWrite<std::set<std::string>>(written_prop_names);
+  txn_ctx->InsertNodePropertyWrite<std::set<std::string>>(
+      rdg_dir_.string(), written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -197,7 +198,8 @@ katana::RDGCore::AddEdgeProperties(
   auto written_prop_names = KATANA_CHECKED(AddProperties(
       props, &edge_properties_, &part_header_.edge_prop_info_list()));
   // store write properties into transaction context
-  txn_ctx->InsertEdgePropertyWrite<std::set<std::string>>(written_prop_names);
+  txn_ctx->InsertEdgePropertyWrite<std::set<std::string>>(
+      rdg_dir_.string(), written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -209,7 +211,8 @@ katana::RDGCore::UpsertNodeProperties(
   auto written_prop_names = KATANA_CHECKED(UpsertProperties(
       props, &node_properties_, &part_header_.node_prop_info_list()));
   // store write properties into transaction context
-  txn_ctx->InsertNodePropertyWrite<std::set<std::string>>(written_prop_names);
+  txn_ctx->InsertNodePropertyWrite<std::set<std::string>>(
+      rdg_dir_.string(), written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -221,7 +224,8 @@ katana::RDGCore::UpsertEdgeProperties(
   auto written_prop_names = KATANA_CHECKED(UpsertProperties(
       props, &edge_properties_, &part_header_.edge_prop_info_list()));
   // store write properties into transaction context
-  txn_ctx->InsertEdgePropertyWrite<std::set<std::string>>(written_prop_names);
+  txn_ctx->InsertEdgePropertyWrite<std::set<std::string>>(
+      rdg_dir_.string(), written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -279,7 +283,7 @@ katana::RDGCore::RemoveNodeProperty(int i, katana::TxnContext* txn_ctx) {
   auto field = node_properties_->field(i);
   node_properties_ = KATANA_CHECKED(node_properties_->RemoveColumn(i));
   // store write properties into transaction context
-  txn_ctx->InsertNodePropertyWrite(field->name());
+  txn_ctx->InsertNodePropertyWrite(rdg_dir_.string(), field->name());
 
   return part_header_.RemoveNodeProperty(field->name());
 }
@@ -289,7 +293,7 @@ katana::RDGCore::RemoveEdgeProperty(int i, katana::TxnContext* txn_ctx) {
   auto field = edge_properties_->field(i);
   edge_properties_ = KATANA_CHECKED(edge_properties_->RemoveColumn(i));
   // store write properties into transaction context
-  txn_ctx->InsertEdgePropertyWrite(field->name());
+  txn_ctx->InsertEdgePropertyWrite(rdg_dir_.string(), field->name());
 
   return part_header_.RemoveEdgeProperty(field->name());
 }


### PR DESCRIPTION
Add RDG directory as prefix when tracking property names in `TxnContext`. This is for graphs with the same property names.

Jira tasks: [KAT-1688] [KAT-3051]
Enterprise repo: [PR #3105](https://github.com/KatanaGraph/katana-enterprise/pull/3105)

[KAT-1688]: https://katanagraph.atlassian.net/browse/KAT-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAT-3051]: https://katanagraph.atlassian.net/browse/KAT-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ