### PR TITLE
[KAT-2689] Add support for keyword parameter for capture environment

### DIFF
--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -206,7 +206,6 @@ def is_interactive():
 
 
 def capture_environment(filename: Optional[Union[str, Path, Any]] = None, **kwargs):
-    # pylint: disable=unused-argument
     """
     Capture the execution and build environment in as much detail as reasonably possible
     and store it to a file. This is used for bug reporting.
@@ -233,7 +232,7 @@ def capture_environment(filename: Optional[Union[str, Path, Any]] = None, **kwar
     try:
         with zipfile.ZipFile(file=file, mode="w", compression=zipfile.ZIP_BZIP2) as zipout:
             for f in _environment_capture_routines:
-                f(zipout)
+                f(zipout, kwargs)
     finally:
         if filename is not None:
             file.close()

--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -19,7 +19,7 @@ def register_capture_routine(f):
 
 
 @register_capture_routine
-def _capture_system(zipout: zipfile.ZipFile):
+def _capture_system(zipout: zipfile.ZipFile, **kwargs):
     import katana  # Imported here to avoid cyclical import
 
     capture_string(
@@ -92,7 +92,7 @@ def _capture_system(zipout: zipfile.ZipFile):
 
 
 @register_capture_routine
-def _capture_build(zipout: zipfile.ZipFile):
+def _capture_build(zipout: zipfile.ZipFile, **kwargs):
     """
     Capture build related files into zip.
     """
@@ -203,7 +203,7 @@ def is_interactive():
     return hasattr(sys, "ps1")
 
 
-def capture_environment(filename: Optional[Union[str, Path, Any]] = None):
+def capture_environment(filename: Optional[Union[str, Path, Any]] = None, **kwargs):
     """
     Capture the execution and build environment in as much detail as reasonably possible
     and store it to a file. This is used for bug reporting.
@@ -211,6 +211,7 @@ def capture_environment(filename: Optional[Union[str, Path, Any]] = None):
     :param filename: The file name for the captured environment information.
         (Default: an auto generated file in the system temporary directory)
     :type filename: str or Path or a file-like object or None
+    :key client: Required if using remote enviroment. Expects katana.remote.Client
     :return: A file path where the captured environment information is stored.
     """
     # pylint: disable=consider-using-with

--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -232,7 +232,7 @@ def capture_environment(filename: Optional[Union[str, Path, Any]] = None, **kwar
     try:
         with zipfile.ZipFile(file=file, mode="w", compression=zipfile.ZIP_BZIP2) as zipout:
             for f in _environment_capture_routines:
-                f(zipout, kwargs)
+                f(zipout, **kwargs)
     finally:
         if filename is not None:
             file.close()

--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -20,6 +20,7 @@ def register_capture_routine(f):
 
 @register_capture_routine
 def _capture_system(zipout: zipfile.ZipFile, **kwargs):
+    # pylint: disable=unused-argument
     import katana  # Imported here to avoid cyclical import
 
     capture_string(
@@ -93,6 +94,7 @@ def _capture_system(zipout: zipfile.ZipFile, **kwargs):
 
 @register_capture_routine
 def _capture_build(zipout: zipfile.ZipFile, **kwargs):
+    # pylint: disable=unused-argument
     """
     Capture build related files into zip.
     """
@@ -204,6 +206,7 @@ def is_interactive():
 
 
 def capture_environment(filename: Optional[Union[str, Path, Any]] = None, **kwargs):
+    # pylint: disable=unused-argument
     """
     Capture the execution and build environment in as much detail as reasonably possible
     and store it to a file. This is used for bug reporting.

--- a/python/katana/bug/environment.py
+++ b/python/katana/bug/environment.py
@@ -213,7 +213,7 @@ def capture_environment(filename: Optional[Union[str, Path, Any]] = None, **kwar
     :param filename: The file name for the captured environment information.
         (Default: an auto generated file in the system temporary directory)
     :type filename: str or Path or a file-like object or None
-    :key client: Required if using remote enviroment. Expects katana.remote.Client
+    :key client: When using remote environment please provide the katana.remote.Client. Otherwise, not required.
     :return: A file path where the captured environment information is stored.
     """
     # pylint: disable=consider-using-with


### PR DESCRIPTION
This change allows for capturing keyword parameters which can be used in registered call backs for capture environment as needed.

Jira: KAT-2689