### PR TITLE
Separate docs and code workflows [KAT-3130]

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'master'
       - 'release/*'
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -19,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # If this job becomes a required check, make sure to sync with `cpp_bypass.yaml`
   do_cpp:
     if: |
       github.event_name != 'pull_request' ||
@@ -30,6 +29,7 @@ jobs:
       - name: Info
         run: echo "will build"
 
+  # If this job becomes a required check, make sure to sync with `cpp_bypass.yaml`
   do_cpp_test:
     needs:
       - do_cpp
@@ -44,9 +44,7 @@ jobs:
       - name: Info
         run: echo "will build"
 
-  ###################################################################
-  # lint
-  ###################################################################
+  # Make sure to keep in sync with "lint" in `cpp_bypass.yaml` 
   lint:
     needs: do_cpp
     runs-on: ${{matrix.os}}
@@ -99,9 +97,7 @@ jobs:
     - name: Check docs
       run: .github/workflows/check_docs.sh $HOME/build
 
-  ###################################################################
-  # build_and_test
-  ###################################################################
+  # Make sure to keep in sync with "build_and_test" in `cpp_bypass.yaml`
   build_and_test:
     needs: do_cpp_test
     runs-on: ${{matrix.os}}

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -5,7 +5,11 @@ on:
     branches:
       - 'master'
       - 'release/*'
+    paths-ignore:
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 # Cancel any previous runs with the same key.
 concurrency:

--- a/.github/workflows/cpp_bypass.yaml
+++ b/.github/workflows/cpp_bypass.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'master'
       - 'release/*'
-    paths:
-      - 'docs/**'
   pull_request:
     paths:
       - 'docs/**'

--- a/.github/workflows/cpp_bypass.yaml
+++ b/.github/workflows/cpp_bypass.yaml
@@ -1,0 +1,69 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/*'
+    paths:
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'docs/**'
+
+# Cancel any previous runs with the same key.
+concurrency:
+  # Example key: Repository Structure CI-refs/pull/1381/merge
+  #   or Repository Structure CI-<owner>-<sha> for pushes
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.repository_owner, github.sha) }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os:
+        - ubuntu-20.04
+        build_type:
+        - Debug
+    steps:
+      - run: 'echo "lint not required" '
+
+  build_and_test:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os:
+        - ubuntu-20.04
+        build_type:
+        - Debug
+        - Release
+        - Sanitizer
+        cxx:
+        - g++
+        - g++-9
+        - clang++-10
+        - clang++-12
+        # Only build and test the following configurations a subset of
+        # configurations to reduce the total number of concurrent jobs.
+        #
+        # The key "include" exists but only allows for the refinement of an
+        # existing matrix "job" (i.e., point in the product space) by adding
+        # more variables. Fallback to "exclude".
+        exclude:
+            # Ubuntu ({g++-9,clang++-10} [most])
+        - os: ubuntu-20.04
+          build_type: Sanitizer
+          cxx: g++
+        - os: ubuntu-20.04
+          build_type: Sanitizer
+          cxx: g++-9
+        - os: ubuntu-20.04
+          build_type: Debug
+          cxx: clang++-10
+        - os: ubuntu-20.04
+          build_type: Debug
+          cxx: clang++-12
+    steps:
+      - run: 'echo "build_and_test not required" '

--- a/.github/workflows/requirements.yaml
+++ b/.github/workflows/requirements.yaml
@@ -5,7 +5,11 @@ on:
     branches:
       - 'master'
       - 'release/*'
+    paths-ignore:
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 # Cancel any previous runs with the same key.
 concurrency:

--- a/.github/workflows/requirements.yaml
+++ b/.github/workflows/requirements.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'master'
       - 'release/*'
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
This is just one step in what will be a large effort by @aspring in [KAT-2769](https://katanagraph.atlassian.net/browse/KAT-2769) to streamline CI. The goal here was to accomplish the limited task set forth in [KAT-3130](https://katanagraph.atlassian.net/browse/KAT-3130) to separate docs CI.

KAT-3130