### PR TITLE
Reserve the exact size of property to avoid over allocations

### DIFF
--- a/libgraph/include/katana/Properties.h
+++ b/libgraph/include/katana/Properties.h
@@ -571,7 +571,7 @@ struct StructProperty
 
     auto type = res.ValueOrDie();
     arrow::FixedSizeBinaryBuilder builder(type);
-    builder.Reserve(num_rows);
+    builder.ReserveData(num_rows);
     if (auto res = builder.AppendEmptyValues(num_rows); !res.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to append values {}", res);

--- a/libgraph/include/katana/Properties.h
+++ b/libgraph/include/katana/Properties.h
@@ -500,18 +500,15 @@ struct Property {
     using Builder = typename arrow::TypeTraits<ArrowType>::BuilderType;
     Builder builder;
 
-    builder.Reserve(num_rows);
-    if (auto r = builder.AppendEmptyValues(num_rows); !r.ok()) {
-      return KATANA_ERROR(
-          katana::ErrorCode::ArrowError, "failed to append values {}", r);
-    }
+    KATANA_CHECKED(builder.Reserve(num_rows));
+    KATANA_CHECKED_ERROR_CODE(
+        builder.AppendEmptyValues(num_rows), katana::ErrorCode::ArrowError,
+        "failed to append values");
 
     std::shared_ptr<arrow::Array> array;
-    if (auto r = builder.Finish(&array); !r.ok()) {
-      return KATANA_ERROR(
-          katana::ErrorCode::ArrowError, "failed to construct arrow array {}",
-          r);
-    }
+    KATANA_CHECKED_ERROR_CODE(
+        builder.Finish(&array), katana::ErrorCode::ArrowError,
+        "failed to construct arrow array");
 
     return arrow::Table::Make(
         arrow::schema({arrow::field(
@@ -571,17 +568,15 @@ struct StructProperty
 
     auto type = res.ValueOrDie();
     arrow::FixedSizeBinaryBuilder builder(type);
-    builder.ReserveData(num_rows);
-    if (auto res = builder.AppendEmptyValues(num_rows); !res.ok()) {
-      return KATANA_ERROR(
-          katana::ErrorCode::ArrowError, "failed to append values {}", res);
-    }
+    KATANA_CHECKED(builder.Reserve(num_rows));
+    KATANA_CHECKED_ERROR_CODE(
+        builder.AppendEmptyValues(num_rows), katana::ErrorCode::ArrowError,
+        "failed to append values");
+
     std::shared_ptr<arrow::Array> array;
-    if (auto res = builder.Finish(&array); !res.ok()) {
-      return KATANA_ERROR(
-          katana::ErrorCode::ArrowError, "failed to construct arrow array {}",
-          res);
-    }
+    KATANA_CHECKED_ERROR_CODE(
+        builder.Finish(&array), katana::ErrorCode::ArrowError,
+        "failed to construct arrow array ");
 
     return katana::Result<std::shared_ptr<arrow::Table>>(
         arrow::Table::Make(arrow::schema({arrow::field(name, type)}), {array}));

--- a/libgraph/include/katana/Properties.h
+++ b/libgraph/include/katana/Properties.h
@@ -498,12 +498,10 @@ struct Property {
   static Result<std::shared_ptr<arrow::Table>> Allocate(
       size_t num_rows, const std::string& name) {
     using Builder = typename arrow::TypeTraits<ArrowType>::BuilderType;
-    using CType = typename arrow::TypeTraits<ArrowType>::CType;
     Builder builder;
 
-    // TODO(lhc): replace this with AppendEmptyValues() on Arrow >= 3.0.
-    katana::PODVector<CType> rows(num_rows);
-    if (auto r = builder.AppendValues(rows.data(), num_rows); !r.ok()) {
+    builder.Reserve(num_rows);
+    if (auto r = builder.AppendEmptyValues(num_rows); !r.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to append values {}", r);
     }
@@ -573,10 +571,8 @@ struct StructProperty
 
     auto type = res.ValueOrDie();
     arrow::FixedSizeBinaryBuilder builder(type);
-    // TODO(lhc): replace this with AppendEmptyValues() on Arrow >= 3.0.
-    katana::PODVector<uint8_t> data(sizeof(T) * num_rows);
-
-    if (auto res = builder.AppendValues(data.data(), num_rows); !res.ok()) {
+    builder.Reserve(num_rows);
+    if (auto res = builder.AppendEmptyValues(num_rows); !res.ok()) {
       return KATANA_ERROR(
           katana::ErrorCode::ArrowError, "failed to append values {}", res);
     }


### PR DESCRIPTION
The past property allocates more memory than it needs due to its power-of-two memory allocator and it was not necessary.
This was problem and caused out-of-memory during louvain clustering tests on generally big graphs, like clueweb12 or wdc12.
This PR reserves the exact size of property in advance, and therefore, avoids unnecessary memory consumption.

This PR also includes updating to `AppendEmptyValues()` which now supports from Arrow 3.0 ver.
The past version used `AppendValues()` and passed dummy objects to mimic `AppendEmptyValues()`.