### PR TITLE
Build: pin cmake version to <3.22

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -22,7 +22,8 @@ dependencies:
  - clang-tools>=10
  - clang-tools>=10
  - clangxx>=10
- - cmake>=3.17,<4a0
+   # the aws-sdk cmake is incompatible with version 3.22
+ - cmake>=3.17,<3.22a0
  - conda-build>=3
  - conda-verify>=3
  - coverage>=5.5

--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -110,6 +110,9 @@ cmake:
   labels:
     - apt
     - conda/dev
+  version_overrides:
+    conda/dev: ">=3.17,<3.22a0"
+    conda: ">=3.17,<3.22a0"
 conan:
   version: [ 1.40, null ]
   labels:


### PR DESCRIPTION
The specific issue is that the FindAWS<Something> cmake function that is bundled
with aws-sdk has a while loop that uses syntax that breaks in CMake
3.22.