### PR TITLE
[KAT-2749] Add bindings for certain additional entity type manager methods

### DIFF
--- a/libkatana_python_native/src/EntityTypeManager.cpp
+++ b/libkatana_python_native/src/EntityTypeManager.cpp
@@ -34,13 +34,14 @@ struct AtomicEntityType : public EntityType {
   std::string name() { return ToString(); }
 };
 
-katana::SetOfEntityTypeIDs GetSetOfEntityTypeIds(std::vector<EntityType> types) {
-    katana::SetOfEntityTypeIDs type_ids;
-    type_ids.resize(types.size());
-    for (auto t : types) {
-      type_ids.set(t.type_id);
-    }
-    return type_ids;
+katana::SetOfEntityTypeIDs
+GetSetOfEntityTypeIds(std::vector<EntityType> types) {
+  katana::SetOfEntityTypeIDs type_ids;
+  type_ids.resize(types.size());
+  for (auto t : types) {
+    type_ids.set(t.type_id);
+  }
+  return type_ids;
 }
 
 }  // namespace
@@ -108,8 +109,8 @@ katana::python::InitEntityTypeManager(py::module_& m) {
              std::vector<EntityType> types) -> Result<EntityType> {
             auto set_of_type_ids = GetSetOfEntityTypeIds(types);
             return EntityType{
-                self,
-                KATANA_CHECKED(self->GetOrAddNonAtomicEntityType(set_of_type_ids))};
+                self, KATANA_CHECKED(
+                          self->GetOrAddNonAtomicEntityType(set_of_type_ids))};
           })
       .def(
           "type_from_id",
@@ -124,11 +125,12 @@ katana::python::InitEntityTypeManager(py::module_& m) {
           "get_atomic_subtypes",
           [](const katana::EntityTypeManager* self, EntityType type) {
             py::set ret;
-            if(self -> HasEntityType(type.type_id)) {
-              auto type_set = self -> GetAtomicSubtypes(type.type_id);
-              for (EntityTypeID subtype_id = 0; subtype_id < type_set.size(); ++subtype_id) {
+            if (self->HasEntityType(type.type_id)) {
+              auto type_set = self->GetAtomicSubtypes(type.type_id);
+              for (EntityTypeID subtype_id = 0; subtype_id < type_set.size();
+                   ++subtype_id) {
                 if (type_set.test(subtype_id)) {
-                  if(self -> GetAtomicTypeName(subtype_id).has_value()) {
+                  if (self->GetAtomicTypeName(subtype_id).has_value()) {
                     ret.add(AtomicEntityType{{self, subtype_id}});
                   }
                 }
@@ -140,9 +142,10 @@ katana::python::InitEntityTypeManager(py::module_& m) {
           "get_supertypes",
           [](const katana::EntityTypeManager* self, EntityType type) {
             py::set ret;
-            if(self -> GetAtomicTypeName(type.type_id).has_value()) {
-              auto type_set = self -> GetSupertypes(type.type_id);
-              for (EntityTypeID subtype_id = 0; subtype_id < type_set.size(); ++subtype_id) {
+            if (self->GetAtomicTypeName(type.type_id).has_value()) {
+              auto type_set = self->GetSupertypes(type.type_id);
+              for (EntityTypeID subtype_id = 0; subtype_id < type_set.size();
+                   ++subtype_id) {
                 if (type_set.test(subtype_id)) {
                   ret.add(EntityType{self, subtype_id});
                 }
@@ -151,8 +154,7 @@ katana::python::InitEntityTypeManager(py::module_& m) {
             return ret;
           })
       .def(
-          "get_num_atomic_types",
-          &katana::EntityTypeManager::GetNumAtomicTypes)
+          "get_num_atomic_types", &katana::EntityTypeManager::GetNumAtomicTypes)
       .def(
           "get_num_of_entity_types",
           &katana::EntityTypeManager::GetNumEntityTypes);

--- a/libkatana_python_native/src/EntityTypeManager.cpp
+++ b/libkatana_python_native/src/EntityTypeManager.cpp
@@ -1,6 +1,7 @@
 #include "katana/EntityTypeManager.h"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "katana/python/Conventions.h"
 #include "katana/python/CythonIntegration.h"
@@ -32,6 +33,15 @@ struct EntityType {
 struct AtomicEntityType : public EntityType {
   std::string name() { return ToString(); }
 };
+
+katana::SetOfEntityTypeIDs GetSetOfEntityTypeIds(std::vector<EntityType> types) {
+    katana::SetOfEntityTypeIDs type_ids;
+    type_ids.resize(types.size());
+    for (auto t : types) {
+      type_ids.set(t.type_id);
+    }
+    return type_ids;
+}
 
 }  // namespace
 
@@ -87,13 +97,19 @@ katana::python::InitEntityTypeManager(py::module_& m) {
           "get_non_atomic_entity_type",
           [](katana::EntityTypeManager* self,
              std::vector<EntityType> types) -> Result<EntityType> {
-            katana::SetOfEntityTypeIDs type_ids;
-            for (auto t : types) {
-              type_ids.set(t.type_id);
-            }
+            auto set_of_type_ids = GetSetOfEntityTypeIds(types);
             return EntityType{
                 self,
-                KATANA_CHECKED(self->GetOrAddNonAtomicEntityType(type_ids))};
+                KATANA_CHECKED(self->GetNonAtomicEntityType(set_of_type_ids))};
+          })
+      .def(
+          "get_or_add_non_atomic_entity_type",
+          [](katana::EntityTypeManager* self,
+             std::vector<EntityType> types) -> Result<EntityType> {
+            auto set_of_type_ids = GetSetOfEntityTypeIds(types);
+            return EntityType{
+                self,
+                KATANA_CHECKED(self->GetOrAddNonAtomicEntityType(set_of_type_ids))};
           })
       .def(
           "type_from_id",
@@ -103,5 +119,41 @@ katana::python::InitEntityTypeManager(py::module_& m) {
             } else {
               return py::cast(EntityType{self, id});
             }
-          });
+          })
+      .def(
+          "get_atomic_subtypes",
+          [](const katana::EntityTypeManager* self, EntityType type) {
+            py::set ret;
+            if(self -> HasEntityType(type.type_id)) {
+              auto type_set = self -> GetAtomicSubtypes(type.type_id);
+              for (EntityTypeID subtype_id = 0; subtype_id < type_set.size(); ++subtype_id) {
+                if (type_set.test(subtype_id)) {
+                  if(self -> GetAtomicTypeName(subtype_id).has_value()) {
+                    ret.add(AtomicEntityType{{self, subtype_id}});
+                  }
+                }
+              }
+            }
+            return ret;
+          })
+      .def(
+          "get_supertypes",
+          [](const katana::EntityTypeManager* self, EntityType type) {
+            py::set ret;
+            if(self -> GetAtomicTypeName(type.type_id).has_value()) {
+              auto type_set = self -> GetSupertypes(type.type_id);
+              for (EntityTypeID subtype_id = 0; subtype_id < type_set.size(); ++subtype_id) {
+                if (type_set.test(subtype_id)) {
+                  ret.add(EntityType{self, subtype_id});
+                }
+              }
+            }
+            return ret;
+          })
+      .def(
+          "get_num_atomic_types",
+          &katana::EntityTypeManager::GetNumAtomicTypes)
+      .def(
+          "get_num_of_entity_types",
+          &katana::EntityTypeManager::GetNumEntityTypes);
 }

--- a/libkatana_python_native/src/EntityTypeManager.cpp
+++ b/libkatana_python_native/src/EntityTypeManager.cpp
@@ -127,12 +127,12 @@ katana::python::InitEntityTypeManager(py::module_& m) {
             py::set ret;
             if (self->HasEntityType(type.type_id)) {
               auto type_set = self->GetAtomicSubtypes(type.type_id);
+              // TODO(denish44): This isn't very efficient. we should add a method that
+              // efficiently finds ones (by iterating over 64-bit words and doing bit magic).
               for (EntityTypeID subtype_id = 0; subtype_id < type_set.size();
                    ++subtype_id) {
                 if (type_set.test(subtype_id)) {
-                  if (self->GetAtomicTypeName(subtype_id).has_value()) {
-                    ret.add(AtomicEntityType{{self, subtype_id}});
-                  }
+                  ret.add(AtomicEntityType{{self, subtype_id}});
                 }
               }
             }
@@ -153,9 +153,6 @@ katana::python::InitEntityTypeManager(py::module_& m) {
             }
             return ret;
           })
-      .def(
-          "get_num_atomic_types", &katana::EntityTypeManager::GetNumAtomicTypes)
-      .def(
-          "get_num_of_entity_types",
-          &katana::EntityTypeManager::GetNumEntityTypes);
+      .def("num_atomic_types", &katana::EntityTypeManager::GetNumAtomicTypes)
+      .def("num_types", &katana::EntityTypeManager::GetNumEntityTypes);
 }

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -359,7 +359,8 @@ def test_types(graph):
         == non_atomic_type
     )
     assert graph.node_types.get_atomic_subtypes(non_atomic_type) == {
-        node_atomic_types["Message"], node_atomic_types["Post"]
+        node_atomic_types["Message"],
+        node_atomic_types["Post"],
     }
     assert graph.node_types.get_supertypes(node_atomic_types["Message"]).issuperset(
         {node_atomic_types["Message"], non_atomic_type}

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -359,10 +359,10 @@ def test_types(graph):
         == non_atomic_type
     )
     assert graph.node_types.get_atomic_subtypes(non_atomic_type) == {
-        [node_atomic_types["Message"], node_atomic_types["Post"]]
+        node_atomic_types["Message"], node_atomic_types["Post"]
     }
     assert graph.node_types.get_supertypes(node_atomic_types["Message"]).issuperset(
-        {[node_atomic_types["Message"], non_atomic_type]}
+        {node_atomic_types["Message"], non_atomic_type}
     )
 
     edge_atomic_types = graph.edge_types.atomic_types

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -358,11 +358,11 @@ def test_types(graph):
         graph.node_types.get_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
         == non_atomic_type
     )
-    assert graph.node_types.get_atomic_subtypes(non_atomic_type) == set(
+    assert graph.node_types.get_atomic_subtypes(non_atomic_type) == {
         [node_atomic_types["Message"], node_atomic_types["Post"]]
-    )
+    }
     assert graph.node_types.get_supertypes(node_atomic_types["Message"]).issuperset(
-        set([node_atomic_types["Message"], non_atomic_type])
+        {[node_atomic_types["Message"], non_atomic_type]}
     )
 
     edge_atomic_types = graph.edge_types.atomic_types

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -350,7 +350,7 @@ def test_types(graph):
         "Post": 11,
     }
     assert graph.node_types.is_subtype_of(0, 1) is True
-    non_atomic_type = graph.get_or_add_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
+    non_atomic_type = graph.node_types.get_or_add_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
     assert (
         graph.node_types.get_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
         == non_atomic_type

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas
 import pyarrow
 import pytest
+
 from katana import GaloisError, do_all, do_all_operator
 from katana.local import Graph
 from katana.local.import_data import from_csr

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -361,8 +361,8 @@ def test_types(graph):
     assert graph.node_types.get_atomic_subtypes(non_atomic_type) == set(
         [node_atomic_types["Message"], node_atomic_types["Post"]]
     )
-    assert graph.node_types.get_supertypes(node_atomic_types["Message"]) == set(
-        [node_atomic_types["Message"], non_atomic_type]
+    assert graph.node_types.get_supertypes(node_atomic_types["Message"]).issuperset(
+        set([node_atomic_types["Message"], non_atomic_type])
     )
 
     edge_atomic_types = graph.edge_types.atomic_types

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -351,7 +351,9 @@ def test_types(graph):
         "Post": 11,
     }
     assert graph.node_types.is_subtype_of(0, 1) is True
-    non_atomic_type = graph.node_types.get_or_add_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
+    non_atomic_type = graph.node_types.get_or_add_non_atomic_entity_type(
+        [node_atomic_types["Message"], node_atomic_types["Post"]]
+    )
     assert (
         graph.node_types.get_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
         == non_atomic_type

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas
 import pyarrow
 import pytest
-
 from katana import GaloisError, do_all, do_all_operator
 from katana.local import Graph
 from katana.local.import_data import from_csr
@@ -351,6 +350,17 @@ def test_types(graph):
         "Post": 11,
     }
     assert graph.node_types.is_subtype_of(0, 1) is True
+    non_atomic_type = graph.get_or_add_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
+    assert (
+        graph.node_types.get_non_atomic_entity_type([node_atomic_types["Message"], node_atomic_types["Post"]])
+        == non_atomic_type
+    )
+    assert graph.node_types.get_atomic_subtypes(non_atomic_type) == set(
+        [node_atomic_types["Message"], node_atomic_types["Post"]]
+    )
+    assert graph.node_types.get_supertypes(node_atomic_types["Message"]) == set(
+        [node_atomic_types["Message"], non_atomic_type]
+    )
 
     edge_atomic_types = graph.edge_types.atomic_types
     edge_name_to_id_map = {name: edge_atomic_types[name].id for name in edge_atomic_types}


### PR DESCRIPTION
EntityTypeManager have some methods that aren't exposed in the python binding. This PR adds additional methods to the python wrapper which logically makes sense to expose.


Jira: KAT-2749