### PR TITLE
reduce parallelism for conda build

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -123,6 +123,7 @@ jobs:
     - name: Build conda Packages
       run: |
         . .github/workflows/activate_miniconda.sh
+        export CPU_COUNT=1
         scripts/build_conda.py --output-folder $HOME/build/
 
     - name: Build conda Packages for Katana Metagraph Plugin


### PR DESCRIPTION
without this change, the default level is 2 which
can cause issues in our CI

example of the kind of failure this fixes: https://github.com/KatanaGraph/katana/runs/5041815770?check_suite_focus=true