### PR TITLE
Add BUILD_CPP_TESTING and BUILD_PYTHON_TESTING to control testing by language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ add_subdirectory(libtsuba)
 add_subdirectory(libgalois)
 add_subdirectory(libgraph)
 
-if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
   add_subdirectory(lonestar)
 else()
   # If we are not testing, only build lonestar targets if they are required by
@@ -71,7 +71,7 @@ if (python IN_LIST KATANA_LANG_BINDINGS)
                                DEPENDS Katana::support arrow::arrow Katana::galois Katana::graph Katana::python_native
                                       pybind11::headers
                                COMPONENT python)
-  if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+  if(KATANA_IS_MAIN_PROJECT AND python IN_LIST KATANA_LANG_TESTING)
     add_python_setuptools_tests(katana_python PATH python/test)
   endif()
   add_katana_sphinx_target(katana_python)

--- a/cmake/Modules/BuildCommon.cmake
+++ b/cmake/Modules/BuildCommon.cmake
@@ -41,7 +41,15 @@ set(KATANA_USE_JEMALLOC OFF CACHE BOOL "Use jemalloc")
 set(BUILD_SHARED_LIBS YES CACHE BOOL "Build shared libraries. Default: YES")
 # This option is added by include(CTest). We define it here to let people know
 # that this is a standard option.
-set(BUILD_TESTING ON CACHE BOOL "Build tests")
+set(BUILD_TESTING ON CACHE BOOL "Build/run tests")
+
+if (BUILD_TESTING)
+  set(KATANA_LANG_TESTING_DEFAULT "cpp;python")
+else()
+  set(KATANA_LANG_TESTING_DEFAULT "")
+endif()
+set(KATANA_LANG_TESTING "${KATANA_LANG_TESTING_DEFAULT}" CACHE STRING "Semi-colon separated list of languages to test. Default: cpp;python if BUILD_TESTING, none otherwise")
+
 set(BUILD_DOCS "" CACHE STRING "Build documentation with make doc. Supported values: <unset>, external, internal. external docs hide '*-draft*' and '*-internal* documentation pages and directories when building documentation")
 # Set here to override the cmake default of "/usr/local" because
 # "/usr/local/lib" is not a default search location for ld.so
@@ -67,6 +75,19 @@ set(KATANA_NUM_DOC_THREADS "" CACHE STRING "Maximum number of threads to use whe
 set(KATANA_USE_DEPRECATED_ERROR OFF CACHE BOOL "If set, when treating warnings as errors also treat deprecated declarations as errors")
 
 ###### Configure (users don't need to go beyond here) ######
+
+if (BUILD_TESTING AND KATANA_LANG_TESTING STREQUAL "")
+  message(FATAL_ERROR "BUILD_TESTING (${BUILD_TESTING}) and KATANA_LANG_TESTING (${KATANA_LANG_TESTING}) disagree. "
+          "If BUILD_TESTING is enabled at least one language must be included in KATANA_LANG_TESTING.")
+endif()
+if (NOT BUILD_TESTING AND NOT (KATANA_LANG_TESTING STREQUAL ""))
+  message(WARNING "BUILD_TESTING is disabled (${BUILD_TESTING}) so KATANA_LANG_TESTING (${KATANA_LANG_TESTING}) is ignored.")
+endif()
+if (NOT BUILD_TESTING)
+  set(KATANA_LANG_TESTING "")
+endif()
+
+message(STATUS "Testing for languages: ${KATANA_LANG_TESTING}")
 
 # Without these, build tree shared libraries are not used on a machine where Katana is already installed
 SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-new-dtags")
@@ -367,7 +388,7 @@ else()
 endif()
 
 # Testing-only dependencies
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND cpp IN_LIST KATANA_LANG_TESTING)
   find_package(benchmark REQUIRED)
 endif ()
 

--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -83,7 +83,7 @@ if(VTune_FOUND)
   target_link_libraries(katana_galois PRIVATE ${VTune_LIBRARIES})
 endif()
 
-if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/libgpu/CMakeLists.txt
+++ b/libgpu/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory(test)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
+  add_subdirectory(test)
+endif()

--- a/libgraph/CMakeLists.txt
+++ b/libgraph/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(katana_graph PUBLIC LibXml2::LibXml2)
 
 set_common_katana_library_options(katana_graph)
 
-if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/libsanitize/libdisable_dlclose/CMakeLists.txt
+++ b/libsanitize/libdisable_dlclose/CMakeLists.txt
@@ -9,4 +9,6 @@ target_sources(katana_disable_dlclose PRIVATE
 
 set_common_katana_library_options(katana_disable_dlclose ALWAYS_SHARED)
 
-add_subdirectory(test)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
+  add_subdirectory(test)
+endif()

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -104,7 +104,7 @@ else()
   target_link_libraries(katana_support PUBLIC Boost::filesystem)
 endif()
 
-if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -43,7 +43,7 @@ set_common_katana_library_options(katana_tsuba ALWAYS_SHARED)
 target_link_libraries(katana_tsuba PUBLIC katana_support)
 target_link_libraries(katana_tsuba PUBLIC katana_galois)
 
-if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/tools/graph-convert/CMakeLists.txt
+++ b/tools/graph-convert/CMakeLists.txt
@@ -92,6 +92,6 @@ install(TARGETS graph-properties-convert
 )
 add_dependencies(tools graph-properties-convert)
 
-if(KATANA_IS_MAIN_PROJECT AND BUILD_TESTING)
+if(KATANA_IS_MAIN_PROJECT AND cpp IN_LIST KATANA_LANG_TESTING)
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
This reduces the time required to link all the tests when you really just need the server and worker binaries to test python code.