### PR TITLE
Fix bugs affecting projection topologies

### DIFF
--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -270,23 +270,16 @@ katana::PropertyGraph::Make(
 std::unique_ptr<katana::PropertyGraph>
 katana::PropertyGraph::MakeEmptyEdgeProjectedGraph(
     const PropertyGraph& pg, uint32_t num_new_nodes,
-    const DynamicBitset& bitset) {
+    const DynamicBitset& nodes_bitset,
+    NUMAArray<Node>&& original_to_projected_nodes_mapping,
+    NUMAArray<GraphTopology::PropertyIndex>&&
+        projected_to_original_nodes_mapping) {
   const auto& topology = pg.topology();
 
   NUMAArray<Edge> out_indices;
   out_indices.allocateInterleaved(num_new_nodes);
 
   NUMAArray<Node> out_dests;
-  NUMAArray<Node> original_to_projected_nodes_mapping;
-  original_to_projected_nodes_mapping.allocateInterleaved(topology.NumNodes());
-  katana::ParallelSTL::fill(
-      original_to_projected_nodes_mapping.begin(),
-      original_to_projected_nodes_mapping.end(),
-      static_cast<Node>(topology.NumNodes()));
-
-  NUMAArray<GraphTopology::PropertyIndex> projected_to_original_nodes_mapping;
-  projected_to_original_nodes_mapping.allocateInterleaved(num_new_nodes);
-
   NUMAArray<Edge> original_to_projected_edges_mapping;
   NUMAArray<GraphTopology::PropertyIndex> projected_to_original_edges_mapping;
 
@@ -298,7 +291,7 @@ katana::PropertyGraph::MakeEmptyEdgeProjectedGraph(
   NUMAArray<uint8_t> node_bitmask;
   node_bitmask.allocateInterleaved((topology.NumNodes() + 7) / 8);
 
-  FillBitMask(topology.NumNodes(), bitset, &node_bitmask);
+  FillBitMask(topology.NumNodes(), nodes_bitset, &node_bitmask);
 
   NUMAArray<uint8_t> edge_bitmask;
   edge_bitmask.allocateInterleaved((topology.NumEdges() + 7) / 8);
@@ -317,8 +310,18 @@ katana::PropertyGraph::MakeEmptyEdgeProjectedGraph(
 
 std::unique_ptr<katana::PropertyGraph>
 katana::PropertyGraph::MakeEmptyProjectedGraph(
-    const katana::PropertyGraph& pg, const katana::DynamicBitset& bitset) {
-  return MakeEmptyEdgeProjectedGraph(pg, 0, bitset);
+    const katana::PropertyGraph& pg,
+    const katana::DynamicBitset& nodes_bitset) {
+  const auto& topology = pg.topology();
+  NUMAArray<Node> original_to_projected_nodes_mapping;
+  original_to_projected_nodes_mapping.allocateInterleaved(topology.NumNodes());
+  katana::ParallelSTL::fill(
+      original_to_projected_nodes_mapping.begin(),
+      original_to_projected_nodes_mapping.end(),
+      static_cast<Node>(topology.NumNodes()));
+
+  return MakeEmptyEdgeProjectedGraph(
+      pg, 0, nodes_bitset, std::move(original_to_projected_nodes_mapping), {});
 }
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
@@ -499,7 +502,10 @@ katana::PropertyGraph::MakeProjectedGraph(
     if (num_new_edges == 0) {
       // no edge selected
       // return empty graph with only selected nodes
-      return MakeEmptyEdgeProjectedGraph(pg, num_new_nodes, bitset_nodes);
+      return MakeEmptyEdgeProjectedGraph(
+          pg, num_new_nodes, bitset_nodes,
+          std::move(original_to_projected_nodes_mapping),
+          std::move(projected_to_original_nodes_mapping));
     }
   }
 

--- a/libsupport/include/katana/Iterators.h
+++ b/libsupport/include/katana/Iterators.h
@@ -323,6 +323,36 @@ MakeDisjointRangesEnd(
       DisjointRangesIterator<I>::RangeKind::kSecond);
 }
 
+template <typename T>
+constexpr auto
+Enumerate(T&& iterable) {
+  static_assert(
+      std::is_same_v<
+          decltype(std::begin(std::declval<T>())),
+          decltype(std::end(std::declval<T>()))>,
+      "Enumerate can only accept an iterable.");
+
+  struct iterator {
+    size_t i;
+    using TIter = decltype(::std::begin(::std::declval<T>()));
+    TIter iter;
+    bool operator!=(const iterator& other) const { return iter != other.iter; }
+    void operator++() {
+      ++i;
+      ++iter;
+    }
+    auto operator*() const { return std::tie(i, *iter); }
+  };
+
+  struct iterable_wrapper {
+    T iterable;
+    auto begin() { return iterator{0, std::begin(iterable)}; }
+    auto end() { return iterator{0, std::end(iterable)}; }
+  };
+
+  return iterable_wrapper{std::forward<T>(iterable)};
+}
+
 }  // end namespace katana
 
 #endif


### PR DESCRIPTION
Fix how projections with no resulting edges are constructed. Earlier implementation did not map to the correct original node ID in case projections resulted in 0 edges.

Additionally, this PR adds the `Enumerate` iterator wrapper, which enables Python-style iteration: `for [i, value] : collection`.