### PR TITLE
Ignore distutils packages, as PyYAML is needed for the tool itself

### DIFF
--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -117,7 +117,7 @@ fi
 # Use the requirements tool to install apt packages with: apt-get satisfy --allow-downgrades --yes --quiet
 "$REPO_ROOT"/scripts/requirements install --arg=--allow-downgrades --arg=--yes --arg=--quiet --label apt --label apt/dev --packaging-system "apt$PKG_SYS_SUFFIX"
 # Use the requirements tool to install pip packages with: python3 -m pip --upgrade
-run_as_original_user "$REPO_ROOT"/scripts/requirements install --label pip --label pip/dev --packaging-system "pip$PKG_SYS_SUFFIX"
+run_as_original_user "$REPO_ROOT"/scripts/requirements install --label pip --label pip/dev --arg=--ignore-installed --packaging-system "pip$PKG_SYS_SUFFIX"
 
 # Toolchain variants
 if [[ -n "${SETUP_TOOLCHAIN_VARIANTS}" ]]; then


### PR DESCRIPTION
Previously, `setup_ubuntu.sh` script failed if it wants to install in `pip` a package that is already installed in the system (distutils). This could be worked around for some packages by uninstalling them from the system. However, `PyYAML` is required for running the Katana install tool itself, as well as many Ubuntu system packages depend on `python3-yaml`. So uninstalling it in distutils is not an option, and the only option I see is in passing `--ignore-installed` to `pip`.