### PR TITLE
tracer: add offset time from when a span starts to logs

### DIFF
--- a/libsupport/include/katana/JSONTracer.h
+++ b/libsupport/include/katana/JSONTracer.h
@@ -1,6 +1,7 @@
 #ifndef KATANA_LIBSUPPORT_KATANA_JSONTRACER_H_
 #define KATANA_LIBSUPPORT_KATANA_JSONTRACER_H_
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -11,6 +12,8 @@
 
 namespace katana {
 
+using Clock = std::chrono::high_resolution_clock;
+using TimePoint = std::chrono::time_point<Clock>;
 using OutputCB = std::function<void(const std::string&)>;
 
 class KATANA_EXPORT JSONTracer : public ProgressTracer {
@@ -88,6 +91,8 @@ private:
 
   JSONContext context_;
   OutputCB out_callback_;
+  std::string span_name_;
+  TimePoint start_time_;
 };
 
 }  // namespace katana

--- a/libsupport/include/katana/TextTracer.h
+++ b/libsupport/include/katana/TextTracer.h
@@ -1,6 +1,7 @@
 #ifndef KATANA_LIBSUPPORT_KATANA_TEXTTRACER_H_
 #define KATANA_LIBSUPPORT_KATANA_TEXTTRACER_H_
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -9,6 +10,9 @@
 #include "katana/config.h"
 
 namespace katana {
+
+using Clock = std::chrono::high_resolution_clock;
+using TimePoint = std::chrono::time_point<Clock>;
 
 class KATANA_EXPORT TextTracer : public ProgressTracer {
 public:
@@ -75,6 +79,7 @@ private:
 
   TextContext context_;
   std::string span_name_;
+  TimePoint start_time_;
 };
 
 }  // namespace katana


### PR DESCRIPTION
Adds more metadata to logs so devs can quickly see how long a span took