### PR TITLE
Add how-to template and fix formatting. [KAT-2298]

### DIFF
--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -2,8 +2,9 @@
 Documentation
 =============
 
+********
 Overview
-========
+********
 
 People turn to documentation for many different reasons, so it is important to
 consider the audience and what their needs are. What a person wants out of
@@ -30,8 +31,9 @@ answer specific questions:
 - :ref:`contributing`: I'd like to improve to Katana itself. What should I
   know?
 
+**********************
 Building Documentation
-======================
+**********************
 
 To build the documentation, set the ``-DBUILD_DOCS=`` option to either
 ``internal`` or ``external`` and ``-DKATANA_LANG_BINDINGS=python`` ``cmake``
@@ -50,8 +52,9 @@ options and then make the ``docs`` build target.
    cd $BUILD_DIR
    make docs
 
+*****************************************
 Annotating Internal or Draft only Content
-=========================================
+*****************************************
 
 Files ending in ``-draft.[rst/ipynb]`` or ``-internal.[rst/ipynb]`` will not be
 included in external facing documentation.
@@ -59,8 +62,9 @@ included in external facing documentation.
 Whole directories ending in ``-draft/`` or ``-internal/`` will be omitted when
 building external documentation.
 
+*****************
 Restructured Text
-=================
+*****************
 
 Most documentation is written in Restructured Text (``.rst``) format, which is
 similar to Markdown (``.md``) in spirit but has a slightly different syntax.
@@ -158,14 +162,95 @@ similar to Markdown (``.md``) in spirit but has a slightly different syntax.
 
 - https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 
+*****************
 Jupyter Notebooks
-=================
+*****************
 
 Guides on how to use Katana Graph in Python should be written as Jupyter
 Notebooks. They will be parsed similar to Restructured Text (``.rst``) files.
 
+Style
+=====
+
+* Keep titles and headings in sentence case (capitalize first letter of first
+  word, proper nouns, first letter of subheading after colon, and no
+  punctuation).
+* Code cells in user guides must be evaluated with results less than 30 lines.
+* Do not number headings of step titles in step by step guide. For substep
+  sequences, use numbered bullet points under a given step title.
+* Write in the second person: "Delete your database."
+
+How-to template
+===============
+
+``katana/docs/contributing/how_to_template.ipynb`` is a template for creating a
+how-to guide in the form of a Jupyter Notebook. Use it when you wish to take a
+reader through a detailed series of steps required to do an individual task or
+procedure. Be sure to follow the section structure in the notebook and to use
+the above Katana Graph writing style.
+
+Customization
+-------------
+
+#. Choose a filename that matches or abbreviates what you wish to title the
+   guide. Add the ``-draft`` tag (with hyphen) to the end of the filename. For
+   example, ``const_cool_graphs-draft.ipynb`` for a guide titled "Constructing
+   Cool Graphs."
+#. The guide should be committed to
+   ``/docs/user-guides/<most relevant directory>``. Create a new directory in
+   ``/docs/user-guides/`` if a relevant directory does not exist.
+#. In the above directory, ensure that the filename is added to the list under
+   ``.. toctree::`` located in that directory's ``index.rst`` file. The name is
+   to be included without the file extension. For example,
+   ``const_cool_graphs-draft``. If you created a directory in the previous step,
+   you will need to create a new ``index.rst`` and copy the format used in
+   another user guide subdirectory.
+#. Use a descriptive title according to the style guide.
+
+Fill out the Requirements section
+---------------------------------
+
+This section prevents readers from getting halfway through and discovering that
+they need to go and read other documentation before they can continue.
+Prerequisites can include other articles or information to read, or it can be
+technical dependencies. If there is more than one prerequisite, a bulleted list
+is good to make the needs clearer. Describe what the audience needs to know, or
+needs to have, before they attempt the how-to. By stating the requirements
+up-front, you prevent your readers from having a bad experience with your
+how-to. You must include links to procedures or information about how to get
+what they need. If not possible, give useful pointers.
+
+Explain steps and process
+-------------------------
+
+Images
+^^^^^^
+
+When you are explaining steps in a process, it can be useful to include images
+(such as screenshots) for each key part of the process. This can help readers
+orientate themselves as they move through the steps. It can also help someone
+who is evaluating the software see how it works without having to install it.
+When an image is quicker to interpret than descriptive text, put the screenshot
+first, otherwise lead with the text.
+
+Ordered lists
+^^^^^^^^^^^^^
+
+In general, ordered lists should be avoided in favor of section titles presented
+in order to the reader. When unavoidable, provide a lead-in sentence before the
+ordered list.
+
+Code
+^^^^
+
+Break up your code where possible into smaller code cells and provide a lead-in
+sentence explaining the code snippet. Describe what you are doing and your
+expected result. If a large code block cannot be broken up, provide comments in
+your code as well. Your code must not be pseudocode and the notebook as a whole
+must be fully executable with no errors or warnings.
+
 Orphaned Notebooks
-------------------
+==================
 
 This means that it doesn’t appear in a toctree (see ``index.rst``),
 but other pages can still link to it.
@@ -179,8 +264,9 @@ metadata:
       "orphan": true
    }
 
+*****************
 API Documentation
-=================
+*****************
 
 API documentation is a form of reference information, usually embedded in code
 files, and is targeted towards people who know the general concepts in question
@@ -204,7 +290,7 @@ is best to keep text simple and communicate using basic text that can be read
 easily without being rendered by a separate documentation tool.
 
 C++
----
+===
 
 .. code-block:: cpp
 
@@ -243,7 +329,7 @@ particular code block.
    /// \endcode DO_NOT_DOCUMENT
 
 Python
-------
+======
 
 .. code-block:: python
 
@@ -269,7 +355,7 @@ Python
       ...
 
 Go
---
+==
 
 .. code-block:: go
 

--- a/docs/contributing/how_to_template.ipynb
+++ b/docs/contributing/how_to_template.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \\<Title of how-to guide\\>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\\<Introduction - Summarize what this how-to guide is about in a sentence or two. Ensure you link to the relevant explanations in the introduction so that the reader can gain more understanding of the related topics.\\>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Requirements\n",
+    "\n",
+    "Before you begin, make sure you meet these prerequisites:\n",
+    "\n",
+    "* \\<First prerequisite\\>\n",
+    "* \\<Next prerequisite\\>\n",
+    "\n",
+    "\\<Include other important information here, such as known issues or bugs.\\>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load libraries\n",
+    "\n",
+    "\\<For example:\\>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from katana import remote\n",
+    "from katana.remote import import_data, analytics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Connect client\n",
+    "\n",
+    "Starting a Katana remote Client is required to interface with the Katana remote service and schedule distributed operations. Provide the Katana Graph server address by setting the environment variable `KATANA_SERVER_ADDRESS`. This variable applies only to your current shell session. If you want the variable to be automatically set for future shell sessions, set the variable in your shell startup file. For more detailed information refer to the Getting Started section of the documentation. Alternatively, you can pass in the address of the remote service by calling `Client(address=\"localhost:8080\")` for Linux machines or `Client(address=\"host.docker.internal:8080\")` for macOS and Windows machines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect to the Katana Server\n",
+    "client = remote.Client()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load data\n",
+    "\n",
+    "\\<Create a new graph and load data to that graph.\\>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \\<Title of step 1\\>\n",
+    "\n",
+    "### \\<Title of substep 1\\>\n",
+    "\n",
+    "### \\<Title of next substep\\>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## \\<Title of next step\\>\n",
+    "\n",
+    "### \\<Title of substep 1\\>\n",
+    "\n",
+    "### \\<Title of next substep\\>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "\\<Provide recommendations of other resources or documentation sections for the reader. Include links for each recommendation.\\>"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -16,3 +16,4 @@ Contributing
    releases
    tips-tricks
    rdg-storage-format
+   How-to guide template <how_to_template>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@ Katana
 ======
 
 .. toctree::
+   :hidden:
    
    getting-started/index
    user-guides/index


### PR DESCRIPTION
I added a How-to guide template, usage notes for the template in "Contributing", and hid the table of contents on the homepage since it is now fully visible on the left-hand sidebar.

KAT-2298