### PR TITLE
Add global toc [KAT-2560]

### DIFF
--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -1,0 +1,12 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="{{ _('Main navigation') }}">
+    <div class="bd-toc-item active">
+      {{ generate_nav_html("sidebar",
+                           startdepth=0,
+                           show_nav_level=theme_show_nav_level|int,
+                           maxdepth=theme_navigation_depth|int,
+                           collapse=theme_collapse_navigation|tobool,
+                           includehidden=True,
+                           titles_only=True) }}
+    </div>
+  </nav>
+  


### PR DESCRIPTION
Overriding the `html` template with an extra variable, `startdepth=0`, tricks the Python script behind `pydata-sphinx-theme` to use a the equivalent to `globaltoc.html`.

KAT-2560