### PR TITLE
fixup arrow, requirements install on ubuntu21.04

### DIFF
--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -419,7 +419,7 @@ libnuma:
   labels:
     - apt
 ccache:
-  version: [3, 4]
+  version: [3, 4.3]
   labels:
     - apt/dev
     - conda/apt

--- a/scripts/katana_requirements/__main__.py
+++ b/scripts/katana_requirements/__main__.py
@@ -197,9 +197,10 @@ def setup_install_arguments(parser):
 
 def get_apt_version():
     version_information_str = str(subprocess.check_output(["apt-get", "-v"], stderr=subprocess.DEVNULL), "UTF-8")
-    version_match = re.match(r"apt ([0-9.]+) \(.*\)", version_information_str)
+    version_match = re.match(r"apt ([0-9.]+)(?:ubuntu[0-9.]+)? \(.*\)", version_information_str)
     if not version_match:
         raise RuntimeError(f"apt-get returned unexpected version information:\n{version_information_str}")
+
     return Version(version_match.group(1))
 
 

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -93,11 +93,13 @@ if [ "$VERSION" == "21" ]; then
     curl "http://archive.ubuntu.com/ubuntu/pool/main/r/re2/libre2-5_20200101+dfsg-1build1_amd64.deb" \
          --output /tmp/libre2-5.deb
     apt install -yq /tmp/libre2-5.deb && rm /tmp/libre2-5.deb
-else
-    curl "https://apache.jfrog.io/artifactory/arrow/$RELEASE_ID/apache-arrow-apt-source-latest-$RELEASE_CODENAME.deb" \
-         --output /tmp/apache-arrow-apt-source-latest.deb
 fi
+
+curl "https://apache.jfrog.io/artifactory/arrow/$RELEASE_ID/apache-arrow-apt-source-latest-$RELEASE_CODENAME.deb" \
+     --output /tmp/apache-arrow-apt-source-latest.deb
+
 apt install -yq /tmp/apache-arrow-apt-source-latest.deb && rm /tmp/apache-arrow-apt-source-latest.deb
+
 
 #
 # Install dependencies


### PR DESCRIPTION
on 21.04 the apt version is:
```
$apt-get --version
apt 2.2.4ubuntu0.1 (amd64)
```

which broke the version check in our requirements script.
Add a fallback path to catch this.