### PR TITLE
Return nullptr in index_to_type_map_data if no types

### DIFF
--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -598,6 +598,9 @@ public:
   void invalidate() noexcept { is_valid_ = false; };
 
   const EntityTypeID* index_to_type_map_data() const noexcept {
+    if (index_to_type_map_.empty()) {
+      return nullptr;
+    }
     return &index_to_type_map_[0];
   }
 


### PR DESCRIPTION
This was causing a sanitizer error when committing to an empty graph. It doesn't seem to actually change anything functionally.
