### PR TITLE
Replace Property's value appending with empty value appending

### DIFF
--- a/libgraph/include/katana/Properties.h
+++ b/libgraph/include/katana/Properties.h
@@ -498,12 +498,10 @@ struct Property {
   static Result<std::shared_ptr<arrow::Table>> Allocate(
       size_t num_rows, const std::string& name) {
     using Builder = typename arrow::TypeTraits<ArrowType>::BuilderType;
-    using CType = typename arrow::TypeTraits<ArrowType>::CType;
     Builder builder;
 
-    // TODO(lhc): replace this with AppendEmptyValues() on Arrow >= 3.0.
-    katana::PODVector<CType> rows(num_rows);
-    if (auto r = builder.AppendValues(rows.data(), num_rows); !r.ok()) {
+    builder.Reserve(num_rows);
+    if (auto r = builder.AppendEmptyValues(num_rows); !r.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to append values {}", r);
     }


### PR DESCRIPTION
This draft updates two parts of Property struct.
The first one is to replace `AppendValues()` with `AppendEmptyValues()`. 
In the past, the former appends dummy vector of size `num_rows`. The current Arrow version has much proper API, `AppendEmptyValues()`. 

The second one is to call `Reserve()` before appending empty values to avoid over memory allocations.
AppendEmptyValues() allocates about 2x more memory than users passed for optimizations to avoid frequent reallocations.
But this caused out-of-memory when we tested louvain on big graphs like clueweb12.

@roshandathathri  I need above updates but I am not sure if it is the best design option.
Could you please assign reviewers who are experts and give any suggestions?