### PR TITLE
Introduce RDGOptionalDatastructures: RDKLSHIndex

### DIFF
--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -351,6 +351,34 @@ public:
   template <typename integer>
   void AppendOffsets(std::vector<integer>* vec) const;
 
+  DynamicBitset& operator|=(const DynamicBitset& other) {
+    KATANA_LOG_ASSERT(size() == other.size());
+    bitwise_or(other);
+    return *this;
+  }
+
+  DynamicBitset& operator&=(const DynamicBitset& other) {
+    KATANA_LOG_ASSERT(size() == other.size());
+    bitwise_and(other);
+    return *this;
+  }
+
+  bool operator==(const DynamicBitset& other) const { return Equals(other); }
+
+  bool operator!=(const DynamicBitset& other) const { return !Equals(other); }
+
+  bool Equals(const DynamicBitset& other) const {
+    if (size() != other.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < size(); i++) {
+      if (test(i) != other.test(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   //TODO(emcginnis): DynamicBitset is not actually memory copyable, remove this
   //! this is defined to
   using tt_is_copyable = int;

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -315,6 +315,24 @@ public:
     return *edge_entity_type_manager_;
   }
 
+  Result<std::optional<RDKLSHIndexPrimitive>> LoadRDKLSHIndexPrimitive() {
+    return rdg_->LoadRDKLSHIndexPrimitive();
+  }
+
+  Result<void> WriteRDKLSHIndexPrimitive(RDKLSHIndexPrimitive& index) {
+    return rdg_->WriteRDKLSHIndexPrimitive(index);
+  }
+
+  Result<std::optional<RDKSubstructureIndexPrimitive>>
+  LoadRDKSubstructureIndexPrimitive() {
+    return rdg_->LoadRDKSubstructureIndexPrimitive();
+  }
+
+  Result<void> WriteRDKSubstructureIndexPrimitive(
+      RDKSubstructureIndexPrimitive& index) {
+    return rdg_->WriteRDKSubstructureIndexPrimitive(index);
+  }
+
   const std::string& rdg_dir() const { return rdg_->rdg_dir().string(); }
 
   uint32_t partition_id() const { return rdg_->partition_id(); }

--- a/libtsuba/include/katana/RDG.h
+++ b/libtsuba/include/katana/RDG.h
@@ -21,6 +21,8 @@
 #include "katana/RDGLineage.h"
 #include "katana/RDGStorageFormatVersion.h"
 #include "katana/RDGTopology.h"
+#include "katana/RDKLSHIndexPrimitive.h"
+#include "katana/RDKSubstructureIndexPrimitive.h"
 #include "katana/ReadGroup.h"
 #include "katana/Result.h"
 #include "katana/TxnContext.h"
@@ -311,6 +313,20 @@ public:
   void set_prop_cache(katana::PropertyCache* prop_cache) {
     prop_cache_ = prop_cache;
   }
+
+  // Returns katana::ResultErrno if the RDKLSHIndexPrimitive is not found on disk
+  katana::Result<std::optional<katana::RDKLSHIndexPrimitive>>
+  LoadRDKLSHIndexPrimitive();
+
+  katana::Result<void> WriteRDKLSHIndexPrimitive(
+      katana::RDKLSHIndexPrimitive& index);
+
+  // Returns katana::ResultErrno if the RDKSubstructureIndexPrimitive is not found on disk
+  katana::Result<std::optional<katana::RDKSubstructureIndexPrimitive>>
+  LoadRDKSubstructureIndexPrimitive();
+
+  katana::Result<void> WriteRDKSubstructureIndexPrimitive(
+      katana::RDKSubstructureIndexPrimitive& index);
 
 private:
   std::string view_type_;

--- a/libtsuba/include/katana/RDGOptionalDatastructure.h
+++ b/libtsuba/include/katana/RDGOptionalDatastructure.h
@@ -1,0 +1,82 @@
+#ifndef KATANA_LIBTSUBA_KATANA_RDGOPTIONALDATASTRUCTURE_H_
+#define KATANA_LIBTSUBA_KATANA_RDGOPTIONALDATASTRUCTURE_H_
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "katana/AtomicWrapper.h"
+#include "katana/DynamicBitset.h"
+#include "katana/ErrorCode.h"
+#include "katana/FileView.h"
+#include "katana/JSON.h"
+#include "katana/Logging.h"
+#include "katana/NUMAArray.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+#include "katana/WriteGroup.h"
+#include "katana/config.h"
+#include "katana/tsuba.h"
+
+namespace katana {
+
+/// Base class for all optional datastructures.
+/// Paths to the RDGOptionalDatastructure files are stored in the RDGPartHeader::optional_datastructure_manifests_
+class KATANA_EXPORT RDGOptionalDatastructure {
+public:
+  std::map<std::string, std::string> paths() const { return paths_; }
+  void set_paths(std::map<std::string, std::string> paths) { paths_ = paths; }
+
+  /// Load() should make the Optional Data structure fully available to the caller,
+  /// Mapping any additional files defined in paths_ into memory as necessary
+  static katana::Result<RDGOptionalDatastructure> Load(
+      const katana::Uri& rdg_dir_path, const std::string& path) = delete;
+
+  /// Write() should immediately persist the optional data structure to disk
+  /// Users of RDGOptionalDatastructures should ensure Write() is called before RDG::Store()
+  katana::Result<std::string> Write(katana::Uri rdg_dir_path) = delete;
+
+  static katana::Result<void> ChangeStorageLocation(
+      const std::string& manifest_relpath, const katana::Uri& old_loc,
+      const katana::Uri& new_loc) {
+    katana::Uri old_manifest_path = old_loc.Join(manifest_relpath);
+    katana::FileView fv;
+    KATANA_CHECKED(fv.Bind(old_manifest_path.string(), true));
+    RDGOptionalDatastructure data;
+    KATANA_CHECKED(katana::JsonParse<RDGOptionalDatastructure>(fv, &data));
+
+    // copy over any extra files the optional datastructure relies on
+    // Assumes that all OptionalDatastructures properly extend the RDGOptionalDatastructure class
+    for (const auto& file : data.paths_) {
+      katana::FileView fvtmp;
+      katana::Uri old_path = old_loc.Join(file.second);
+      KATANA_CHECKED(fvtmp.Bind(old_path.string(), true));
+      katana::Uri new_path = new_loc.Join(file.second);
+      KATANA_CHECKED(katana::FileStore(
+          new_path.string(), fvtmp.ptr<uint8_t>(), fvtmp.size()));
+      KATANA_CHECKED(fvtmp.Unbind());
+    }
+
+    // copy out the manifest itself
+    katana::Uri new_manifest_path = new_loc.Join(manifest_relpath);
+    KATANA_CHECKED(katana::FileStore(
+        new_manifest_path.string(), fv.ptr<uint8_t>(), fv.size()));
+    KATANA_CHECKED(fv.Unbind());
+
+    return katana::ResultSuccess();
+  }
+
+  friend void to_json(nlohmann::json& j, const RDGOptionalDatastructure& data);
+  friend void from_json(
+      const nlohmann::json& j, RDGOptionalDatastructure& data);
+
+protected:
+  // map of exta files this optional datastructure will load
+  // { "file_name" : "rdg-relative_path" }
+  // track these so that when we move the RDG, we also move these extra files
+  std::map<std::string, std::string> paths_;
+};
+
+}  // namespace katana
+
+#endif

--- a/libtsuba/include/katana/RDKLSHIndexPrimitive.h
+++ b/libtsuba/include/katana/RDKLSHIndexPrimitive.h
@@ -1,0 +1,127 @@
+#ifndef KATANA_LIBTSUBA_KATANA_RDKLSHINDEXPRIMITIVE_H_
+#define KATANA_LIBTSUBA_KATANA_RDKLSHINDEXPRIMITIVE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "katana/AtomicWrapper.h"
+#include "katana/DynamicBitset.h"
+#include "katana/ErrorCode.h"
+#include "katana/FileView.h"
+#include "katana/JSON.h"
+#include "katana/Logging.h"
+#include "katana/NUMAArray.h"
+#include "katana/RDGOptionalDatastructure.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+#include "katana/WriteGroup.h"
+#include "katana/config.h"
+#include "katana/tsuba.h"
+
+namespace katana {
+
+const std::string kOptionalDatastructureRDKLSHIndexPrimitive =
+    "kg.v1.rdk_lsh_index";
+
+class KATANA_EXPORT RDKLSHIndexPrimitive
+    : private katana::RDGOptionalDatastructure {
+public:
+  static katana::Result<RDKLSHIndexPrimitive> Load(
+      const katana::Uri& rdg_dir_path, const std::string& path) {
+    RDKLSHIndexPrimitive index =
+        KATANA_CHECKED(LoadJson(rdg_dir_path.Join(path).string()));
+    return index;
+  }
+
+  katana::Result<std::string> Write(katana::Uri rdg_dir_path) {
+    // Write out our json manifest
+    katana::Uri manifest_path = rdg_dir_path.RandFile("rdk_lsh_index_manifest");
+    KATANA_CHECKED(WriteManifest(manifest_path.string()));
+    return manifest_path.BaseName();
+  }
+
+  uint64_t num_hashes_per_bucket() const { return num_hashes_per_bucket_; }
+  void set_num_hashes_per_bucket(uint64_t num) { num_hashes_per_bucket_ = num; }
+
+  uint64_t num_buckets() const { return num_buckets_; }
+  void set_num_buckets(const uint64_t num) { num_buckets_ = num; }
+
+  uint64_t fingerprint_length() const { return fingerprint_length_; }
+  void set_fingerprint_length(const uint64_t len) { fingerprint_length_ = len; }
+
+  size_t num_fingerprints() const { return num_fingerprints_; }
+  void set_num_fingerprints(const size_t num) { num_fingerprints_ = num; }
+
+  std::vector<std::map<uint64_t, std::vector<uint64_t>>>& hash_structure() {
+    return hash_structure_;
+  }
+  void set_hash_structure(
+      std::vector<std::map<uint64_t, std::vector<uint64_t>>> hash_struct) {
+    hash_structure_ = std::move(hash_struct);
+  }
+
+  std::vector<katana::DynamicBitset>& fingerprints() { return fingerprints_; }
+  void set_fingerprints(std::vector<katana::DynamicBitset> prints) {
+    fingerprints_ = std::move(prints);
+  }
+
+  std::vector<std::string> smiles() { return smiles_; }
+  void set_smiles(std::vector<std::string> smiles) {
+    smiles_ = std::move(smiles);
+  }
+
+  friend void to_json(nlohmann::json& j, const RDKLSHIndexPrimitive& index);
+  friend void from_json(const nlohmann::json& j, RDKLSHIndexPrimitive& index);
+
+private:
+  uint64_t num_hashes_per_bucket_;
+  uint64_t num_buckets_;
+  uint64_t fingerprint_length_;
+  size_t num_fingerprints_;
+
+  std::vector<std::string> smiles_;
+
+  /// data structures dumped to their own files
+
+  std::vector<std::map<uint64_t, std::vector<uint64_t>>> hash_structure_;
+
+  // Array of fingerprint bitsets indexed on num_fingerprints_
+  std::vector<katana::DynamicBitset> fingerprints_;
+
+  static katana::Result<RDKLSHIndexPrimitive> LoadJson(
+      const std::string& path) {
+    katana::FileView fv;
+    KATANA_CHECKED(fv.Bind(path, true));
+
+    if (fv.size() == 0) {
+      return RDKLSHIndexPrimitive();
+    }
+
+    RDKLSHIndexPrimitive index;
+    KATANA_CHECKED(katana::JsonParse<RDKLSHIndexPrimitive>(fv, &index));
+
+    return index;
+  }
+
+  katana::Result<void> WriteManifest(const std::string& path) const {
+    std::string serialized = KATANA_CHECKED(katana::JsonDump(*this));
+    // POSIX files end with newlines
+    serialized = serialized + "\n";
+
+    auto ff = std::make_unique<katana::FileFrame>();
+    KATANA_CHECKED(ff->Init(serialized.size()));
+    if (auto res = ff->Write(serialized.data(), serialized.size()); !res.ok()) {
+      return KATANA_ERROR(
+          katana::ArrowToKatana(res.code()), "arrow error: {}", res);
+    }
+    ff->Bind(path);
+    // persist now
+    KATANA_CHECKED(ff->Persist());
+
+    return katana::ResultSuccess();
+  }
+};
+
+}  // namespace katana
+
+#endif

--- a/libtsuba/include/katana/RDKSubstructureIndexPrimitive.h
+++ b/libtsuba/include/katana/RDKSubstructureIndexPrimitive.h
@@ -1,0 +1,121 @@
+#ifndef KATANA_LIBTSUBA_KATANA_RDKSUBSTRUCTUREINDEXPRIMITIVE_H_
+#define KATANA_LIBTSUBA_KATANA_RDKSUBSTRUCTUREINDEXPRIMITIVE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "katana/AtomicWrapper.h"
+#include "katana/DynamicBitset.h"
+#include "katana/ErrorCode.h"
+#include "katana/FileView.h"
+#include "katana/JSON.h"
+#include "katana/Logging.h"
+#include "katana/NUMAArray.h"
+#include "katana/RDGOptionalDatastructure.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+#include "katana/WriteGroup.h"
+#include "katana/config.h"
+#include "katana/tsuba.h"
+
+namespace katana {
+
+const std::string kOptionalDatastructureRDKSubstructureIndexPrimitive =
+    "kg.v1.rdk_substructure_index";
+
+class KATANA_EXPORT RDKSubstructureIndexPrimitive
+    : private katana::RDGOptionalDatastructure {
+public:
+  static katana::Result<RDKSubstructureIndexPrimitive> Load(
+      const katana::Uri& rdg_dir_path, const std::string& path) {
+    RDKSubstructureIndexPrimitive substructure_index =
+        KATANA_CHECKED(LoadJson(rdg_dir_path.Join(path).string()));
+    return substructure_index;
+  }
+
+  katana::Result<std::string> Write(katana::Uri rdg_dir_path) {
+    // Write out our json manifest
+    katana::Uri manifest_path =
+        rdg_dir_path.RandFile("rdk_substructure_index_manifest");
+    KATANA_CHECKED(WriteManifest(manifest_path.string()));
+    return manifest_path.BaseName();
+  }
+
+  size_t fp_size() const { return fp_size_; }
+  void set_fp_size(size_t size) { fp_size_ = size; }
+
+  size_t num_entries() const { return num_entries_; }
+  void set_num_entries(size_t num) { num_entries_ = num; }
+
+  std::vector<std::vector<std::uint64_t>>& index() { return index_; }
+  void set_index(std::vector<std::vector<std::uint64_t>> index) {
+    index_ = std::move(index);
+  }
+
+  std::vector<katana::DynamicBitset>& fingerprints() { return fingerprints_; }
+  void set_fingerprints(std::vector<katana::DynamicBitset> prints) {
+    fingerprints_ = std::move(prints);
+  }
+
+  std::vector<std::string> smiles() { return smiles_; }
+  void set_smiles(std::vector<std::string> smiles) {
+    smiles_ = std::move(smiles);
+  }
+
+  friend void to_json(
+      nlohmann::json& j, const RDKSubstructureIndexPrimitive& index);
+  friend void from_json(
+      const nlohmann::json& j, RDKSubstructureIndexPrimitive& index);
+
+private:
+  size_t fp_size_;
+
+  size_t num_entries_;
+
+  // Array of smiles strings indexed on num_entries
+  std::vector<std::string> smiles_;
+
+  // Array of fingerprint bitsets indexed on num_entries
+  std::vector<katana::DynamicBitset> fingerprints_;
+
+  // has size fp_size
+  std::vector<std::vector<std::uint64_t>> index_;
+
+  static katana::Result<RDKSubstructureIndexPrimitive> LoadJson(
+      const std::string& path) {
+    katana::FileView fv;
+    KATANA_CHECKED(fv.Bind(path, true));
+
+    if (fv.size() == 0) {
+      return RDKSubstructureIndexPrimitive();
+    }
+
+    RDKSubstructureIndexPrimitive substructure_index;
+    KATANA_CHECKED(katana::JsonParse<RDKSubstructureIndexPrimitive>(
+        fv, &substructure_index));
+
+    return substructure_index;
+  }
+
+  katana::Result<void> WriteManifest(const std::string& path) const {
+    std::string serialized = KATANA_CHECKED(katana::JsonDump(*this));
+    // POSIX files end with newlines
+    serialized = serialized + "\n";
+
+    auto ff = std::make_unique<katana::FileFrame>();
+    KATANA_CHECKED(ff->Init(serialized.size()));
+    if (auto res = ff->Write(serialized.data(), serialized.size()); !res.ok()) {
+      return KATANA_ERROR(
+          katana::ArrowToKatana(res.code()), "arrow error: {}", res);
+    }
+    ff->Bind(path);
+    // persist now
+    KATANA_CHECKED(ff->Persist());
+
+    return katana::ResultSuccess();
+  }
+};
+
+}  // namespace katana
+
+#endif

--- a/libtsuba/src/FileView.cpp
+++ b/libtsuba/src/FileView.cpp
@@ -67,7 +67,7 @@ katana::FileView::Bind(
     std::string_view filename, uint64_t begin, uint64_t end, bool resolve) {
   StatBuf buf;
   filename_ = filename;
-  KATANA_CHECKED(FileStat(filename_, &buf));
+  KATANA_CHECKED_CONTEXT(FileStat(filename_, &buf), "{}", filename);
 
   uint64_t in_end = std::min<uint64_t>(end, static_cast<uint64_t>(buf.size));
   if (in_end < begin) {

--- a/libtsuba/src/RDG.cpp
+++ b/libtsuba/src/RDG.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <regex>
 #include <string>
 #include <unordered_set>
@@ -1046,6 +1047,80 @@ katana::RDG::SetEdgeEntityTypeIDArrayFile(
 katana::Result<katana::NUMAArray<katana::EntityTypeID>>
 katana::RDG::edge_entity_type_id_array() const {
   return KATANA_CHECKED(core_->edge_entity_type_id_array());
+}
+
+katana::Result<std::optional<katana::RDKLSHIndexPrimitive>>
+katana::RDG::LoadRDKLSHIndexPrimitive() {
+  if (!KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)) {
+    return KATANA_ERROR(
+        ErrorCode::InvalidArgument,
+        "The UnstableRDGStorageFormat feature flag must be set to use this "
+        "feature");
+  }
+  std::optional<std::string> res =
+      KATANA_CHECKED(core_->part_header().OptionalDatastructureManifest(
+          kOptionalDatastructureRDKLSHIndexPrimitive));
+  if (!res) {
+    return std::nullopt;
+  }
+
+  katana::RDKLSHIndexPrimitive index = KATANA_CHECKED_CONTEXT(
+      katana::RDKLSHIndexPrimitive::Load(rdg_dir(), res.value()),
+      "Failed to load RDKLSHIndexPrimitive located at {}", res.value());
+  return index;
+}
+
+katana::Result<void>
+katana::RDG::WriteRDKLSHIndexPrimitive(katana::RDKLSHIndexPrimitive& index) {
+  if (!KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)) {
+    return KATANA_ERROR(
+        ErrorCode::InvalidArgument,
+        "The UnstableRDGStorageFormat feature flag must be set to use this "
+        "feature");
+  }
+  std::string path = KATANA_CHECKED(index.Write(rdg_dir()));
+  core_->part_header().AppendOptionalDatastructureManifest(
+      kOptionalDatastructureRDKLSHIndexPrimitive, path);
+
+  return katana::ResultSuccess();
+}
+
+katana::Result<std::optional<katana::RDKSubstructureIndexPrimitive>>
+katana::RDG::LoadRDKSubstructureIndexPrimitive() {
+  if (!KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)) {
+    return KATANA_ERROR(
+        ErrorCode::InvalidArgument,
+        "The UnstableRDGStorageFormat feature flag must be set to use this "
+        "feature");
+  }
+  std::optional<std::string> res =
+      KATANA_CHECKED(core_->part_header().OptionalDatastructureManifest(
+          kOptionalDatastructureRDKSubstructureIndexPrimitive));
+  if (!res) {
+    return std::nullopt;
+  }
+
+  katana::RDKSubstructureIndexPrimitive index = KATANA_CHECKED_CONTEXT(
+      katana::RDKSubstructureIndexPrimitive::Load(rdg_dir(), res.value()),
+      "Failed to load RDKSubstructureIndexPrimitive located at {}",
+      res.value());
+  return index;
+}
+
+katana::Result<void>
+katana::RDG::WriteRDKSubstructureIndexPrimitive(
+    katana::RDKSubstructureIndexPrimitive& index) {
+  if (!KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat)) {
+    return KATANA_ERROR(
+        ErrorCode::InvalidArgument,
+        "The UnstableRDGStorageFormat feature flag must be set to use this "
+        "feature");
+  }
+  std::string path = KATANA_CHECKED(index.Write(rdg_dir()));
+  core_->part_header().AppendOptionalDatastructureManifest(
+      kOptionalDatastructureRDKSubstructureIndexPrimitive, path);
+
+  return katana::ResultSuccess();
 }
 
 katana::RDG::RDG(std::unique_ptr<RDGCore>&& core) : core_(std::move(core)) {}

--- a/libtsuba/src/RDGPartHeader.h
+++ b/libtsuba/src/RDGPartHeader.h
@@ -21,6 +21,8 @@
 #include "katana/RDG.h"
 #include "katana/RDGStorageFormatVersion.h"
 #include "katana/RDGTopology.h"
+#include "katana/RDKLSHIndexPrimitive.h"
+#include "katana/RDKSubstructureIndexPrimitive.h"
 #include "katana/Result.h"
 #include "katana/URI.h"
 #include "katana/WriteGroup.h"
@@ -469,6 +471,26 @@ public:
     return topology_metadata_.Append(std::move(new_entry));
   }
 
+  katana::Result<std::optional<std::string>> OptionalDatastructureManifest(
+      const std::string& optional_datastructure_name) {
+    auto search =
+        optional_datastructure_manifests_.find(optional_datastructure_name);
+    if (search != optional_datastructure_manifests_.end()) {
+      return search->second;
+    }
+    KATANA_LOG_DEBUG(
+        "No optional datastructure manifest available matching [{}]",
+        optional_datastructure_name);
+    return std::nullopt;
+  }
+
+  void AppendOptionalDatastructureManifest(
+      const std::string& optional_datastructure_name,
+      const std::string& optional_datastructure_path) {
+    optional_datastructure_manifests_.emplace(
+        optional_datastructure_name, optional_datastructure_path);
+  }
+
   friend void to_json(nlohmann::json& j, const RDGPartHeader& header);
   friend void from_json(const nlohmann::json& j, RDGPartHeader& header);
 
@@ -628,6 +650,11 @@ private:
   // entity_type_id_name maps from Atomic Entity Type ID to string name for the Entity Type ID
   katana::EntityTypeIDToAtomicTypeNameMap node_entity_type_id_name_;
   katana::EntityTypeIDToAtomicTypeNameMap edge_entity_type_id_name_;
+
+  // map from the name of an optional_datastructure to its json manifest path
+  // if no optional data structures are present, this map is empty
+  std::unordered_map<std::string, std::string>
+      optional_datastructure_manifests_;
 };
 
 void to_json(nlohmann::json& j, const RDGPartHeader& header);
@@ -647,6 +674,18 @@ void from_json(const nlohmann::json& j, PartitionTopologyMetadata& topomd);
 
 void to_json(
     nlohmann::json& j, const std::vector<katana::PropStorageInfo>& vec_pmd);
+
+void to_json(nlohmann::json& j, const katana::DynamicBitset& topomd);
+void from_json(const nlohmann::json& j, katana::DynamicBitset& topomd);
+
+void to_json(nlohmann::json& j, const RDKLSHIndexPrimitive& index);
+void from_json(const nlohmann::json& j, RDKLSHIndexPrimitive& index);
+
+void to_json(nlohmann::json& j, const RDKSubstructureIndexPrimitive& index);
+void from_json(const nlohmann::json& j, RDKSubstructureIndexPrimitive& index);
+
+void to_json(nlohmann::json& j, const RDGOptionalDatastructure& data);
+void from_json(const nlohmann::json& j, RDGOptionalDatastructure& data);
 
 // nlohmann map enum values to JSON as strings
 // *** do not alter these mappings, only append to them ***

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -9,6 +9,7 @@
 #include "katana/FileView.h"
 #include "katana/Plugin.h"
 #include "katana/Signals.h"
+#include "katana/URI.h"
 #include "katana/file.h"
 
 namespace {

--- a/libtsuba/test/CMakeLists.txt
+++ b/libtsuba/test/CMakeLists.txt
@@ -94,3 +94,21 @@ add_executable(${test_name} storage-format-version/v3-uint16-entity-type-ids.cpp
 target_link_libraries(${test_name} katana_tsuba)
 target_include_directories(${test_name} PRIVATE ../src)
 add_test(NAME ${name} COMMAND ${test_name} ${RDG_LDBC_003_V3})
+
+
+
+set(name storage-format-version-v4-v5-optional-datastructure-rdk)
+set(test_name ${name}-test)
+add_test_dataset_fixture(${PROJECT_BINARY_DIR} ${RDG_LDBC_003} -${name} tmp_input_location input-setup-fixture-group)
+add_executable(${test_name} storage-format-version/v5-optional-datastructure-rdk.cpp)
+target_link_libraries(${test_name} katana_tsuba)
+target_link_libraries(${test_name} katana_galois)
+target_include_directories(${test_name} PRIVATE ../src)
+add_test(NAME ${name} COMMAND ${test_name} ${tmp_input_location})
+set_tests_properties(${name} PROPERTIES
+  ENVIRONMENT KATANA_ENABLE_EXPERIMENTAL=UnstableRDGStorageFormat)
+set_property(TEST ${name} APPEND PROPERTY LABELS quick)
+set_tests_properties(${name} PROPERTIES LABELS quick)
+set_property(TEST ${name}
+  APPEND PROPERTY
+  FIXTURES_REQUIRED ${input-setup-fixture-group})

--- a/libtsuba/test/storage-format-version/v5-optional-datastructure-rdk.cpp
+++ b/libtsuba/test/storage-format-version/v5-optional-datastructure-rdk.cpp
@@ -1,0 +1,274 @@
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+#include "../test-rdg.h"
+#include "katana/Experimental.h"
+#include "katana/Galois.h"
+#include "katana/Logging.h"
+#include "katana/RDG.h"
+#include "katana/RDGManifest.h"
+#include "katana/RDGStorageFormatVersion.h"
+#include "katana/RDKLSHIndexPrimitive.h"
+#include "katana/RDKSubstructureIndexPrimitive.h"
+#include "katana/Result.h"
+#include "katana/URI.h"
+
+std::vector<std::map<uint64_t, std::vector<uint64_t>>>
+GenerateHashes() {
+  std::vector<std::map<uint64_t, std::vector<uint64_t>>> hashes(128);
+  for (uint64_t i = 0; i < 128; i++) {
+    for (uint64_t j = 0; j < 64; j++) {
+      std::map<uint64_t, std::vector<uint64_t>> tmp;
+      tmp[j] = {i, j, i + j};
+      hashes.emplace_back(tmp);
+    }
+  }
+  return hashes;
+}
+
+std::vector<katana::DynamicBitset>
+GenerateFingerprints() {
+  std::vector<katana::DynamicBitset> fingerprints;
+
+  for (size_t i = 0; i < 4; i++) {
+    katana::DynamicBitset bset;
+    for (size_t j = 0; j < i; j++) {
+      bset.resize(j + 1);
+      bset.set(j);
+    }
+    fingerprints.emplace_back(std::move(bset));
+  }
+
+  return fingerprints;
+}
+
+std::vector<std::string>
+GenerateSmiles() {
+  std::vector<std::string> smiles = {"smile1", "smile2", "smile3", "smile4"};
+  return smiles;
+}
+
+std::vector<std::vector<std::uint64_t>>
+GenerateIndices() {
+  std::vector<std::vector<std::uint64_t>> indices(
+      128, std::vector<uint64_t>(64));
+  for (size_t i = 0; i < 128; i++) {
+    for (size_t j = 0; j < 64; j++) {
+      indices[i][j] = i + j;
+    }
+  }
+  return indices;
+}
+
+katana::RDKLSHIndexPrimitive
+GenerateLSHIndex() {
+  katana::RDKLSHIndexPrimitive index;
+
+  std::vector<katana::DynamicBitset> fingerprints = GenerateFingerprints();
+  index.set_num_hashes_per_bucket(16);
+  index.set_num_buckets(96);
+  index.set_fingerprint_length(42);
+  index.set_num_fingerprints(fingerprints.size());
+  index.set_hash_structure(GenerateHashes());
+  index.set_fingerprints(std::move(fingerprints));
+  index.set_smiles(GenerateSmiles());
+  return index;
+}
+
+void
+ValidateLSHIndex(katana::RDKLSHIndexPrimitive& index) {
+  KATANA_LOG_ASSERT(index.num_hashes_per_bucket() == 16);
+  KATANA_LOG_ASSERT(index.num_buckets() == 96);
+  KATANA_LOG_ASSERT(index.fingerprint_length() == 42);
+  KATANA_LOG_ASSERT(index.num_fingerprints() == 4);
+  KATANA_LOG_ASSERT(index.hash_structure() == GenerateHashes());
+  KATANA_LOG_ASSERT(index.fingerprints() == GenerateFingerprints());
+  KATANA_LOG_ASSERT(index.smiles() == GenerateSmiles());
+}
+
+katana::RDKSubstructureIndexPrimitive
+GenerateSubstructIndex() {
+  katana::RDKSubstructureIndexPrimitive index;
+
+  std::vector<katana::DynamicBitset> fingerprints = GenerateFingerprints();
+  auto smiles = GenerateSmiles();
+  auto indices = GenerateIndices();
+  KATANA_LOG_VASSERT(
+      smiles.size() == fingerprints.size(), "smiles = {}, finger  = {}",
+      smiles.size(), fingerprints.size());
+
+  index.set_fp_size(indices.size());
+  index.set_num_entries(smiles.size());
+  index.set_index(std::move(indices));
+  index.set_fingerprints(std::move(fingerprints));
+  index.set_smiles(std::move(smiles));
+  return index;
+}
+
+void
+ValidateSubstructIndex(katana::RDKSubstructureIndexPrimitive& index) {
+  KATANA_LOG_ASSERT(index.fp_size() == 128);
+  KATANA_LOG_ASSERT(index.num_entries() == 4);
+  KATANA_LOG_ASSERT(index.index() == GenerateIndices());
+  KATANA_LOG_ASSERT(index.fingerprints() == GenerateFingerprints());
+  KATANA_LOG_ASSERT(index.smiles() == GenerateSmiles());
+}
+
+/*
+ * Tests: Optional Datastructure, RDKLSHIndexPrimitive, RDKSubstructureIndexPrimitive functionality
+ *
+ * 1) loading an RDG without an optional index and adding one to it (RDKLSHIndexPrimitive)
+ * 2) storing an RDG with an optional index (RDKLSHIndexPrimitive)
+ * 3) loading an RDG with an optional index (RDKLSHIndexPrimitive)
+ * 4) storing an RDG with 2 optional indices (RDKLSHIndexPrimitive, RDKSubstructureIndexPrimitive)
+ * 5) loading an RDG with 2 optional indices (RDKLSHIndexPrimitive, RDKSubstructureIndexPrimitive)
+ */
+katana::Result<void>
+TestRoundTripRDKIndex(const std::string& rdg_dir) {
+  KATANA_LOG_ASSERT(!rdg_dir.empty());
+  katana::RDKLSHIndexPrimitive lsh_index = GenerateLSHIndex();
+  ValidateLSHIndex(lsh_index);
+
+  // load the rdg, no optional indices present
+  katana::RDG rdg = KATANA_CHECKED(LoadRDG(rdg_dir));
+
+  // write out an optional index
+  KATANA_CHECKED(rdg.WriteRDKLSHIndexPrimitive(lsh_index));
+
+  // Read the index back and ensure it matches what we put in
+  std::optional<katana::RDKLSHIndexPrimitive> lsh_index_res_2 =
+      KATANA_CHECKED(rdg.LoadRDKLSHIndexPrimitive());
+  KATANA_LOG_ASSERT(lsh_index_res_2);
+  katana::RDKLSHIndexPrimitive& lsh_index_2 = lsh_index_res_2.value();
+  ValidateLSHIndex(lsh_index_2);
+
+  // Store the RDG in a new location
+  std::string rdg_dir2 = KATANA_CHECKED(WriteRDG(std::move(rdg)));
+
+  // Load the RDG from the new location
+  katana::RDG rdg2 = KATANA_CHECKED(LoadRDG(rdg_dir2));
+
+  // Ensure our index is still correct
+  std::optional<katana::RDKLSHIndexPrimitive> lsh_index_res_3 =
+      KATANA_CHECKED(rdg2.LoadRDKLSHIndexPrimitive());
+  KATANA_LOG_ASSERT(lsh_index_res_3);
+  katana::RDKLSHIndexPrimitive& lsh_index_3 = lsh_index_res_3.value();
+  ValidateLSHIndex(lsh_index_3);
+
+  // Add a different optional index
+  katana::RDKSubstructureIndexPrimitive substruct_index =
+      GenerateSubstructIndex();
+  KATANA_CHECKED(rdg2.WriteRDKSubstructureIndexPrimitive(substruct_index));
+
+  // Read it back right away and ensure it matches what we put in
+  std::optional<katana::RDKSubstructureIndexPrimitive> substruct_index_res_2 =
+      KATANA_CHECKED(rdg2.LoadRDKSubstructureIndexPrimitive());
+  KATANA_LOG_ASSERT(substruct_index_res_2);
+  katana::RDKSubstructureIndexPrimitive& substruct_index_2 =
+      substruct_index_res_2.value();
+  ValidateSubstructIndex(substruct_index_2);
+
+  // Store the RDG in a new location
+  std::string rdg_dir3 = KATANA_CHECKED(WriteRDG(std::move(rdg2)));
+
+  // Load the RDG from the new location
+  katana::RDG rdg3 = KATANA_CHECKED(LoadRDG(rdg_dir3));
+
+  // Ensure both of our indices are still correct
+  std::optional<katana::RDKSubstructureIndexPrimitive> substruct_index_res_3 =
+      KATANA_CHECKED(rdg3.LoadRDKSubstructureIndexPrimitive());
+  KATANA_LOG_ASSERT(substruct_index_res_3);
+  katana::RDKSubstructureIndexPrimitive& substruct_index_3 =
+      substruct_index_res_3.value();
+  ValidateSubstructIndex(substruct_index_3);
+  std::optional<katana::RDKLSHIndexPrimitive> lsh_index_res_4 =
+      KATANA_CHECKED(rdg3.LoadRDKLSHIndexPrimitive());
+  KATANA_LOG_ASSERT(lsh_index_res_4);
+  katana::RDKLSHIndexPrimitive& lsh_index_4 = lsh_index_res_4.value();
+  ValidateLSHIndex(lsh_index_4);
+
+  return katana::ResultSuccess();
+}
+
+/*
+ * Tests that we fail loading an invalid version of an optional topology
+ * and that we fail in a way that the caller can recover from
+ */
+katana::Result<void>
+TestLoadFail(const std::string& rdg_dir) {
+  // make a copy of the RDG in a new location
+  katana::RDG rdg = KATANA_CHECKED(LoadRDG(rdg_dir));
+  // add an optional index
+  katana::RDKLSHIndexPrimitive lsh_index = GenerateLSHIndex();
+  ValidateLSHIndex(lsh_index);
+  KATANA_CHECKED(rdg.WriteRDKLSHIndexPrimitive(lsh_index));
+  std::string rdg_dir2 = KATANA_CHECKED(WriteRDG(std::move(rdg)));
+
+  // Load the RDG from the new location
+  katana::RDG rdg2 = KATANA_CHECKED(LoadRDG(rdg_dir2));
+
+  // make a garbage json file in the place of an optional datastructure
+  std::vector dummy = {"these", "are", "some", "bad", "values"};
+  std::string serialized = KATANA_CHECKED(katana::JsonDump(dummy));
+  // POSIX files end with newlines
+  serialized = serialized + "\n";
+
+  auto ff = std::make_unique<katana::FileFrame>();
+  KATANA_CHECKED(ff->Init(serialized.size()));
+  if (auto res = ff->Write(serialized.data(), serialized.size()); !res.ok()) {
+    return KATANA_ERROR(
+        katana::ArrowToKatana(res.code()), "arrow error: {}", res);
+  }
+
+  // write garbage over existing optional datastructure manifest
+  // rdg must have only one of these manifests available for this test to function propertly
+  std::string path =
+      KATANA_CHECKED(find_file(rdg_dir2, "rdk_lsh_index_manifest"));
+  std::filesystem::remove(path);
+  ff->Bind(path);
+  KATANA_CHECKED(ff->Persist());
+
+  // expect this to fail
+  auto res = rdg2.LoadRDKLSHIndexPrimitive();
+  if (res) {
+    KATANA_LOG_ASSERT("Loading the garbage manifest should fail!");
+  }
+
+  return katana::ResultSuccess();
+}
+
+int
+main(int argc, char* argv[]) {
+  if (auto init_good = katana::InitTsuba(); !init_good) {
+    KATANA_LOG_FATAL("katana::InitTsuba: {}", init_good.error());
+  }
+  katana::GaloisRuntime Katana_runtime;
+
+  if (argc <= 1) {
+    KATANA_LOG_FATAL("missing rdg file directory");
+  }
+
+  // Ensure the feature flag is actually set
+  KATANA_LOG_ASSERT(KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat));
+
+  const std::string& rdg = argv[1];
+
+  auto res = TestRoundTripRDKIndex(rdg);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  res = TestLoadFail(rdg);
+  if (!res) {
+    KATANA_LOG_FATAL("test failed: {}", res.error());
+  }
+
+  if (auto fini_good = katana::FiniTsuba(); !fini_good) {
+    KATANA_LOG_FATAL("katana::FiniTsuba: {}", fini_good.error());
+  }
+
+  return 0;
+}


### PR DESCRIPTION
RDGOptionalDatastructures are datastructures that may be appended to an RDG
These datastructures are represented by a manifest file, which is json
encoded and stores the information required to load the optional
datastructure.

The only mandatory field in an optional datastructure manifest file is
"paths" which is used to list any additional files that make up the
optional datastructure. The "paths" field is
```
unordered_map<name, file_path>
```
the file_path is relative to the rdg_directory.

The RDGPartHeader tracks these optional data structures in the new field
```
optional_datastructure_manifests_
```
Any amount of optional datastructures may or may not be present in any
RDG. It is expected that if an optional datastructure is not present,
that the user will generate it instead.

The first optional datastructure is RDKLSHIndex.

JIRA: KAT-3696

