### PR TITLE
Maintain Shared Pointer to PropertyGraph in PropertyGraphViews [KAT-3405]

### DIFF
--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -248,18 +248,6 @@ public:
     KATANA_LOG_DEBUG_ASSERT(edge_entity_type_ids_.size() == NumEdges());
   }
 
-  template <typename PGView>
-  PGView BuildView() noexcept {
-    return pg_view_cache_.BuildView<PGView>(this);
-  }
-
-  template <typename PGView>
-  PGView BuildView(
-      const std::vector<std::string>& node_types,
-      const std::vector<std::string>& edge_types) noexcept {
-    return pg_view_cache_.BuildView<PGView>(this, node_types, edge_types);
-  }
-
   /// Make a property graph from a constructed RDG. Take ownership of the RDG
   /// and its underlying resources.
   static Result<std::unique_ptr<PropertyGraph>> Make(
@@ -907,6 +895,8 @@ public:
   // Returns the property index associated with the named property
   katana::Result<katana::EntityIndex<GraphTopology::Node>*> GetNodeIndex(
       const std::string& property_name) const;
+
+  PGViewCache* GetPGViewCache() { return &pg_view_cache_; }
 };
 
 /// SortAllEdgesByDest sorts edges for each node by destination

--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -34,13 +34,14 @@ class TypedPropertyGraph {
   using NodeView = PropertyViewTuple<NodeProps>;
   using EdgeView = PropertyViewTuple<EdgeProps>;
 
-  PropertyGraph* pg_;
+  std::shared_ptr<PropertyGraph> pg_;
 
   NodeView node_view_;
   EdgeView edge_view_;
 
-  TypedPropertyGraph(PropertyGraph* pg, NodeView node_view, EdgeView edge_view)
-      : pg_(pg),
+  TypedPropertyGraph(
+      std::shared_ptr<PropertyGraph> pg, NodeView node_view, EdgeView edge_view)
+      : pg_(std::move(pg)),
         node_view_(std::move(node_view)),
         edge_view_(std::move(edge_view)) {}
 
@@ -351,7 +352,7 @@ TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
 
   auto pg_view = PGView::Make(std::move(pg));
   return TypedPropertyGraphView(
-      std::move(*pg_view), std::move(node_view_result.value()),
+      *pg_view, std::move(node_view_result.value()),
       std::move(edge_view_result.value()));
 }
 
@@ -363,7 +364,7 @@ TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
   auto node_fields = pg->loaded_node_schema()->field_names();
   auto edge_fields = pg->loaded_edge_schema()->field_names();
   return TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
-      std::move(pg_view), std::move(node_fields), std::move(edge_fields));
+      *pg_view, std::move(node_fields), std::move(edge_fields));
 }
 
 template <typename PGView, typename NodeProps, typename EdgeProps>

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -686,7 +686,7 @@ struct ClusteringImplementationBase {
     if (!pfg_next_res) {
       return pfg_next_res.error();
     }
-    std::unique_ptr<katana::PropertyGraph> pfg_next =
+    std::shared_ptr<katana::PropertyGraph> pfg_next =
         std::move(pfg_next_res.value());
 
     if (auto result = katana::analytics::ConstructNodeProperties<NodeData>(
@@ -701,7 +701,7 @@ struct ClusteringImplementationBase {
       return result.error();
     }
 
-    auto graph_result = Graph::Make(pfg_next.get());
+    auto graph_result = Graph::Make(pfg_next);
     if (!graph_result) {
       return graph_result.error();
     }
@@ -716,7 +716,7 @@ struct ClusteringImplementationBase {
         katana::no_stats());
 
     TimerGraphBuild.stop();
-    return std::unique_ptr<katana::PropertyGraph>(std::move(pfg_next));
+    return std::make_unique<katana::PropertyGraph>(std::move(*pfg_next));
   }
 
   /**

--- a/libgraph/include/katana/analytics/betweenness_centrality/betweenness_centrality.h
+++ b/libgraph/include/katana/analytics/betweenness_centrality/betweenness_centrality.h
@@ -80,8 +80,8 @@ KATANA_EXPORT extern const BetweennessCentralitySources
 ///          nodes; if this is an int process that number of source nodes.
 /// @param plan
 KATANA_EXPORT Result<void> BetweennessCentrality(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const BetweennessCentralitySources& sources =
         kBetweennessCentralityAllNodes,
     BetweennessCentralityPlan plan = {});
@@ -102,7 +102,8 @@ struct KATANA_EXPORT BetweennessCentralityStatistics {
   void Print(std::ostream& os = std::cout);
 
   static katana::Result<BetweennessCentralityStatistics> Compute(
-      PropertyGraph* pg, const std::string& output_property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& output_property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/bfs/bfs.h
+++ b/libgraph/include/katana/analytics/bfs/bfs.h
@@ -76,7 +76,7 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Bfs(
-    PropertyGraph* pg, uint32_t start_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t start_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     BfsPlan algo = {});
 
@@ -85,7 +85,8 @@ KATANA_EXPORT Result<void> Bfs(
 /// @return a failure if the BFS results do not pass validation or if there is a
 ///     failure during checking.
 KATANA_EXPORT Result<void> BfsAssertValid(
-    PropertyGraph* pg, uint32_t source, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t source,
+    const std::string& property_name);
 
 /// Statistics about a graph that can be extracted from the results of BFS.
 struct KATANA_EXPORT BfsStatistics {
@@ -97,7 +98,8 @@ struct KATANA_EXPORT BfsStatistics {
 
   /// Compute the statistics of BFS results stored in property_name.
   static katana::Result<BfsStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<katana::PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/cdlp/cdlp.h
+++ b/libgraph/include/katana/analytics/cdlp/cdlp.h
@@ -98,9 +98,10 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Cdlp(
-    PropertyGraph* pg, const std::string& output_property_name,
-    size_t max_iterations, katana::TxnContext* txn_ctx,
-    const bool& is_symmetric = false, CdlpPlan plan = CdlpPlan());
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, size_t max_iterations,
+    katana::TxnContext* txn_ctx, const bool& is_symmetric = false,
+    CdlpPlan plan = CdlpPlan());
 
 /// TODO (Yasin): This Struct (Compute function) is now being used by louvain,
 /// cc, and cdlp, basically everything which is calculating communities. Explore
@@ -120,7 +121,8 @@ struct KATANA_EXPORT CdlpStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<CdlpStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/connected_components/connected_components.h
+++ b/libgraph/include/katana/analytics/connected_components/connected_components.h
@@ -158,12 +158,13 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> ConnectedComponents(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, const bool& is_symmetric = false,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    const bool& is_symmetric = false,
     ConnectedComponentsPlan plan = ConnectedComponentsPlan());
 
 KATANA_EXPORT Result<void> ConnectedComponentsAssertValid(
-    PropertyGraph* pg, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, const std::string& property_name);
 
 struct KATANA_EXPORT ConnectedComponentsStatistics {
   /// Total number of unique components in the graph.
@@ -179,7 +180,8 @@ struct KATANA_EXPORT ConnectedComponentsStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<ConnectedComponentsStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/independent_set/independent_set.h
+++ b/libgraph/include/katana/analytics/independent_set/independent_set.h
@@ -57,11 +57,12 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call. The created property has type uint8_t.
 KATANA_EXPORT Result<void> IndependentSet(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, IndependentSetPlan plan = {});
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    IndependentSetPlan plan = {});
 
 KATANA_EXPORT Result<void> IndependentSetAssertValid(
-    PropertyGraph* pg, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, const std::string& property_name);
 
 struct KATANA_EXPORT IndependentSetStatistics {
   /// The number of nodes in the independent set.
@@ -71,7 +72,7 @@ struct KATANA_EXPORT IndependentSetStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<IndependentSetStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      std::shared_ptr<PropertyGraph>& pg, const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/jaccard/jaccard.h
+++ b/libgraph/include/katana/analytics/jaccard/jaccard.h
@@ -58,12 +58,13 @@ using JaccardSimilarity = katana::PODProperty<double>;
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Jaccard(
-    PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     JaccardPlan plan = {});
 
 KATANA_EXPORT Result<void> JaccardAssertValid(
-    PropertyGraph* pg, uint32_t compare_node, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
+    const std::string& property_name);
 
 struct KATANA_EXPORT JaccardStatistics {
   /// The maximum similarity excluding the comparison node.
@@ -77,7 +78,7 @@ struct KATANA_EXPORT JaccardStatistics {
   void Print(std::ostream& os = std::cout);
 
   static katana::Result<JaccardStatistics> Compute(
-      katana::PropertyGraph* pg, uint32_t compare_node,
+      const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
       const std::string& property_name);
 };
 

--- a/libgraph/include/katana/analytics/k_core/k_core.h
+++ b/libgraph/include/katana/analytics/k_core/k_core.h
@@ -48,12 +48,12 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> KCore(
-    PropertyGraph* pg, uint32_t k_core_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric = false, KCorePlan plan = KCorePlan());
 
 KATANA_EXPORT Result<void> KCoreAssertValid(
-    PropertyGraph* pg, uint32_t k_core_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
     const std::string& property_name);
 
 struct KATANA_EXPORT KCoreStatistics {
@@ -64,7 +64,7 @@ struct KATANA_EXPORT KCoreStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<KCoreStatistics> Compute(
-      katana::PropertyGraph* pg, uint32_t k_core_number,
+      const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
       const std::string& property_name);
 };
 

--- a/libgraph/include/katana/analytics/k_truss/k_truss.h
+++ b/libgraph/include/katana/analytics/k_truss/k_truss.h
@@ -50,11 +50,12 @@ public:
 ///
 /// @warning This algorithm will reorder nodes and edges in the graph.
 KATANA_EXPORT Result<void> KTruss(
-    katana::TxnContext* txn_ctx, PropertyGraph* pg, uint32_t k_truss_number,
-    const std::string& output_property_name, KTrussPlan plan = KTrussPlan());
+    katana::TxnContext* txn_ctx, const std::shared_ptr<PropertyGraph>& pg,
+    uint32_t k_truss_number, const std::string& output_property_name,
+    KTrussPlan plan = KTrussPlan());
 
 KATANA_EXPORT Result<void> KTrussAssertValid(
-    PropertyGraph* pg, uint32_t k_truss_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_truss_number,
     const std::string& property_name);
 
 struct KATANA_EXPORT KTrussStatistics {
@@ -65,7 +66,7 @@ struct KATANA_EXPORT KTrussStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<KTrussStatistics> Compute(
-      katana::PropertyGraph* pg, uint32_t k_truss_number,
+      const std::shared_ptr<PropertyGraph>& pg, uint32_t k_truss_number,
       const std::string& property_name);
 };
 

--- a/libgraph/include/katana/analytics/leiden_clustering/leiden_clustering.h
+++ b/libgraph/include/katana/analytics/leiden_clustering/leiden_clustering.h
@@ -143,12 +143,14 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> LeidenClustering(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric = false, LeidenClusteringPlan plan = {});
 
 KATANA_EXPORT Result<void> LeidenClusteringAssertValid(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name);
 
 struct KATANA_EXPORT LeidenClusteringStatistics {
@@ -167,7 +169,8 @@ struct KATANA_EXPORT LeidenClusteringStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<LeidenClusteringStatistics> Compute(
-      PropertyGraph* pg, const std::string& edge_weight_property_name,
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& edge_weight_property_name,
       const std::string& output_property_name, katana::TxnContext* txn_ctx);
 };
 

--- a/libgraph/include/katana/analytics/local_clustering_coefficient/local_clustering_coefficient.h
+++ b/libgraph/include/katana/analytics/local_clustering_coefficient/local_clustering_coefficient.h
@@ -82,8 +82,9 @@ public:
  * @warning This algorithm will reorder nodes and edges in the graph.
  */
 KATANA_EXPORT Result<void> LocalClusteringCoefficient(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, LocalClusteringCoefficientPlan plan = {});
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    LocalClusteringCoefficientPlan plan = {});
 
 }  // namespace katana::analytics
 

--- a/libgraph/include/katana/analytics/louvain_clustering/louvain_clustering.h
+++ b/libgraph/include/katana/analytics/louvain_clustering/louvain_clustering.h
@@ -120,12 +120,14 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> LouvainClustering(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric, LouvainClusteringPlan plan = {});
 
 KATANA_EXPORT Result<void> LouvainClusteringAssertValid(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name);
 
 struct KATANA_EXPORT LouvainClusteringStatistics {
@@ -144,7 +146,8 @@ struct KATANA_EXPORT LouvainClusteringStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<LouvainClusteringStatistics> Compute(
-      PropertyGraph* pg, const std::string& edge_weight_property_name,
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& edge_weight_property_name,
       const std::string& output_property_name, katana::TxnContext* txn_ctx);
 };
 

--- a/libgraph/include/katana/analytics/matrix_completion/matrix_completion.h
+++ b/libgraph/include/katana/analytics/matrix_completion/matrix_completion.h
@@ -129,7 +129,7 @@ public:
 /// an ArrayProperty.
 /// The plan controls the algorithm and parameters used to compute the latent vectors.
 KATANA_EXPORT Result<void> MatrixCompletion(
-    katana::PropertyGraph* pg, katana::TxnContext* txn_ctx,
+    const std::shared_ptr<PropertyGraph>& pg, katana::TxnContext* txn_ctx,
     MatrixCompletionPlan plan = {});
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/pagerank/pagerank.h
+++ b/libgraph/include/katana/analytics/pagerank/pagerank.h
@@ -109,11 +109,13 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Pagerank(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, PagerankPlan plan = {});
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    PagerankPlan plan = {});
 
 KATANA_EXPORT Result<void> PagerankAssertValid(
-    PropertyGraph* pg, const std::string& property_name);
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name);
 
 struct KATANA_EXPORT PagerankStatistics {
   /// The maximum similarity excluding the comparison node.
@@ -127,7 +129,8 @@ struct KATANA_EXPORT PagerankStatistics {
   void Print(std::ostream& os = std::cout);
 
   static katana::Result<PagerankStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<katana::PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/random_walks/random_walks.h
+++ b/libgraph/include/katana/analytics/random_walks/random_walks.h
@@ -138,9 +138,11 @@ public:
 /// parameters are used by the algorithms. The generated random-walks generated
 /// are returned as a vector of vectors.
 KATANA_EXPORT Result<std::vector<std::vector<uint32_t>>> RandomWalks(
-    PropertyGraph* pg, RandomWalksPlan plan = RandomWalksPlan());
+    const std::shared_ptr<PropertyGraph>& pg,
+    RandomWalksPlan plan = RandomWalksPlan());
 
-KATANA_EXPORT Result<void> RandomWalksAssertValid(PropertyGraph* pg);
+KATANA_EXPORT Result<void> RandomWalksAssertValid(
+    const std::shared_ptr<PropertyGraph>& pg);
 
 }  // namespace katana::analytics
 #endif

--- a/libgraph/include/katana/analytics/sssp/sssp.h
+++ b/libgraph/include/katana/analytics/sssp/sssp.h
@@ -122,13 +122,13 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Sssp(
-    PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     SsspPlan plan = {});
 
 KATANA_EXPORT Result<void> SsspAssertValid(
-    PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name);
 
@@ -144,7 +144,8 @@ struct KATANA_EXPORT SsspStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<SsspStatistics> Compute(
-      PropertyGraph* pg, const std::string& output_property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& output_property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/subgraph_extraction/subgraph_extraction.h
+++ b/libgraph/include/katana/analytics/subgraph_extraction/subgraph_extraction.h
@@ -54,7 +54,7 @@ public:
  */
 KATANA_EXPORT katana::Result<std::unique_ptr<katana::PropertyGraph>>
 SubGraphExtraction(
-    katana::PropertyGraph* pg,
+    const PropertyGraphViews::EdgesSortedByDestID& sg,
     const std::vector<katana::PropertyGraph::Node>& node_vec,
     SubGraphExtractionPlan plan = {});
 // const std::vector<std::string>& node_properties_to_copy, const std::vector<std::string>& edge_properties_to_copy);

--- a/libgraph/include/katana/analytics/triangle_count/triangle_count.h
+++ b/libgraph/include/katana/analytics/triangle_count/triangle_count.h
@@ -102,7 +102,9 @@ public:
  * @param plan
  */
 KATANA_EXPORT katana::Result<uint64_t> TriangleCount(
-    PropertyGraph* pg, TriangleCountPlan plan = {});
+    const PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID&
+        sorted_view,
+    TriangleCountPlan plan = {});
 
 }  // namespace katana::analytics
 

--- a/libgraph/src/analytics/betweenness_centrality/betweenness_centrality.cpp
+++ b/libgraph/src/analytics/betweenness_centrality/betweenness_centrality.cpp
@@ -27,8 +27,9 @@ const BetweennessCentralitySources
 
 katana::Result<void>
 katana::analytics::BetweennessCentrality(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, const BetweennessCentralitySources& sources,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    const BetweennessCentralitySources& sources,
     BetweennessCentralityPlan plan) {
   switch (plan.algorithm()) {
     //TODO (gill) Needs bidirectional graph (CSR_CSC)
@@ -39,10 +40,10 @@ katana::analytics::BetweennessCentrality(
     //     break;
   case BetweennessCentralityPlan::kLevel:
     return BetweennessCentralityLevel(
-        pg, sources, output_property_name, plan, txn_ctx);
+        pg.get(), sources, output_property_name, plan, txn_ctx);
   case BetweennessCentralityPlan::kOuter:
     return BetweennessCentralityOuter(
-        pg, sources, output_property_name, plan, txn_ctx);
+        pg.get(), sources, output_property_name, plan, txn_ctx);
   default:
     return katana::ErrorCode::InvalidArgument;
   }
@@ -57,7 +58,8 @@ BetweennessCentralityStatistics::Print(std::ostream& os) {
 
 katana::Result<BetweennessCentralityStatistics>
 BetweennessCentralityStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& output_property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name) {
   auto values_result = pg->GetNodePropertyTyped<float>(output_property_name);
   if (!values_result) {
     return values_result.error();

--- a/libgraph/src/analytics/betweenness_centrality/level.cpp
+++ b/libgraph/src/analytics/betweenness_centrality/level.cpp
@@ -216,13 +216,14 @@ LevelBackwardBrandes(
 //! property graph for use by stats/output verification
 katana::Result<void>
 ExtractBC(
-    katana::PropertyGraph* pg, const LevelGraph& array_of_struct_graph,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const LevelGraph& array_of_struct_graph,
     const BCLevelNodeDataArray& graph_data,
     const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   // construct the new property
   if (auto result =
           katana::analytics::ConstructNodeProperties<std::tuple<NodeBC>>(
-              pg, txn_ctx, {output_property_name});
+              pg.get(), txn_ctx, {output_property_name});
       !result) {
     return result.error();
   }
@@ -247,7 +248,7 @@ ExtractBC(
 
 katana::Result<void>
 BetweennessCentralityLevel(
-    katana::PropertyGraph* pg,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
     katana::analytics::BetweennessCentralitySources sources,
     const std::string& output_property_name,
     katana::analytics::BetweennessCentralityPlan plan [[maybe_unused]],

--- a/libgraph/src/analytics/betweenness_centrality/outer.cpp
+++ b/libgraph/src/analytics/betweenness_centrality/outer.cpp
@@ -246,7 +246,8 @@ struct HasOut {
 
 katana::Result<void>
 BetweennessCentralityOuter(
-    katana::PropertyGraph* pg, BetweennessCentralitySources sources,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    BetweennessCentralitySources sources,
     const std::string& output_property_name,
     BetweennessCentralityPlan plan [[maybe_unused]],
     katana::TxnContext* txn_ctx) {

--- a/libgraph/src/analytics/bfs/bfs.cpp
+++ b/libgraph/src/analytics/bfs/bfs.cpp
@@ -451,11 +451,11 @@ BfsImpl(
 
 katana::Result<void>
 katana::analytics::Bfs(
-    PropertyGraph* pg, GNode start_node,
+    const std::shared_ptr<PropertyGraph>& pg, GNode start_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     BfsPlan algo) {
   if (auto result = ConstructNodeProperties<std::tuple<BfsNodeParent>>(
-          pg, txn_ctx, {output_property_name});
+          pg.get(), txn_ctx, {output_property_name});
       !result) {
     return result.error();
   }
@@ -610,7 +610,7 @@ CheckParentByLevel(
 
 katana::Result<void>
 katana::analytics::BfsAssertValid(
-    PropertyGraph* pg, const GNode source,
+    const std::shared_ptr<PropertyGraph>& pg, const GNode source,
     const std::string& output_property_name) {
   auto graph = KATANA_CHECKED(Graph::Make(pg, {output_property_name}, {}));
   auto bidir_view =
@@ -629,7 +629,8 @@ katana::analytics::BfsAssertValid(
 
 katana::Result<BfsStatistics>
 katana::analytics::BfsStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name) {
   auto pg_result = BfsImplementation::Graph::Make(pg, {property_name}, {});
   if (!pg_result) {
     return pg_result.error();

--- a/libgraph/src/analytics/cdlp/cdlp.cpp
+++ b/libgraph/src/analytics/cdlp/cdlp.cpp
@@ -136,15 +136,16 @@ struct CdlpAsynchronousAlgo : CdlpAlgo<GraphViewTy> {
 template <typename Algorithm>
 static katana::Result<void>
 CdlpWithWrap(
-    katana::PropertyGraph* pg, std::string output_property_name,
-    size_t max_iterations, katana::TxnContext* txn_ctx) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    std::string output_property_name, size_t max_iterations,
+    katana::TxnContext* txn_ctx) {
   katana::EnsurePreallocated(
       2, pg->topology().NumNodes() * sizeof(typename Algorithm::NodeCommunity));
   katana::ReportPageAllocGuard page_alloc;
 
   if (auto r = ConstructNodeProperties<
           std::tuple<typename Algorithm::NodeCommunity>>(
-          pg, txn_ctx, {output_property_name});
+          pg.get(), txn_ctx, {output_property_name});
       !r) {
     return r.error();
   }
@@ -169,9 +170,9 @@ CdlpWithWrap(
 
 katana::Result<void>
 katana::analytics::Cdlp(
-    PropertyGraph* pg, const std::string& output_property_name,
-    size_t max_iterations, katana::TxnContext* txn_ctx,
-    const bool& is_symmetric, CdlpPlan plan) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, size_t max_iterations,
+    katana::TxnContext* txn_ctx, const bool& is_symmetric, CdlpPlan plan) {
   switch (plan.algorithm()) {
   case CdlpPlan::kSynchronous:
     if (is_symmetric)
@@ -200,7 +201,8 @@ katana::analytics::Cdlp(
 /// to avoid code duplication.
 katana::Result<CdlpStatistics>
 katana::analytics::CdlpStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   using CommunityType = uint64_t;
   struct NodeCommunity : public katana::PODProperty<CommunityType> {};
 

--- a/libgraph/src/analytics/connected_components/connected_components.cpp
+++ b/libgraph/src/analytics/connected_components/connected_components.cpp
@@ -1137,15 +1137,16 @@ struct ConnectedComponentsEdgeTiledAfforestAlgo {
 template <typename Algorithm>
 static katana::Result<void>
 ConnectedComponentsWithWrap(
-    katana::PropertyGraph* pg, std::string output_property_name,
-    katana::TxnContext* txn_ctx, ConnectedComponentsPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    std::string output_property_name, katana::TxnContext* txn_ctx,
+    ConnectedComponentsPlan plan) {
   katana::EnsurePreallocated(
       2, pg->topology().NumNodes() * sizeof(typename Algorithm::NodeComponent));
   katana::ReportPageAllocGuard page_alloc;
 
   if (auto r = ConstructNodeProperties<
           std::tuple<typename Algorithm::NodeComponent>>(
-          pg, txn_ctx, {output_property_name});
+          pg.get(), txn_ctx, {output_property_name});
       !r) {
     return r.error();
   }
@@ -1173,8 +1174,9 @@ ConnectedComponentsWithWrap(
 template <typename GraphViewTy>
 katana::Result<void>
 ConnectedComponentsSelectAlgorithm(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, ConnectedComponentsPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    ConnectedComponentsPlan plan) {
   switch (plan.algorithm()) {
   case ConnectedComponentsPlan::kSerial:
     return ConnectedComponentsWithWrap<
@@ -1224,9 +1226,9 @@ ConnectedComponentsSelectAlgorithm(
 
 katana::Result<void>
 katana::analytics::ConnectedComponents(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, const bool& is_symmetric,
-    ConnectedComponentsPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    const bool& is_symmetric, ConnectedComponentsPlan plan) {
   if (is_symmetric) {
     using GraphView = katana::PropertyGraphViews::Default;
     return ConnectedComponentsSelectAlgorithm<GraphView>(
@@ -1240,7 +1242,8 @@ katana::analytics::ConnectedComponents(
 
 katana::Result<void>
 katana::analytics::ConnectedComponentsAssertValid(
-    PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name) {
   using ComponentType = uint64_t;
   struct NodeComponent : public katana::PODProperty<ComponentType> {};
 
@@ -1284,7 +1287,8 @@ katana::analytics::ConnectedComponentsAssertValid(
 
 katana::Result<ConnectedComponentsStatistics>
 katana::analytics::ConnectedComponentsStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name) {
   using ComponentType = uint64_t;
   struct NodeComponent : public katana::PODProperty<ComponentType> {};
 

--- a/libgraph/src/analytics/independent_set/independent_set.cpp
+++ b/libgraph/src/analytics/independent_set/independent_set.cpp
@@ -599,12 +599,12 @@ struct IsBad {
 
 template <typename Algo>
 katana::Result<void>
-Run(katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx) {
+Run(const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   using Graph = typename Algo::Graph;
   using GNode = typename Graph::Node;
   auto result = ConstructNodeProperties<typename Algo::NodeData>(
-      pg, txn_ctx, {output_property_name});
+      pg.get(), txn_ctx, {output_property_name});
   if (!result) {
     return result.error();
   }
@@ -663,8 +663,9 @@ Run(katana::PropertyGraph* pg, const std::string& output_property_name,
 
 katana::Result<void>
 katana::analytics::IndependentSet(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, IndependentSetPlan plan) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    IndependentSetPlan plan) {
   switch (plan.algorithm()) {
   case IndependentSetPlan::kSerial:
     return Run<SerialAlgo>(pg, output_property_name, txn_ctx);
@@ -681,7 +682,8 @@ katana::analytics::IndependentSet(
 
 katana::Result<void>
 katana::analytics::IndependentSetAssertValid(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   auto pg_result =
       katana::TypedPropertyGraph<IsBad::NodeData, IsBad::EdgeData>::Make(
           pg, {property_name}, {});
@@ -706,7 +708,8 @@ katana::analytics::IndependentSetStatistics::Print(std::ostream& os) const {
 
 katana::Result<IndependentSetStatistics>
 katana::analytics::IndependentSetStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name) {
   auto property_result = pg->GetNodePropertyTyped<uint8_t>(property_name);
   if (!property_result) {
     return property_result.error();

--- a/libgraph/src/analytics/jaccard/jaccard.cpp
+++ b/libgraph/src/analytics/jaccard/jaccard.cpp
@@ -138,11 +138,11 @@ JaccardImpl(Graph& graph, size_t compare_node, JaccardPlan /*plan*/) {
 
 katana::Result<void>
 katana::analytics::Jaccard(
-    PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     JaccardPlan plan) {
   if (auto result = ConstructNodeProperties<NodeData>(
-          pg, txn_ctx, {output_property_name});
+          pg.get(), txn_ctx, {output_property_name});
       !result) {
     return result.error();
   }
@@ -169,10 +169,9 @@ constexpr static const double EPSILON = 1e-6;
 
 katana::Result<void>
 katana::analytics::JaccardAssertValid(
-    katana::PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& property_name) {
   Graph graph = KATANA_CHECKED(Graph::Make(pg, {property_name}, {}));
-  ;
 
   if (abs(graph.GetData<JaccardSimilarity>(compare_node) - 1.0) > EPSILON) {
     return katana::ErrorCode::AssertionFailed;
@@ -196,10 +195,9 @@ katana::analytics::JaccardAssertValid(
 
 katana::Result<JaccardStatistics>
 katana::analytics::JaccardStatistics::Compute(
-    katana::PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& property_name) {
   Graph graph = KATANA_CHECKED(Graph::Make(pg, {property_name}, {}));
-  ;
 
   katana::GReduceMax<double> max_similarity;
   katana::GReduceMin<double> min_similarity;

--- a/libgraph/src/analytics/k_core/k_core.cpp
+++ b/libgraph/src/analytics/k_core/k_core.cpp
@@ -227,7 +227,7 @@ KCoreImpl(GraphTy* graph, KCorePlan algo, uint32_t k_core_number) {
 
 katana::Result<void>
 katana::analytics::KCore(
-    katana::PropertyGraph* pg, uint32_t k_core_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric, KCorePlan plan) {
   katana::analytics::TemporaryPropertyGuard temporary_property{
@@ -235,7 +235,7 @@ katana::analytics::KCore(
 
   KATANA_CHECKED(katana::analytics::ConstructNodeProperties<
                  std::tuple<KCoreNodeCurrentDegree>>(
-      pg, txn_ctx, {temporary_property.name()}));
+      pg.get(), txn_ctx, {temporary_property.name()}));
 
   if (is_symmetric) {
     using Graph = katana::TypedPropertyGraphView<
@@ -256,7 +256,7 @@ katana::analytics::KCore(
   // Post processing. Mark alive nodes.
   KATANA_CHECKED(
       katana::analytics::ConstructNodeProperties<std::tuple<KCoreNodeAlive>>(
-          pg, txn_ctx, {output_property_name}));
+          pg.get(), txn_ctx, {output_property_name}));
 
   using GraphTy = katana::TypedPropertyGraph<
       std::tuple<KCoreNodeAlive, KCoreNodeCurrentDegree>, std::tuple<>>;
@@ -272,7 +272,7 @@ katana::analytics::KCore(
 // TODO (gill) Add a validity routine.
 katana::Result<void>
 katana::analytics::KCoreAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg,
+    [[maybe_unused]] const std::shared_ptr<PropertyGraph>& pg,
     [[maybe_unused]] uint32_t k_core_number,
     [[maybe_unused]] const std::string& property_name) {
   return katana::ResultSuccess();
@@ -280,8 +280,8 @@ katana::analytics::KCoreAssertValid(
 
 katana::Result<KCoreStatistics>
 katana::analytics::KCoreStatistics::Compute(
-    katana::PropertyGraph* pg, [[maybe_unused]] uint32_t k_core_number,
-    const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    [[maybe_unused]] uint32_t k_core_number, const std::string& property_name) {
   using Graph =
       katana::TypedPropertyGraph<std::tuple<KCoreNodeAlive>, std::tuple<>>;
   using GNode = Graph::Node;

--- a/libgraph/src/analytics/k_truss/k_truss.cpp
+++ b/libgraph/src/analytics/k_truss/k_truss.cpp
@@ -346,13 +346,13 @@ BSPCoreThenTrussAlgo(SortedGraphView* g, uint32_t k) {
 
 katana::Result<void>
 katana::analytics::KTruss(
-    katana::TxnContext* txn_ctx, katana::PropertyGraph* pg,
+    katana::TxnContext* txn_ctx, const std::shared_ptr<PropertyGraph>& pg,
     uint32_t k_truss_number, const std::string& output_property_name,
     KTrussPlan plan) {
   katana::ReportPageAllocGuard page_alloc;
 
-  KATANA_CHECKED(
-      ConstructEdgeProperties<EdgeData>(pg, txn_ctx, {output_property_name}));
+  KATANA_CHECKED(ConstructEdgeProperties<EdgeData>(
+      pg.get(), txn_ctx, {output_property_name}));
 
   auto graph =
       KATANA_CHECKED(SortedGraphView::Make(pg, {}, {output_property_name}));
@@ -380,7 +380,7 @@ katana::analytics::KTruss(
 // TODO (gill) Add a validity routine.
 katana::Result<void>
 katana::analytics::KTrussAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg,
+    [[maybe_unused]] const std::shared_ptr<PropertyGraph>& pg,
     [[maybe_unused]] uint32_t k_truss_number,
     [[maybe_unused]] const std::string& property_name) {
   return katana::ResultSuccess();
@@ -388,7 +388,8 @@ katana::analytics::KTrussAssertValid(
 
 katana::Result<KTrussStatistics>
 katana::analytics::KTrussStatistics::Compute(
-    katana::PropertyGraph* pg, [[maybe_unused]] uint32_t k_truss_number,
+    const std::shared_ptr<PropertyGraph>& pg,
+    [[maybe_unused]] uint32_t k_truss_number,
     const std::string& property_name) {
   auto graph = KATANA_CHECKED(Graph::Make(pg, {}, {property_name}));
 

--- a/libgraph/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
+++ b/libgraph/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
@@ -242,10 +242,10 @@ struct LocalClusteringCoefficientPerThread {
 template <typename Algorithm>
 katana::Result<void>
 LocalClusteringCoefficientWithWrap(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   if (auto result = katana::analytics::ConstructNodeProperties<NodeData>(
-          pg, txn_ctx, {output_property_name});
+          pg.get(), txn_ctx, {output_property_name});
       !result) {
     return result.error();
   }
@@ -258,8 +258,9 @@ LocalClusteringCoefficientWithWrap(
 
 katana::Result<void>
 katana::analytics::LocalClusteringCoefficient(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, LocalClusteringCoefficientPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    LocalClusteringCoefficientPlan plan) {
   katana::StatTimer timer_graph_read(
       "GraphReadingTime", "LocalClusteringCoefficient");
   katana::StatTimer timer_auto_algo(

--- a/libgraph/src/analytics/matrix_completion/matrix_completion.cpp
+++ b/libgraph/src/analytics/matrix_completion/matrix_completion.cpp
@@ -370,9 +370,9 @@ public:
 
 template <typename Algo>
 katana::Result<void>
-Run(katana::PropertyGraph* pg, MatrixCompletionPlan plan,
+Run(const std::shared_ptr<katana::PropertyGraph>& pg, MatrixCompletionPlan plan,
     katana::TxnContext* txn_ctx) {
-  KATANA_CHECKED(ConstructNodeProperties<NodeData>(pg, txn_ctx));
+  KATANA_CHECKED(ConstructNodeProperties<NodeData>(pg.get(), txn_ctx));
   Graph graph = KATANA_CHECKED(Graph::Make(pg));
 
   Algo algo;
@@ -398,7 +398,7 @@ Run(katana::PropertyGraph* pg, MatrixCompletionPlan plan,
 
 katana::Result<void>
 katana::analytics::MatrixCompletion(
-    katana::PropertyGraph* pg, katana::TxnContext* txn_ctx,
+    const std::shared_ptr<PropertyGraph>& pg, katana::TxnContext* txn_ctx,
     MatrixCompletionPlan plan) {
   switch (plan.algorithm()) {
   case MatrixCompletionPlan::kSGDByItems:

--- a/libgraph/src/analytics/pagerank/pagerank-impl.h
+++ b/libgraph/src/analytics/pagerank/pagerank-impl.h
@@ -34,19 +34,23 @@ typedef float PRTy;
 using NodeValue = katana::PODProperty<PRTy>;
 
 katana::Result<void> PagerankPullTopological(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 katana::Result<void> PagerankPullResidual(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 katana::Result<void> PagerankPushAsynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 katana::Result<void> PagerankPushSynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 #endif

--- a/libgraph/src/analytics/pagerank/pagerank-pull.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank-pull.cpp
@@ -300,11 +300,12 @@ ComputePRTopological(
 
 katana::Result<void>
 PagerankPullTopological(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   KATANA_CHECKED(
       katana::analytics::ConstructNodeProperties<std::tuple<NodeValue>>(
-          pg, txn_ctx, {output_property_name}));
+          pg.get(), txn_ctx, {output_property_name}));
 
   Graph graph = KATANA_CHECKED(Graph::Make(pg, {output_property_name}, {}));
 
@@ -323,10 +324,11 @@ PagerankPullTopological(
 
 katana::Result<void>
 PagerankPullResidual(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   KATANA_CHECKED(katana::analytics::ConstructNodeProperties<NodeData>(
-      pg, txn_ctx, {output_property_name}));
+      pg.get(), txn_ctx, {output_property_name}));
 
   Graph graph = KATANA_CHECKED(Graph::Make(pg, {output_property_name}, {}));
 

--- a/libgraph/src/analytics/pagerank/pagerank-push.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank-push.cpp
@@ -54,7 +54,8 @@ InitializeNodeResidual(
 
 katana::Result<void>
 PagerankPushAsynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   katana::EnsurePreallocated(5, 5 * pg->NumNodes() * sizeof(NodeData));
   katana::ReportPageAllocGuard page_alloc;
@@ -63,7 +64,7 @@ PagerankPushAsynchronous(
       pg->NodeMutablePropertyView()};
 
   if (auto result = katana::analytics::ConstructNodeProperties<NodeData>(
-          pg, txn_ctx, {output_property_name, temporary_property.name()});
+          pg.get(), txn_ctx, {output_property_name, temporary_property.name()});
       !result) {
     return result.error();
   }
@@ -110,7 +111,8 @@ PagerankPushAsynchronous(
 
 katana::Result<void>
 PagerankPushSynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   katana::EnsurePreallocated(5, 5 * pg->NumNodes() * sizeof(NodeData));
   katana::ReportPageAllocGuard page_alloc;
@@ -119,7 +121,7 @@ PagerankPushSynchronous(
       pg->NodeMutablePropertyView()};
 
   if (auto result = katana::analytics::ConstructNodeProperties<NodeData>(
-          pg, txn_ctx, {output_property_name, temporary_property.name()});
+          pg.get(), txn_ctx, {output_property_name, temporary_property.name()});
       !result) {
     return result.error();
   }

--- a/libgraph/src/analytics/pagerank/pagerank.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank.cpp
@@ -22,8 +22,9 @@
 
 katana::Result<void>
 katana::analytics::Pagerank(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, katana::analytics::PagerankPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    katana::analytics::PagerankPlan plan) {
   switch (plan.algorithm()) {
   case PagerankPlan::kPullResidual:
     return PagerankPullResidual(pg, output_property_name, plan, txn_ctx);
@@ -41,7 +42,7 @@ katana::analytics::Pagerank(
 /// \cond DO_NOT_DOCUMENT
 katana::Result<void>
 katana::analytics::PagerankAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg,
+    [[maybe_unused]] const std::shared_ptr<katana::PropertyGraph>&,
     [[maybe_unused]] const std::string& property_name) {
   // TODO(gill): This should have real checks. amp has no idea what to check.
   return katana::ResultSuccess();
@@ -57,7 +58,8 @@ katana::analytics::PagerankStatistics::Print(std::ostream& os) {
 
 katana::Result<katana::analytics::PagerankStatistics>
 katana::analytics::PagerankStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name) {
   auto graph_result =
       TypedPropertyGraph<std::tuple<NodeValue>, std::tuple<>>::Make(
           pg, {property_name}, {});

--- a/libgraph/src/analytics/random_walks/random_walks.cpp
+++ b/libgraph/src/analytics/random_walks/random_walks.cpp
@@ -504,7 +504,8 @@ RandomWalksWithWrap(
 }
 
 katana::Result<std::vector<std::vector<uint32_t>>>
-katana::analytics::RandomWalks(PropertyGraph* pg, RandomWalksPlan plan) {
+katana::analytics::RandomWalks(
+    const std::shared_ptr<PropertyGraph>& pg, RandomWalksPlan plan) {
   switch (plan.algorithm()) {
   case RandomWalksPlan::kNode2Vec: {
     auto graph =
@@ -525,7 +526,7 @@ katana::analytics::RandomWalks(PropertyGraph* pg, RandomWalksPlan plan) {
 /// \cond DO_NOT_DOCUMENT
 katana::Result<void>
 katana::analytics::RandomWalksAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg) {
+    [[maybe_unused]] const std::shared_ptr<PropertyGraph>& pg) {
   // TODO(gill): This should have real checks.
   return katana::ResultSuccess();
 }

--- a/libgraph/src/analytics/sssp/sssp.cpp
+++ b/libgraph/src/analytics/sssp/sssp.cpp
@@ -514,12 +514,12 @@ Sssp(
 template <typename Weight>
 static katana::Result<void>
 SSSPWithWrap(
-    katana::PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, SsspPlan plan,
     katana::TxnContext* txn_ctx) {
   if (auto r = ConstructNodeProperties<std::tuple<SsspNodeDistance<Weight>>>(
-          pg, txn_ctx, {output_property_name});
+          pg.get(), txn_ctx, {output_property_name});
       !r) {
     return r.error();
   }
@@ -545,7 +545,7 @@ SSSPWithWrap(
 
 katana::Result<void>
 katana::analytics::Sssp(
-    PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     SsspPlan plan) {
@@ -590,7 +590,7 @@ namespace {
 template <typename Weight>
 static katana::Result<void>
 SsspValidateImpl(
-    katana::PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name) {
   using Impl = SsspImplementation<Weight>;
@@ -623,7 +623,7 @@ SsspValidateImpl(
 
 katana::Result<void>
 katana::analytics::SsspAssertValid(
-    katana::PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name) {
   switch (
@@ -660,7 +660,8 @@ namespace {
 template <typename Weight>
 static katana::Result<SsspStatistics>
 ComputeStatistics(
-    katana::PropertyGraph* pg, const std::string& output_property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name) {
   auto pg_result = katana::TypedPropertyGraph<
       typename SsspImplementation<Weight>::NodeData,
       std::tuple<>>::Make(pg, {output_property_name}, {});
@@ -698,7 +699,8 @@ ComputeStatistics(
 
 katana::Result<SsspStatistics>
 SsspStatistics::Compute(
-    PropertyGraph* pg, const std::string& output_property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name) {
   switch (
       KATANA_CHECKED(pg->GetNodeProperty(output_property_name))->type()->id()) {
   case arrow::UInt32Type::type_id:

--- a/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
+++ b/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
@@ -94,7 +94,7 @@ SubGraphNodeSet(
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::analytics::SubGraphExtraction(
-    katana::PropertyGraph* pg, const std::vector<Node>& node_vec,
+    const SortedGraphView& sg, const std::vector<Node>& node_vec,
     SubGraphExtractionPlan plan) {
   // Remove duplicates from the node vector
   std::unordered_set<uint32_t> set;
@@ -108,8 +108,6 @@ katana::analytics::SubGraphExtraction(
   if (dedup_node_vec.empty()) {
     return std::make_unique<katana::PropertyGraph>();
   }
-
-  SortedGraphView sg = pg->BuildView<SortedGraphView>();
 
   katana::StatTimer execTime("SubGraph-Extraction");
   switch (plan.algorithm()) {

--- a/libgraph/src/analytics/triangle_count/triangle_count.cpp
+++ b/libgraph/src/analytics/triangle_count/triangle_count.cpp
@@ -263,7 +263,7 @@ EdgeIteratingAlgo(const SortedGraphView* graph) {
 
 katana::Result<uint64_t>
 katana::analytics::TriangleCount(
-    katana::PropertyGraph* pg, TriangleCountPlan plan) {
+    const SortedGraphView& sorted_view, TriangleCountPlan plan) {
   katana::StatTimer timer_graph_read("GraphReadingTime", "TriangleCount");
   katana::StatTimer timer_auto_algo("AutoRelabel", "TriangleCount");
 
@@ -271,7 +271,6 @@ katana::analytics::TriangleCount(
 
   katana::StatTimer timer_relabel("GraphRelabelTimer", "TriangleCount");
   timer_relabel.start();
-  SortedGraphView sorted_view = pg->BuildView<SortedGraphView>();
   timer_relabel.stop();
 
   // TODO(amber): Today we sort unconditionally. Figure out a way to re-enable the
@@ -325,7 +324,8 @@ katana::analytics::TriangleCount(
   timer_graph_read.stop();
 #endif
 
-  katana::EnsurePreallocated(1, 16 * (pg->NumNodes() + pg->NumEdges()));
+  katana::EnsurePreallocated(
+      1, 16 * (sorted_view.NumNodes() + sorted_view.NumEdges()));
   katana::ReportPageAllocGuard page_alloc;
 
   KATANA_LOG_VERBOSE("Done relabeling. Starting TriangleCount");

--- a/libgraph/test/property-graph-optional-topology-generation.cpp
+++ b/libgraph/test/property-graph-optional-topology-generation.cpp
@@ -26,12 +26,13 @@ TestOptionalTopologyGenerationEdgeShuffleTopology() {
   KATANA_LOG_DEBUG("##### Testing EdgeShuffleTopology Generation #####");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(ldbc_003InputFile, &txn_ctx);
+  auto pg = std::make_shared<katana::PropertyGraph>(
+      LoadGraph(ldbc_003InputFile, &txn_ctx));
 
   // Build a EdgeSortedByDestID view, which uses GraphTopology EdgeShuffleTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgesSortedByDestID;
 
-  pg.BuildView<SortedGraphView>();
+  SortedGraphView::Make(std::move(pg));
 }
 
 void
@@ -39,13 +40,14 @@ TestOptionalTopologyGenerationShuffleTopology() {
   KATANA_LOG_DEBUG("##### Testing ShuffleTopology Generation #####");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(ldbc_003InputFile, &txn_ctx);
+  auto pg = std::make_shared<katana::PropertyGraph>(
+      LoadGraph(ldbc_003InputFile, &txn_ctx));
 
   // Build a NodesSortedByDegreeEdgesSortedByDestID view, which uses GraphTopology ShuffleTopology in the background
   using SortedGraphView =
       katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID;
 
-  pg.BuildView<SortedGraphView>();
+  SortedGraphView::Make(std::move(pg));
 }
 
 void
@@ -53,12 +55,13 @@ TestOptionalTopologyGenerationEdgeTypeAwareTopology() {
   KATANA_LOG_DEBUG("##### Testing EdgeTypeAware Topology Generation ######");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(ldbc_003InputFile, &txn_ctx);
+  auto pg = std::make_shared<katana::PropertyGraph>(
+      LoadGraph(ldbc_003InputFile, &txn_ctx));
 
   // Build a EdgeTypeAwareBiDir view, which uses GraphTopology EdgeTypeAwareTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgeTypeAwareBiDir;
 
-  pg.BuildView<SortedGraphView>();
+  SortedGraphView::Make(std::move(pg));
 }
 
 int

--- a/libgraph/test/property-graph-transposed-view.cpp
+++ b/libgraph/test/property-graph-transposed-view.cpp
@@ -23,16 +23,16 @@ TestTransposedView() {
   }
 
   auto pg = KATANA_CHECKED(PropertyGraph::Make(builder.ConvertToCSR()));
-  TransposedGraphView pg_tr_view = pg->BuildView<TransposedGraphView>();
+  auto pg_tr_view = TransposedGraphView::Make(std::move(pg));
 
   auto pg_tr = KATANA_CHECKED(PropertyGraph::Make(builder_tr.ConvertToCSR()));
 
-  for (Edge e : pg_tr_view.OutEdges()) {
+  for (Edge e : pg_tr_view->OutEdges()) {
     KATANA_LOG_VASSERT(
-        pg_tr->topology().GetEdgeSrc(e) == pg_tr_view.GetEdgeSrc(e),
+        pg_tr->topology().GetEdgeSrc(e) == pg_tr_view->GetEdgeSrc(e),
         "Edge sources do not match");
     KATANA_LOG_VASSERT(
-        pg_tr->topology().OutEdgeDst(e) == pg_tr_view.OutEdgeDst(e),
+        pg_tr->topology().OutEdgeDst(e) == pg_tr_view->OutEdgeDst(e),
         "Edge destinations do not match");
   }
 

--- a/libgraph/test/property-graph-undirected-view.cpp
+++ b/libgraph/test/property-graph-undirected-view.cpp
@@ -28,7 +28,7 @@ TestDegreeSum(std::unique_ptr<katana::PropertyGraph>&& pg) noexcept {
   using Node = UndirectedView::Node;
   using Edge = UndirectedView::Edge;
 
-  auto view_res = UndirectedView::Make(pg.get(), {"label", "deg_sum"}, {});
+  auto view_res = UndirectedView::Make(std::move(pg), {"label", "deg_sum"}, {});
   KATANA_LOG_VASSERT(
       view_res, "Failed to create Undirected View. Error msg: {}",
       view_res.error());

--- a/libgraph/test/storage-format-version-optional-topologies.h
+++ b/libgraph/test/storage-format-version-optional-topologies.h
@@ -35,23 +35,25 @@ TestOptionalTopologyStorageEdgeShuffleTopology(std::string inputFile) {
   KATANA_LOG_WARN("***** Testing EdgeShuffleTopology *****");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile, &txn_ctx);
+  auto pg =
+      std::make_shared<katana::PropertyGraph>(LoadGraph(inputFile, &txn_ctx));
 
   // Build a EdgeSortedByDestID view, which uses GraphTopology EdgeShuffleTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgesSortedByDestID;
+  auto generated_sorted_view = SortedGraphView::Make(pg);
 
-  SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
   // TODO: ensure this view was generated, not loaded
   // generated_sorted_view.Print();
 
-  std::string g2_rdg_file = StoreGraph(&pg);
-  katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file, &txn_ctx);
+  std::string g2_rdg_file = StoreGraph(pg.get());
+  auto pg2 =
+      std::make_shared<katana::PropertyGraph>(LoadGraph(g2_rdg_file, &txn_ctx));
 
-  SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
+  auto loaded_sorted_view = SortedGraphView::Make(pg2);
 
   //TODO: emcginnis need some way to verify we loaded this view, vs just generating it again
 
-  verify_view(generated_sorted_view, loaded_sorted_view);
+  verify_view(*generated_sorted_view, *loaded_sorted_view);
 }
 
 void
@@ -59,24 +61,26 @@ TestOptionalTopologyStorageShuffleTopology(std::string inputFile) {
   KATANA_LOG_WARN("***** Testing ShuffleTopology *****");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile, &txn_ctx);
+  auto pg =
+      std::make_shared<katana::PropertyGraph>(LoadGraph(inputFile, &txn_ctx));
 
   // Build a NodesSortedByDegreeEdgesSortedByDestID view, which uses GraphTopology ShuffleTopology in the background
   using SortedGraphView =
       katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID;
 
-  SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
+  auto generated_sorted_view = SortedGraphView::Make(pg);
   // TODO: ensure this view was generated, not loaded
   // generated_sorted_view.Print();
 
-  std::string g2_rdg_file = StoreGraph(&pg);
-  katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file, &txn_ctx);
+  std::string g2_rdg_file = StoreGraph(pg.get());
+  auto pg2 =
+      std::make_shared<katana::PropertyGraph>(LoadGraph(g2_rdg_file, &txn_ctx));
 
-  SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
+  auto loaded_sorted_view = SortedGraphView::Make(pg2);
 
   //TODO: emcginnis need some way to verify we loaded this view, vs just generating it again
 
-  verify_view(generated_sorted_view, loaded_sorted_view);
+  verify_view(*generated_sorted_view, *loaded_sorted_view);
 }
 
 void
@@ -84,22 +88,24 @@ TestOptionalTopologyStorageEdgeTypeAwareTopology(std::string inputFile) {
   KATANA_LOG_WARN("***** Testing EdgeTypeAware Topology *****");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile, &txn_ctx);
+  auto pg =
+      std::make_shared<katana::PropertyGraph>(LoadGraph(inputFile, &txn_ctx));
 
   // Build a EdgeTypeAwareBiDir view, which uses GraphTopology EdgeTypeAwareTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgeTypeAwareBiDir;
 
-  SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
+  auto generated_sorted_view = SortedGraphView::Make(pg);
   // generated_sorted_view.Print();
 
-  std::string g2_rdg_file = StoreGraph(&pg);
-  katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file, &txn_ctx);
+  std::string g2_rdg_file = StoreGraph(pg.get());
+  auto pg2 =
+      std::make_shared<katana::PropertyGraph>(LoadGraph(g2_rdg_file, &txn_ctx));
 
-  SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
+  auto loaded_sorted_view = SortedGraphView::Make(pg2);
 
   //TODO: emcginnis need some way to verify we loaded this view, vs just generating it again
 
-  verify_view(generated_sorted_view, loaded_sorted_view);
+  verify_view(*generated_sorted_view, *loaded_sorted_view);
 }
 
 #endif

--- a/python/katana/local/_graph.pxd
+++ b/python/katana/local/_graph.pxd
@@ -42,6 +42,8 @@ cdef class Graph(GraphBase):
 
     cdef _PropertyGraph * underlying_property_graph(self) nogil except NULL
 
+    cdef shared_ptr[_PropertyGraph] shared_underlying_property_graph(self) nogil
+
     @staticmethod
     cdef Graph make(shared_ptr[_PropertyGraph] u)
 

--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -537,6 +537,9 @@ cdef class Graph(GraphBase):
     cdef _PropertyGraph * underlying_property_graph(self) nogil except NULL:
         return self._underlying_property_graph.get()
 
+    cdef shared_ptr[_PropertyGraph] shared_underlying_property_graph(self) nogil:
+        return self._underlying_property_graph
+
     def __init__(self, path, node_properties=None, edge_properties=None, partition_id_to_load=None, TxnContext txn_ctx=None):
         """
         __init__(self, path, node_properties=None, edge_properties=None, partition_id_to_load=None)

--- a/tools/generate-maximal-storage-format-rdg/generate-maximal-storage-format-rdg.cpp
+++ b/tools/generate-maximal-storage-format-rdg/generate-maximal-storage-format-rdg.cpp
@@ -54,17 +54,18 @@ StoreGraph(katana::PropertyGraph* g, std::string& output_path) {
 
 void
 MaximizeGraph(std::string& input_rdg, std::string& output_path) {
-  katana::PropertyGraph g = LoadGraph(input_rdg);
+  auto g = std::make_shared<katana::PropertyGraph>(LoadGraph(input_rdg));
 
   // Add calls which add optional data structures to the RDG here
-  auto generated_sorted_view_sort1 = g.BuildView<
-      katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID>();
+  auto generated_sorted_view_sort1 =
+      katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID::Make(
+          g);
   auto generated_sorted_view_sort2 =
-      g.BuildView<katana::PropertyGraphViews::EdgesSortedByDestID>();
+      katana::PropertyGraphViews::EdgesSortedByDestID::Make(g);
   auto generated_sorted_view_sort3 =
-      g.BuildView<katana::PropertyGraphViews::EdgeTypeAwareBiDir>();
+      katana::PropertyGraphViews::EdgeTypeAwareBiDir::Make(g);
 
-  std::string g2_rdg_file = StoreGraph(&g, output_path);
+  std::string g2_rdg_file = StoreGraph(g.get(), output_path);
   KATANA_LOG_WARN(
       "maximized version of {} stored at {}", input_rdg, g2_rdg_file);
 }


### PR DESCRIPTION
Currently, views maintain raw pointers to the PropertyGraph rather than shared pointers. This can be unsafe because if the PropertyGraph is destroyed before the View, the view will either segfault or return garbage values.

This PR changes the View structures to maintain shared pointers to the PropertyGraph. It additionally removes the PropertyGraph::BuildView functions in favor of PropertyGraphView::Make functions.

This is WIP primarily because I need to wait until the pybind11 wrappings are in to get the python side working. The c++ code should be about ready.