### PR TITLE
Property Graph: require storage location in factory

### DIFF
--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -269,9 +269,17 @@ public:
   static Result<std::unique_ptr<PropertyGraph>> Make(
       GraphTopology&& topo_to_assign);
 
-  /// Make a property graph from topology and type arrays
+  /// [[deprecated("You should provide a rdg dir")]]
   static Result<std::unique_ptr<PropertyGraph>> Make(
       GraphTopology&& topo_to_assign, EntityTypeIDArray&& node_entity_type_ids,
+      EntityTypeIDArray&& edge_entity_type_ids,
+      EntityTypeManager&& node_type_manager,
+      EntityTypeManager&& edge_type_manager);
+
+  /// Make a property graph from topology and type arrays
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      const Uri& rdg_dir, GraphTopology&& topo_to_assign,
+      EntityTypeIDArray&& node_entity_type_ids,
       EntityTypeIDArray&& edge_entity_type_ids,
       EntityTypeManager&& node_type_manager,
       EntityTypeManager&& edge_type_manager);

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -218,16 +218,21 @@ katana::PropertyGraph::Make(katana::GraphTopology&& topo_to_assign) {
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
-    katana::GraphTopology&& topo_to_assign,
+    const katana::Uri& rdg_dir, katana::GraphTopology&& topo_to_assign,
     NUMAArray<EntityTypeID>&& node_entity_type_ids,
     NUMAArray<EntityTypeID>&& edge_entity_type_ids,
     EntityTypeManager&& node_type_manager,
     EntityTypeManager&& edge_type_manager) {
-  return std::make_unique<katana::PropertyGraph>(
+  auto retval = std::make_unique<katana::PropertyGraph>(
       std::unique_ptr<katana::RDGFile>(), katana::RDG{},
       std::move(topo_to_assign), std::move(node_entity_type_ids),
       std::move(edge_entity_type_ids), std::move(node_type_manager),
       std::move(edge_type_manager));
+  // It doesn't make sense to pass a RDGFile to the constructor because this
+  // PropertyGraph wasn't loaded from a file. But all PropertyGraphs have an
+  // associated storage location, so set one here.
+  retval->rdg().set_rdg_dir(rdg_dir);
+  return retval;
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>


### PR DESCRIPTION
The Make overload that accepts a topology and type arrays still needs to
require a storage location. Add an overload that requires a storage
location and deprecated the overload doesn't.