### PR TITLE
Assume all ExtensionType builders inherit from their StorageType's ArrayBuilder

### DIFF
--- a/libsupport/include/katana/ArrowVisitor.h
+++ b/libsupport/include/katana/ArrowVisitor.h
@@ -73,7 +73,12 @@ VisitArrowCast(const arrow::Array& array) {
 
 inline arrow::Type::type
 GetArrowTypeID(const arrow::ArrayBuilder* builder) {
-  return builder->type()->id();
+  arrow::Type::type id = builder->type()->id();
+  if (id != arrow::Type::EXTENSION) {
+    return id;
+  }
+  const auto& ext = static_cast<const arrow::ExtensionType&>(*builder->type());
+  return ext.storage_id();
 }
 
 template <typename T>

--- a/libsupport/include/katana/ArrowVisitor.h
+++ b/libsupport/include/katana/ArrowVisitor.h
@@ -78,7 +78,7 @@ GetArrowTypeID(const arrow::ArrayBuilder* builder) {
     return id;
   }
   const auto& ext = static_cast<const arrow::ExtensionType&>(*builder->type());
-  return ext.storage_id();
+  return ext.storage_type()->id();
 }
 
 template <typename T>


### PR DESCRIPTION
Arrow has ExtensionType, ExtensionArray, and ExtensionScalar, but no such luck for ExtensionBuilder.

Propose an invariant:
Any Builder for an ExtensionType is a subclass of the Builder for its StorageType.
```c++
arrow::ArrayBuilder* builder = ...;
if (builder->type()->id() == arrow::Type::EXTENSION) {
  auto ext_type = std::static_pointer_cast<arrow::ExtensionType>(builder->type());
  arrow::Type::type storage_id = ext_type.storage_type()->id();
  assert(storage_id != arrow::Type::EXTENSION);
  
  // assuming this is valid c++ (I wish)
  using StorageBuilder = typename arrow::TypeIdTraits<storage_id>::BuilderType;
  auto* typed_builder = dynamic_cast<StorageBuilder*>(builder);
  assert(typed_builder != nullptr);
}
```


In support of KAT-2876