### PR TITLE
GetArrowTypeID returns physical type ID for ExtensionType Builders

### DIFF
--- a/libsupport/include/katana/ArrowVisitor.h
+++ b/libsupport/include/katana/ArrowVisitor.h
@@ -73,6 +73,12 @@ VisitArrowCast(const arrow::Array& array) {
 
 inline arrow::Type::type
 GetArrowTypeID(const arrow::ArrayBuilder* builder) {
+  if (builder->type()->id() == arrow::Type::EXTENSION) {
+    auto et = std::dynamic_pointer_cast<arrow::ExtensionType>(builder->type());
+    if (et) {
+      return et->storage_type()->id();
+    }
+  }
   return builder->type()->id();
 }
 


### PR DESCRIPTION
In order to make AppendToBuilder work with extension type builders and scalars,
ID of the physical type of the extension builder is used. This ensures that the visitor calls
the correct Call function 