### PR TITLE
RDG: add NUMAArrray type ids interface

### DIFF
--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -16,6 +16,7 @@
 #include "katana/ErrorCode.h"
 #include "katana/FileFrame.h"
 #include "katana/FileView.h"
+#include "katana/NUMAArray.h"
 #include "katana/PartitionMetadata.h"
 #include "katana/RDGLineage.h"
 #include "katana/RDGStorageFormatVersion.h"
@@ -292,9 +293,13 @@ public:
 
   const FileView& edge_entity_type_id_array_file_storage() const;
 
-  katana::Result<katana::EntityTypeManager> node_entity_type_manager() const;
+  Result<EntityTypeManager> node_entity_type_manager() const;
 
-  katana::Result<katana::EntityTypeManager> edge_entity_type_manager() const;
+  Result<EntityTypeManager> edge_entity_type_manager() const;
+
+  Result<NUMAArray<EntityTypeID>> node_entity_type_id_array() const;
+
+  Result<NUMAArray<EntityTypeID>> edge_entity_type_id_array() const;
 
   void set_view_name(const std::string& v) { view_type_ = v; }
 

--- a/libtsuba/include/katana/RDGSlice.h
+++ b/libtsuba/include/katana/RDGSlice.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "katana/FileView.h"
+#include "katana/NUMAArray.h"
 #include "katana/RDGLineage.h"
 #include "katana/RDGTopology.h"
 #include "katana/Result.h"
@@ -132,8 +133,10 @@ public:
   bool IsUint16tEntityTypeIDs() const;
   const FileView& node_entity_type_id_array_file_storage() const;
   const FileView& edge_entity_type_id_array_file_storage() const;
-  katana::Result<katana::EntityTypeManager> node_entity_type_manager() const;
-  katana::Result<katana::EntityTypeManager> edge_entity_type_manager() const;
+  Result<EntityTypeManager> node_entity_type_manager() const;
+  Result<EntityTypeManager> edge_entity_type_manager() const;
+  Result<NUMAArray<EntityTypeID>> node_entity_type_id_array() const;
+  Result<NUMAArray<EntityTypeID>> edge_entity_type_id_array() const;
 
 private:
   static katana::Result<RDGSlice> Make(

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -980,11 +980,6 @@ katana::RDG::node_entity_type_manager() const {
   return core_->part_header().GetNodeEntityTypeManager();
 }
 
-katana::Result<katana::EntityTypeManager>
-katana::RDG::edge_entity_type_manager() const {
-  return core_->part_header().GetEdgeEntityTypeManager();
-}
-
 katana::Result<void>
 katana::RDG::UnbindNodeEntityTypeIDArrayFileStorage() {
   return core_->node_entity_type_id_array_file_storage().Unbind();
@@ -1003,9 +998,19 @@ katana::RDG::SetNodeEntityTypeIDArrayFile(
   return core_->RegisterNodeEntityTypeIDArrayFile(new_type_id_array.BaseName());
 }
 
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+katana::RDG::node_entity_type_id_array() const {
+  return KATANA_CHECKED(core_->node_entity_type_id_array());
+}
+
 const katana::FileView&
 katana::RDG::edge_entity_type_id_array_file_storage() const {
   return core_->edge_entity_type_id_array_file_storage();
+}
+
+katana::Result<katana::EntityTypeManager>
+katana::RDG::edge_entity_type_manager() const {
+  return core_->part_header().GetEdgeEntityTypeManager();
 }
 
 katana::Result<void>
@@ -1024,6 +1029,11 @@ katana::RDG::SetEdgeEntityTypeIDArrayFile(
         rdg_dir());
   }
   return core_->RegisterEdgeEntityTypeIDArrayFile(new_type_id_array.BaseName());
+}
+
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+katana::RDG::edge_entity_type_id_array() const {
+  return KATANA_CHECKED(core_->edge_entity_type_id_array());
 }
 
 katana::RDG::RDG(std::unique_ptr<RDGCore>&& core) : core_(std::move(core)) {}

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -5,6 +5,7 @@
 #include "katana/ArrowInterchange.h"
 #include "katana/ErrorCode.h"
 #include "katana/ParquetReader.h"
+#include "katana/RDGPrefix.h"
 #include "katana/Result.h"
 
 namespace {
@@ -131,6 +132,40 @@ schemify(const std::vector<katana::PropStorageInfo>& prop_info_list) {
   }
   return arrow::schema(fields);
 }
+
+template <typename StorageType>
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+LoadAndMaybeConvertTypeIDArray(
+    size_t begin, size_t end, const katana::Uri& types_path,
+    const katana::RDGPartHeader& part_header) {
+  katana::NUMAArray<katana::EntityTypeID> types;
+
+  // NB: we add sizeof(EntityTypeIDArrayHeader) to every range element because
+  // the structure of this file is
+  // [header, value, value, value, ...]
+  // Recent storage formats remove this header
+  size_t header_size = part_header.unstable_storage_format()
+                           ? 0
+                           : sizeof(katana::EntityTypeIDArrayHeader);
+  size_t storage_begin = begin * sizeof(StorageType) + header_size;
+  size_t storage_end = end * sizeof(StorageType) + header_size;
+
+  katana::FileView fv;
+
+  KATANA_CHECKED_CONTEXT(
+      fv.Bind(types_path.string(), storage_begin, storage_end, true),
+      "loading node type id array, begin: {}, end: {}", begin, end);
+
+  types.allocateInterleaved(end - begin);
+
+  const auto* storage_types = fv.template valid_ptr<StorageType>();
+  katana::do_all(
+      katana::iterate(size_t{0}, end - begin),
+      [&types, &storage_types](size_t i) { types[i] = storage_types[i]; });
+
+  return types;
+}
+
 }  // namespace
 
 std::shared_ptr<arrow::Schema>
@@ -292,4 +327,49 @@ katana::RDGCore::RemoveEdgeProperty(int i, katana::TxnContext* txn_ctx) {
   txn_ctx->InsertEdgePropertyWrite(field->name());
 
   return part_header_.RemoveEdgeProperty(field->name());
+}
+
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+katana::RDGCore::node_entity_type_id_array(size_t begin, size_t end) const {
+  if (part_header().IsEntityTypeIDsOutsideProperties()) {
+    NUMAArray<EntityTypeID> types;
+    return types;
+  }
+  end = std::min(end, size_t{part_header().metadata().num_nodes_});
+
+  katana::Uri node_types_path =
+      rdg_dir_.Join(part_header().node_entity_type_id_array_path());
+
+  if (part_header().IsUint16tEntityTypeIDs()) {
+    return KATANA_CHECKED(LoadAndMaybeConvertTypeIDArray<EntityTypeID>(
+        begin, end, node_types_path, part_header()));
+
+  } else {
+    return KATANA_CHECKED(LoadAndMaybeConvertTypeIDArray<uint8_t>(
+        begin, end, node_types_path, part_header()));
+  }
+
+  return KATANA_ERROR(katana::ErrorCode::AssertionFailed, "unreachable");
+}
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+katana::RDGCore::edge_entity_type_id_array(size_t begin, size_t end) const {
+  if (part_header().IsEntityTypeIDsOutsideProperties()) {
+    NUMAArray<EntityTypeID> types;
+    return types;
+  }
+  end = std::min(end, size_t{part_header().metadata().num_edges_});
+
+  katana::Uri edge_types_path =
+      rdg_dir_.Join(part_header().edge_entity_type_id_array_path());
+
+  if (part_header().IsUint16tEntityTypeIDs()) {
+    return KATANA_CHECKED(LoadAndMaybeConvertTypeIDArray<EntityTypeID>(
+        begin, end, edge_types_path, part_header()));
+
+  } else {
+    return KATANA_CHECKED(LoadAndMaybeConvertTypeIDArray<uint8_t>(
+        begin, end, edge_types_path, part_header()));
+  }
+
+  return KATANA_ERROR(katana::ErrorCode::AssertionFailed, "unreachable");
 }

--- a/libtsuba/src/RDGCore.h
+++ b/libtsuba/src/RDGCore.h
@@ -10,6 +10,7 @@
 #include "RDGTopologyManager.h"
 #include "katana/FileView.h"
 #include "katana/Logging.h"
+#include "katana/NUMAArray.h"
 #include "katana/RDGTopology.h"
 #include "katana/Result.h"
 #include "katana/TxnContext.h"
@@ -171,6 +172,13 @@ public:
 
   const RDGLineage& lineage() const { return lineage_; }
   void set_lineage(RDGLineage&& lineage) { lineage_ = lineage; }
+
+  /// An alternate interface for loading entity type ids
+  Result<NUMAArray<EntityTypeID>> node_entity_type_id_array(
+      size_t begin = 0, size_t end = std::numeric_limits<size_t>::max()) const;
+  /// An alternate interface for loading entity type ids
+  Result<NUMAArray<EntityTypeID>> edge_entity_type_id_array(
+      size_t begin = 0, size_t end = std::numeric_limits<size_t>::max()) const;
 
   const FileView& node_entity_type_id_array_file_storage() const {
     return node_entity_type_id_array_file_storage_;

--- a/libtsuba/src/RDGSlice.cpp
+++ b/libtsuba/src/RDGSlice.cpp
@@ -577,6 +577,18 @@ katana::RDGSlice::edge_entity_type_manager() const {
   return core_->part_header().GetEdgeEntityTypeManager();
 }
 
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+katana::RDGSlice::node_entity_type_id_array() const {
+  return KATANA_CHECKED(core_->node_entity_type_id_array(
+      slice_arg_.node_range.first, slice_arg_.node_range.second));
+}
+
+katana::Result<katana::NUMAArray<katana::EntityTypeID>>
+katana::RDGSlice::edge_entity_type_id_array() const {
+  return KATANA_CHECKED(core_->edge_entity_type_id_array(
+      slice_arg_.edge_range.first, slice_arg_.edge_range.second));
+}
+
 katana::RDGSlice::RDGSlice(std::unique_ptr<RDGCore>&& core)
     : core_(std::move(core)) {}
 


### PR DESCRIPTION
A common pattern is to load the file associated with a type id
array and then copy it into a NUMAArray. Move this pattern into the RDG
itself so it isn't duplicated so many times. Centralizing this in
RDGCore also creates a single location where storage format
complications are handled.