### PR TITLE
PropertyGraph: always require storage prefix

### DIFF
--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -266,10 +266,16 @@ public:
       const katana::RDGLoadOptions& opts = katana::RDGLoadOptions());
 
   /// Make a property graph from topology
+  // [deprecated("please provide a storage prefix")]
   static Result<std::unique_ptr<PropertyGraph>> Make(
       GraphTopology&& topo_to_assign);
 
-  /// [[deprecated("You should provide a rdg dir")]]
+  /// Make a property graph from topology
+  static Result<std::unique_ptr<PropertyGraph>> Make(
+      const Uri& rdg_dir, GraphTopology&& topo_to_assign);
+
+  /// Make a property graph from topology and type arrays
+  // [deprecated("please provide a storage prefix")]
   static Result<std::unique_ptr<PropertyGraph>> Make(
       GraphTopology&& topo_to_assign, EntityTypeIDArray&& node_entity_type_ids,
       EntityTypeIDArray&& edge_entity_type_ids,

--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -218,6 +218,16 @@ katana::PropertyGraph::Make(katana::GraphTopology&& topo_to_assign) {
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::PropertyGraph::Make(
+    const katana::Uri& rdg_dir, katana::GraphTopology&& topo_to_assign) {
+  return Make(
+      rdg_dir, std::move(topo_to_assign),
+      MakeDefaultEntityTypeIDArray(topo_to_assign.NumNodes()),
+      MakeDefaultEntityTypeIDArray(topo_to_assign.NumEdges()),
+      EntityTypeManager{}, EntityTypeManager{});
+}
+
+katana::Result<std::unique_ptr<katana::PropertyGraph>>
+katana::PropertyGraph::Make(
     katana::GraphTopology&& topo_to_assign,
     NUMAArray<EntityTypeID>&& node_entity_type_ids,
     NUMAArray<EntityTypeID>&& edge_entity_type_ids,


### PR DESCRIPTION
There was one remaining PropertyGraph::Make overload that didn't require
a storage prefix. Add an overload to replace that one that does require
a storage prefix and mark the original one deprecated.