### PR TITLE
Add a custom 404 page

### DIFF
--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+==============
+File not found
+==============
+
+The page you have requested is not available. 
+
+The search field on the left and the menus above may help you find what you are looking for. 
+
+


### PR DESCRIPTION
James found the page explaining how to configure our documentation's server to point at a custom 404 page, so I made one to replace the "storage: object doesn't exist" message that https://docs.katanagraph.com/ currently shows for unrecognized requests.