### PR TITLE
[KAT-3781] Add a warnings config file with a method to disable modin warnings

### DIFF
--- a/python/katana/warnings_config.py
+++ b/python/katana/warnings_config.py
@@ -1,0 +1,13 @@
+import warnings
+
+
+def disable_partial_modin_warnings():
+
+    # Ignore any warnings related to defaulting to pandas for any operation.
+    warnings.filterwarnings("ignore", message=r".*[dD]efaulting to pandas implementation.*", module="modin")
+
+    # Ignore warnings related to distribution of object
+    warnings.filterwarnings("ignore", message=r".*[dD]istributing.*object", module="modin")
+
+    # Ignore warnings for implementation requests
+    warnings.filterwarnings("ignore", message=r".*request implementation.*", module="modin")


### PR DESCRIPTION
This adds a warnings_config file where we can define methods to disable warnings from certain modules. This will be imported and called in katana.remote on the enterprise repo since that's the only place currently using modin.

Note: this doesn't filter out all of modin warnings but the one's that seemed confusing to the user so far. We will disable additional warnings as people see them and find they aren't relevant.

JIra: KAT-3781