### PR TITLE
Call MemorySupervisor::GetTotalSystemMemory static function, don't get instance

### DIFF
--- a/libgalois/src/MemoryPolicy.cpp
+++ b/libgalois/src/MemoryPolicy.cpp
@@ -166,7 +166,7 @@ katana::MemoryPolicyMinimal::MemoryPolicyMinimal()
 
 katana::MemoryPolicy::MemoryPolicy(
     katana::MemoryPolicy::Thresholds thresholds) {
-  physical_ = katana::MemorySupervisor::Get().GetTotalSystemMemory();
+  physical_ = katana::MemorySupervisor::GetTotalSystemMemory();
   // We divide by physical_
   if (physical_ == 0) {
     physical_ = 1;

--- a/libgalois/test/os-memory.cpp
+++ b/libgalois/test/os-memory.cpp
@@ -155,7 +155,7 @@ void
 Run() {
   // Set up property manager and memory supervisor
   katana::PropertyManager property_manager;
-  uint64_t physical = katana::MemorySupervisor::Get().GetTotalSystemMemory();
+  uint64_t physical = katana::MemorySupervisor::GetTotalSystemMemory();
   katana::MemorySupervisor::Get().SetPolicy(
       std::make_unique<katana::MemoryPolicyPerformance>());
   katana::MemorySupervisor::Get().Register(&property_manager);


### PR DESCRIPTION
I accidentally created recursion where I didn't want it, so call the static function and don't create a MemorySupervisor instance while creating a MemorySupervisor instance.  The current state of enterprise/open makes testing tough.