### PR TITLE
Better memory management policies

### DIFF
--- a/libgalois/include/katana/MemoryPolicy.h
+++ b/libgalois/include/katana/MemoryPolicy.h
@@ -17,34 +17,34 @@ public:
 
   /// Given the current memory counts and whatever OS sources the policy consults,
   /// how much standby memory should we reclaim right now?
-  virtual count_t ReclaimForMemoryPressure(
-      [[maybe_unused]] count_t active,
-      [[maybe_unused]] count_t standby) const = 0;
+  virtual count_t ReclaimForMemoryPressure(count_t standby) const = 0;
 
   /// Given the current memory counts and whatever OS sources the policy consults,
   /// should we refuse discretionary allocations?
-  virtual bool MemoryPressureHigh(
-      [[maybe_unused]] count_t active,
-      [[maybe_unused]] count_t standby) const = 0;
+  virtual bool IsMemoryPressureHigh(count_t standby) const = 0;
 
   /// Given the current memory counts and whatever OS sources the policy consults,
   /// should we clean up and exit?
-  virtual bool KillSelfForLackOfMemory(
-      [[maybe_unused]] count_t active,
-      [[maybe_unused]] count_t standby) const = 0;
+  virtual bool KillSelfForLackOfMemory(count_t standby) const = 0;
+
+  void LogMemoryStats(const std::string& message, count_t standby);
 
   /// Utility function to find out our OOM score from Linux
   static uint64_t OOMScore();
+  /// Utility function to find out available memory in the machine
+  static uint64_t AvailableMemoryBytes();
 
   struct MemInfo;
   struct Thresholds {
     double high_used_ratio_threshold;
     double kill_used_ratio_threshold;
+    count_t kill_self_oom_threshold;
+    count_t high_pressure_oom_threshold;
   };
 
 protected:
   MemoryPolicy(Thresholds thresholds);
-  void UpdateMemInfo(MemInfo* mem_info, count_t active, count_t standby) const;
+  void UpdateMemInfo(MemInfo* mem_info, count_t standby) const;
 
   count_t physical() const { return physical_; }
   double high_used_ratio_threshold() const {
@@ -53,31 +53,53 @@ protected:
   double kill_used_ratio_threshold() const {
     return thresholds_.kill_used_ratio_threshold;
   }
+  count_t kill_self_oom_threshold() const {
+    return thresholds_.kill_self_oom_threshold;
+  }
+  count_t high_pressure_oom_threshold() const {
+    return thresholds_.high_pressure_oom_threshold;
+  }
 
 private:
   count_t physical_;
   Thresholds thresholds_;
 };
 
-/// Memory policy that just tries to avoid the OOM killer and does little to evict
-/// unused data from memory
+/// Memory policy that just tries to avoid the OOM killer.  Unfortunately, it is aggressive about
+/// dumping memory when the OOM score is high, which can be an over reaction.
 class KATANA_EXPORT MemoryPolicyMinimal : public MemoryPolicy {
 public:
   MemoryPolicyMinimal();
-  count_t ReclaimForMemoryPressure(
-      count_t active, count_t standby) const override;
-  bool MemoryPressureHigh(count_t active, count_t standby) const override;
-  bool KillSelfForLackOfMemory(count_t active, count_t standby) const override;
+  count_t ReclaimForMemoryPressure(count_t standby) const override;
+  bool IsMemoryPressureHigh(count_t standby) const override;
+  bool KillSelfForLackOfMemory(count_t standby) const override;
 };
 
 /// Memory policy that prioritizes performance, i.e., it uses memory aggressively
 class KATANA_EXPORT MemoryPolicyPerformance : public MemoryPolicy {
 public:
   MemoryPolicyPerformance();
-  count_t ReclaimForMemoryPressure(
-      count_t active, count_t standby) const override;
-  bool MemoryPressureHigh(count_t active, count_t standby) const override;
-  bool KillSelfForLackOfMemory(count_t active, count_t standby) const override;
+  count_t ReclaimForMemoryPressure(count_t standby) const override;
+  bool IsMemoryPressureHigh(count_t standby) const override;
+  bool KillSelfForLackOfMemory(count_t standby) const override;
+};
+
+/// Minimize use of memory, but take free memory when it is available.
+class KATANA_EXPORT MemoryPolicyMeek : public MemoryPolicy {
+public:
+  MemoryPolicyMeek();
+  count_t ReclaimForMemoryPressure(count_t standby) const override;
+  bool IsMemoryPressureHigh(count_t standby) const override;
+  bool KillSelfForLackOfMemory(count_t standby) const override;
+};
+
+/// Do nothing to ever shed memory.  This will OOM if we occupy too much memory.
+class KATANA_EXPORT MemoryPolicyNull : public MemoryPolicy {
+public:
+  MemoryPolicyNull();
+  count_t ReclaimForMemoryPressure(count_t standby) const override;
+  bool IsMemoryPressureHigh(count_t standby) const override;
+  bool KillSelfForLackOfMemory(count_t standby) const override;
 };
 
 }  // namespace katana

--- a/libgalois/include/katana/MemorySupervisor.h
+++ b/libgalois/include/katana/MemorySupervisor.h
@@ -6,6 +6,7 @@
 #include "katana/Cache.h"
 #include "katana/Manager.h"
 #include "katana/MemoryPolicy.h"
+#include "katana/ProgressTracer.h"
 #include "katana/Result.h"
 #include "katana/config.h"
 
@@ -22,6 +23,12 @@ namespace katana {
 /// The MS does not manage per-allocation tokens, it only manages sizes
 /// Clients are trusted to call the proper functions or the MS will make
 /// bad decisions.
+///
+/// The MS does not track active memory.  The problem is that data structures (e.g.,
+/// properties) change in size while they are active.  If client code loads a 100 byte
+/// property and adds a value, it can store back a 102 byte property.  The MS sees 100
+/// bytes made active and 102 bytes made inactive, which makes the count of active
+/// bytes negative.
 
 class PropertyManager;
 
@@ -38,24 +45,23 @@ public:
     return mm_;
   }
 
-  /// Inform MS of allocation of \p bytes for active memory
-  /// Application cannot continue if it does not get memory
-  void BorrowActive(const std::string& name, count_t bytes);
   /// Request permission to allocate \p bytes for standby memory
   /// Returns the number of bytes granted, possibly 0
-  count_t BorrowStandby(const std::string& name, count_t goal);
+  count_t GetStandby(const std::string& name, count_t goal);
 
-  /// Notify MS that manager freed \p bytes of active memory.
-  void ReturnActive(const std::string& name, count_t bytes);
   /// Notify MS that manager freed \p bytes of standby memory.
-  void ReturnStandby(const std::string& name, count_t bytes);
+  void PutStandby(const std::string& name, count_t bytes);
 
   /// Manager \p name wants to transition \p bytes from active to standby
-  /// Returns the number of standby bytes allowed by MS, possibly 0.
-  count_t ActiveToStandby(const std::string& name, count_t bytes);
+  void ActiveToStandby(const std::string& name, count_t bytes);
   /// Manager \p name transitions \p bytes from standby to active.
   /// Managers are always allowed to transition from standby to active
   void StandbyToActive(const std::string& name, count_t bytes);
+
+  /// Give the memory supervisor a chance to release memory.  This is useful to call
+  /// If you will be calling a series of allocations for active memory, you can use
+  /// this to make sure we aren't holding on to too much standby memory.
+  void CheckPressure();
 
   /// The MemoryPolicy controls decisions about memory allocation, like how
   /// aggressively to deallocate.
@@ -64,6 +70,7 @@ public:
   /// Provide access to a property manager, which manages the property cache
   PropertyManager* GetPropertyManager();
   CacheStats GetPropertyCacheStats() const;
+  void LogMemoryStats(const std::string& message);
 
   /// Calls sysconf
   static uint64_t GetTotalSystemMemory();
@@ -78,19 +85,20 @@ private:
 
   struct ManagerInfo {
     std::unique_ptr<Manager> manager_;
-    count_t active{};
     count_t standby{};
   };
   std::unordered_map<std::string, ManagerInfo> managers_;
 
-  count_t Used() { return active_ + standby_; }
-  count_t Available() { return physical_ - Used(); }
+  count_t Available() {
+    auto rss = static_cast<katana::count_t>(
+        katana::ProgressTracer::ParseProcSelfRssBytes());
+    if (rss >= physical_) {
+      return 0;
+    }
+    return physical_ - rss;
+  }
 
   std::unique_ptr<MemoryPolicy> policy_;
-  /// Sum of all active memory across all managers
-  count_t active_{};
-  void ActiveMinus(ManagerInfo& info, count_t bytes);
-  void ActivePlus(ManagerInfo& info, count_t bytes);
 
   /// Sum of all standby memory across all managers
   count_t standby_{};
@@ -101,6 +109,9 @@ private:
   /// than or equal to the total physical memory in the machine.  There are users of
   /// memory outside our control, like the operating system.
   count_t physical_{};
+
+  /// Statistics: bytes reclaimed
+  count_t bytes_reclaimed_{};
 };
 
 }  // namespace katana

--- a/libgalois/src/MemoryPolicy.cpp
+++ b/libgalois/src/MemoryPolicy.cpp
@@ -1,6 +1,7 @@
 #include "katana/MemoryPolicy.h"
 
 #include <fstream>
+#include <regex>
 
 #include "katana/MemoryPolicy.h"
 #include "katana/MemorySupervisor.h"
@@ -11,9 +12,9 @@
 katana::MemoryPolicy::~MemoryPolicy() = default;
 
 struct katana::MemoryPolicy::MemInfo {
-  count_t active;
   count_t standby;
-  uint64_t rss_bytes;
+  count_t rss_bytes;
+  count_t available_bytes;
   double used_ratio;
   int64_t oom_score;
 };
@@ -24,25 +25,31 @@ namespace {
 
 void
 LogIt(const std::string& str, katana::MemoryPolicy::MemInfo* mem_info) {
-  auto scope = katana::GetTracer().StartActiveSpan(str);
-  scope.span().Log(
-      "mem_stats", {
-                       {"rss_gb", katana::ToGB(mem_info->rss_bytes)},
-                       {"oom_score", mem_info->oom_score},
-                       {"used_ratio", mem_info->used_ratio},
-                       {"active_gb", katana::ToGB(mem_info->active)},
-                       {"standby_gb", katana::ToGB(mem_info->standby)},
-                   });
+  katana::GetTracer().GetActiveSpan().Log(
+      str, {
+               {"rss_gb", katana::ToGB(mem_info->rss_bytes)},
+               {"available_gb", katana::ToGB(mem_info->available_bytes)},
+               {"oom_score", mem_info->oom_score},
+               {"used_ratio", mem_info->used_ratio},
+               {"standby_gb", katana::ToGB(mem_info->standby)},
+           });
 }
 
 }  // namespace
 
 void
-katana::MemoryPolicy::UpdateMemInfo(
-    MemInfo* mem_info, count_t active, count_t standby) const {
-  mem_info->active = active;
+katana::MemoryPolicy::LogMemoryStats(
+    const std::string& message, count_t standby) {
+  MemInfo mem_info;
+  UpdateMemInfo(&mem_info, standby);
+  LogIt(message, &mem_info);
+}
+
+void
+katana::MemoryPolicy::UpdateMemInfo(MemInfo* mem_info, count_t standby) const {
   mem_info->standby = standby;
   mem_info->rss_bytes = katana::ProgressTracer::ParseProcSelfRssBytes();
+  mem_info->available_bytes = AvailableMemoryBytes();
   mem_info->used_ratio = (double)mem_info->rss_bytes / physical();
   mem_info->oom_score = OOMScore();
 }
@@ -51,13 +58,13 @@ katana::MemoryPolicy::UpdateMemInfo(
 // MemoryPolicyPerformance
 
 bool
-katana::MemoryPolicyPerformance::MemoryPressureHigh(
-    count_t active, count_t standby) const {
+katana::MemoryPolicyPerformance::IsMemoryPressureHigh(count_t standby) const {
   MemInfo mem_info;
-  UpdateMemInfo(&mem_info, active, standby);
+  UpdateMemInfo(&mem_info, standby);
 
-  if (mem_info.oom_score > 1100 ||
-      mem_info.used_ratio > high_used_ratio_threshold()) {
+  if ((mem_info.oom_score > high_pressure_oom_threshold() ||
+       mem_info.used_ratio > high_used_ratio_threshold()) &&
+      mem_info.available_bytes < 0.1 * physical()) {
     LogIt("memory pressure high", &mem_info);
     return true;
   }
@@ -67,42 +74,37 @@ katana::MemoryPolicyPerformance::MemoryPressureHigh(
 
 count_t
 katana::MemoryPolicyPerformance::ReclaimForMemoryPressure(
-    count_t active, count_t standby) const {
+    count_t standby) const {
   MemInfo mem_info;
-  UpdateMemInfo(&mem_info, active, standby);
+  UpdateMemInfo(&mem_info, standby);
+  count_t reclaim = standby;
 
-  if (mem_info.oom_score < 700 ||
-      mem_info.used_ratio < high_used_ratio_threshold()) {
+  if (mem_info.oom_score < 1000 ||
+      mem_info.used_ratio < high_used_ratio_threshold() ||
+      mem_info.available_bytes > 0.1 * physical()) {
     return 0;
   }
-  if (mem_info.oom_score < 850) {
-    LogIt(
-        fmt::format(
-            "reclaim for memory pressure {} GB", katana::ToGB(standby / 4)),
-        &mem_info);
-    return standby / 4;
-  }
+  // TODO (witchel) this might give back memory too quickly
   if (mem_info.oom_score < 1000) {
-    LogIt(
-        fmt::format(
-            "reclaim for memory pressure {} GB", katana::ToGB(standby / 2)),
-        &mem_info);
-    return standby / 2;
+    reclaim = standby / 4;
+  } else if (mem_info.oom_score < 1200) {
+    reclaim = standby / 2;
   }
   LogIt(
-      fmt::format("reclaim for memory pressure {} GB", katana::ToGB(standby)),
+      fmt::format("reclaim for memory pressure {} GB", katana::ToGB(reclaim)),
       &mem_info);
-  return standby;
+  return reclaim;
 }
 
 bool
 katana::MemoryPolicyPerformance::KillSelfForLackOfMemory(
-    count_t active, count_t standby) const {
+    count_t standby) const {
   MemInfo mem_info;
-  UpdateMemInfo(&mem_info, active, standby);
+  UpdateMemInfo(&mem_info, standby);
 
-  if (mem_info.oom_score > 1200 ||
-      mem_info.used_ratio > kill_used_ratio_threshold()) {
+  if ((mem_info.oom_score > kill_self_oom_threshold() ||
+       mem_info.used_ratio > kill_used_ratio_threshold()) &&
+      mem_info.available_bytes < 0.1 * physical()) {
     LogIt("KILL SELF", &mem_info);
     return true;
   }
@@ -110,18 +112,20 @@ katana::MemoryPolicyPerformance::KillSelfForLackOfMemory(
 }
 
 katana::MemoryPolicyPerformance::MemoryPolicyPerformance()
-    : MemoryPolicy(
-          {.high_used_ratio_threshold = 0.85,
-           .kill_used_ratio_threshold = 0.93}) {}
+    : MemoryPolicy({
+          .high_used_ratio_threshold = 0.85,
+          .kill_used_ratio_threshold = 0.95,
+          .kill_self_oom_threshold = 1280,
+          .high_pressure_oom_threshold = 1100,
+      }) {}
 
 //////////////////////////////////////////////////////////////////////
 // MemoryPolicyMinimal
 bool
-katana::MemoryPolicyMinimal::MemoryPressureHigh(
-    count_t active, count_t standby) const {
+katana::MemoryPolicyMinimal::IsMemoryPressureHigh(count_t standby) const {
   MemInfo mem_info;
-  UpdateMemInfo(&mem_info, active, standby);
-  if (mem_info.oom_score > 1100 ||
+  UpdateMemInfo(&mem_info, standby);
+  if (mem_info.oom_score > high_pressure_oom_threshold() ||
       mem_info.used_ratio > high_used_ratio_threshold()) {
     LogIt("memory pressure high", &mem_info);
     return true;
@@ -131,24 +135,22 @@ katana::MemoryPolicyMinimal::MemoryPressureHigh(
 }
 
 count_t
-katana::MemoryPolicyMinimal::ReclaimForMemoryPressure(
-    count_t active, count_t standby) const {
+katana::MemoryPolicyMinimal::ReclaimForMemoryPressure(count_t standby) const {
   MemInfo mem_info;
-  UpdateMemInfo(&mem_info, active, standby);
+  UpdateMemInfo(&mem_info, standby);
 
-  if (MemoryPressureHigh(active, standby)) {
+  if (IsMemoryPressureHigh(standby)) {
     return standby;
   }
   return 0;
 }
 
 bool
-katana::MemoryPolicyMinimal::KillSelfForLackOfMemory(
-    count_t active, count_t standby) const {
+katana::MemoryPolicyMinimal::KillSelfForLackOfMemory(count_t standby) const {
   MemInfo mem_info;
-  UpdateMemInfo(&mem_info, active, standby);
+  UpdateMemInfo(&mem_info, standby);
 
-  if (mem_info.oom_score > 1200 ||
+  if (mem_info.oom_score > kill_self_oom_threshold() ||
       mem_info.used_ratio > kill_used_ratio_threshold()) {
     LogIt("KILL SELF", &mem_info);
     return true;
@@ -157,9 +159,89 @@ katana::MemoryPolicyMinimal::KillSelfForLackOfMemory(
 }
 
 katana::MemoryPolicyMinimal::MemoryPolicyMinimal()
-    : MemoryPolicy(
-          {.high_used_ratio_threshold = 0.95,
-           .kill_used_ratio_threshold = 0.95}) {}
+    : MemoryPolicy({
+          .high_used_ratio_threshold = 0.95,
+          .kill_used_ratio_threshold = 0.95,
+          .kill_self_oom_threshold = 1280,
+          .high_pressure_oom_threshold = 1100,
+      }) {}
+
+//////////////////////////////////////////////////////////////////////
+// MemoryPolicyMeek
+bool
+katana::MemoryPolicyMeek::IsMemoryPressureHigh(count_t standby) const {
+  MemInfo mem_info;
+  UpdateMemInfo(&mem_info, standby);
+  if ((mem_info.oom_score > high_pressure_oom_threshold() ||
+       mem_info.used_ratio > high_used_ratio_threshold()) &&
+      mem_info.available_bytes < 0.1 * physical()) {
+    LogIt("memory pressure high", &mem_info);
+    return true;
+  }
+
+  return false;
+}
+
+count_t
+katana::MemoryPolicyMeek::ReclaimForMemoryPressure(count_t standby) const {
+  MemInfo mem_info;
+  UpdateMemInfo(&mem_info, standby);
+
+  if (mem_info.available_bytes < 0.1 * physical()) {
+    return standby;
+  }
+  return 0;
+}
+
+bool
+katana::MemoryPolicyMeek::KillSelfForLackOfMemory(count_t standby) const {
+  MemInfo mem_info;
+  UpdateMemInfo(&mem_info, standby);
+
+  if ((mem_info.oom_score > kill_self_oom_threshold() ||
+       mem_info.used_ratio > kill_used_ratio_threshold()) &&
+      mem_info.available_bytes < 0.1 * physical()) {
+    LogIt("KILL SELF", &mem_info);
+    return true;
+  }
+  return false;
+}
+
+katana::MemoryPolicyMeek::MemoryPolicyMeek()
+    : MemoryPolicy({
+          .high_used_ratio_threshold = 0.85,
+          .kill_used_ratio_threshold = 0.95,
+          .kill_self_oom_threshold = 1280,
+          .high_pressure_oom_threshold = 1100,
+      }) {}
+
+//////////////////////////////////////////////////////////////////////
+// MemoryPolicyNull
+bool
+katana::MemoryPolicyNull::IsMemoryPressureHigh(
+    [[maybe_unused]] count_t standby) const {
+  return false;
+}
+
+count_t
+katana::MemoryPolicyNull::ReclaimForMemoryPressure(
+    [[maybe_unused]] count_t standby) const {
+  return 0;
+}
+
+bool
+katana::MemoryPolicyNull::KillSelfForLackOfMemory(
+    [[maybe_unused]] count_t standby) const {
+  return false;
+}
+
+katana::MemoryPolicyNull::MemoryPolicyNull()
+    : MemoryPolicy({
+          .high_used_ratio_threshold = 0.85,
+          .kill_used_ratio_threshold = 0.95,
+          .kill_self_oom_threshold = 1280,
+          .high_pressure_oom_threshold = 1100,
+      }) {}
 
 //////////////////////////////////////////////////////////////////////
 // MemoryPolicy
@@ -196,6 +278,29 @@ katana::MemoryPolicy::OOMScore() {
         "problem parsing output of /proc/self/oom_score: {}", e.what());
   }
   return value;
+}
+
+uint64_t
+katana::MemoryPolicy::AvailableMemoryBytes() {
+  static std::regex kFreeRegex("^MemAvailable:\\s*([0-9]+) kB");
+  std::ifstream proc_self("/proc/meminfo");
+
+  if (!proc_self) {
+    KATANA_LOG_WARN("cannot open /proc/meminfo: {}", std::strerror(errno));
+    return 0;
+  }
+  uint64_t value{};
+  std::string line;
+  while (std::getline(proc_self, line)) {
+    std::smatch sub_match;
+    if (!std::regex_match(line, sub_match, kFreeRegex)) {
+      continue;
+    }
+    std::string val = sub_match[1];
+    value = static_cast<uint64_t>(std::atoll(val.c_str()));
+  }
+
+  return value * 1024;
 }
 
 #else

--- a/libgalois/src/PropertyManager.cpp
+++ b/libgalois/src/PropertyManager.cpp
@@ -4,7 +4,6 @@
 #include "katana/Logging.h"
 #include "katana/MemorySupervisor.h"
 #include "katana/ProgressTracer.h"
-#include "katana/Time.h"
 
 const std::string katana::PropertyManager::name_ = "property";
 
@@ -33,7 +32,7 @@ katana::PropertyManager::GetProperty(const katana::Uri& property_path) {
         static_cast<count_t>(katana::ApproxTableMemUse(property.value()));
     MemorySupervisor::Get().StandbyToActive(Name(), bytes);
     katana::GetTracer().GetActiveSpan().Log(
-        "property cache get evict",
+        "property cache get",
         {
             {"storage_name", property_path.BaseName()},
             {"approx_size_gb",
@@ -41,8 +40,9 @@ katana::PropertyManager::GetProperty(const katana::Uri& property_path) {
         });
     return property.value();
   }
+  MemorySupervisor::Get().CheckPressure();
   katana::GetTracer().GetActiveSpan().Log(
-      "property cache get evict not found",
+      "property cache get not found",
       {
           {"storage_name", property_path.BaseName()},
       });
@@ -52,10 +52,15 @@ katana::PropertyManager::GetProperty(const katana::Uri& property_path) {
 
 void
 katana::PropertyManager::PropertyLoadedActive(
-    const std::shared_ptr<arrow::Table>& property) const {
+    const std::shared_ptr<arrow::Table>& property) {
   KATANA_LOG_DEBUG_ASSERT(property);
-  auto bytes = static_cast<count_t>(katana::ApproxTableMemUse(property));
-  MemorySupervisor::Get().BorrowActive(Name(), bytes);
+  auto sz = katana::ApproxTableMemUse(property);
+  stats.bytes_loaded += sz;
+  katana::GetTracer().GetActiveSpan().Log(
+      "property cache loaded active", {
+                                          {"name", property->field(0)->name()},
+                                          {"approx_size_gb", ToGB(sz)},
+                                      });
 }
 
 void
@@ -63,23 +68,18 @@ katana::PropertyManager::PutProperty(
     const katana::Uri& property_path,
     const std::shared_ptr<arrow::Table>& property) {
   auto bytes = static_cast<count_t>(katana::ApproxTableMemUse(property));
-  auto granted = MemorySupervisor::Get().ActiveToStandby(Name(), bytes);
-  if (granted >= static_cast<count_t>(bytes)) {
-    cache_->Insert(property_path, property);
-    katana::GetTracer().GetActiveSpan().Log(
-        "property cache insert",
-        {
-            {"storage_name", property_path.BaseName()},
-            {"approx_size_gb", ToGB(katana::ApproxTableMemUse(property))},
-        });
-  } else {
-    MemorySupervisor::Get().ReturnActive(Name(), bytes);
-  }
+  cache_->Insert(property_path, property);
+  katana::GetTracer().GetActiveSpan().Log(
+      "property cache insert",
+      {
+          {"storage_name", property_path.BaseName()},
+          {"approx_size_gb", ToGB(katana::ApproxTableMemUse(property))},
+      });
+  MemorySupervisor::Get().ActiveToStandby(Name(), bytes);
 }
 
 katana::count_t
 katana::PropertyManager::FreeStandbyMemory(count_t goal) {
-  count_t total = 0;
   auto scope = katana::GetTracer().StartActiveSpan("free standby memory");
   scope.span().Log(
       "before", {
@@ -87,18 +87,13 @@ katana::PropertyManager::FreeStandbyMemory(count_t goal) {
                     {"cache_gb", ToGB(cache_->size())},
                 });
 
-  if (goal >= static_cast<count_t>(cache_->size())) {
-    total = static_cast<count_t>(cache_->size());
-    MemorySupervisor::Get().ReturnStandby(Name(), std::min(goal, total));
-    cache_->clear();
-  } else {
-    total = static_cast<count_t>(cache_->Reclaim(goal));
-    MemorySupervisor::Get().ReturnStandby(Name(), std::min(goal, total));
-  }
+  auto reclaim = static_cast<count_t>(cache_->Reclaim(goal));
+  MemorySupervisor::Get().PutStandby(Name(), reclaim);
+
   scope.span().Log(
       "after", {
-                   {"reclaimed_gb", ToGB(total)},
+                   {"reclaimed_gb", ToGB(reclaim)},
                    {"cache_gb", ToGB(cache_->size())},
                });
-  return total;
+  return reclaim;
 }

--- a/libsupport/include/katana/Cache.h
+++ b/libsupport/include/katana/Cache.h
@@ -29,7 +29,7 @@ namespace katana {
 
 struct CacheStats {
   float get_hit_percentage() const {
-    if (get_count == 0ULL) {
+    if (get_count == 0LL) {
       return 0.0;
     }
     return 100.0 * static_cast<float>(get_hit_count) / get_count;
@@ -63,10 +63,10 @@ struct CacheStats {
         });
   }
 
-  uint64_t get_count{0ULL};
-  uint64_t get_hit_count{0ULL};
-  uint64_t insert_count{0ULL};
-  uint64_t insert_hit_count{0ULL};
+  int64_t get_count{0LL};
+  int64_t get_hit_count{0LL};
+  int64_t insert_count{0LL};
+  int64_t insert_hit_count{0LL};
 };
 
 template <typename Value>
@@ -86,7 +86,7 @@ class KATANA_EXPORT Cache {
 
 public:
   /// Construct an LRU cache that has a fixed number of entries.
-  Cache(size_t capacity)  // number of entries
+  Cache(int64_t capacity)  // number of entries
       : policy_(ReplacementPolicy::kLRUSize),
         capacity_(capacity),
         value_to_bytes_(nullptr) {
@@ -94,8 +94,8 @@ public:
   }
   /// Construct an LRU cache that holds fixed number of bytes.
   Cache(
-      size_t capacity,  // bytes of entries
-      std::function<size_t(const Value& value)> value_to_bytes)
+      int64_t capacity,  // bytes of entries
+      std::function<int64_t(const Value& value)> value_to_bytes)
       : policy_(ReplacementPolicy::kLRUBytes),
         capacity_(capacity),
         value_to_bytes_(std::move(value_to_bytes)) {
@@ -106,9 +106,11 @@ public:
   }
   /// Construct an LRU cache that holds whatever we put in it and only evicts when we
   /// explicitly tell it to do so.
-  Cache(std::function<size_t(const Value& value)> value_to_bytes)
+  /// NB: The way we use this, the insert hit rate is always 0 because we GetAndEvict and
+  /// then possibly insert back.
+  Cache(std::function<int64_t(const Value& value)> value_to_bytes)
       : policy_(ReplacementPolicy::kLRUExplicit),
-        capacity_(std::numeric_limits<size_t>::max()),
+        capacity_(std::numeric_limits<int64_t>::max()),
         value_to_bytes_(std::move(value_to_bytes)) {
     KATANA_LOG_VASSERT(
         value_to_bytes_ != nullptr,
@@ -117,7 +119,7 @@ public:
 
   /// Returns the size of the cache (in number of elements or size of elements,
   /// depending on the replacement policy).
-  size_t size() const {
+  int64_t size() const {
     if (policy_ == ReplacementPolicy::kLRUSize) {
       return key_to_value_.size();
     }
@@ -126,9 +128,9 @@ public:
 
   /// Returns the capacity (in number of elements or size of elements, depending on
   /// the replacement policy).
-  size_t capacity() const {
+  int64_t capacity() const {
     if (policy_ == ReplacementPolicy::kLRUExplicit) {
-      return std::numeric_limits<size_t>::max();
+      return std::numeric_limits<int64_t>::max();
     }
     return capacity_;
   }
@@ -145,8 +147,8 @@ public:
 
   /// Try to reclaim \p goal bytes (#entries), evicting least recently used entries to
   /// do it.  Returns the number of bytes actually evicted.
-  size_t Reclaim(size_t goal) {
-    size_t reclaimed{};
+  int64_t Reclaim(int64_t goal) {
+    int64_t reclaimed{};
     while (!empty() && reclaimed < goal) {
       reclaimed += EvictLastOne();
     }
@@ -161,7 +163,7 @@ public:
     cache_stats_.insert_count++;
     auto mapit = key_to_value_.find(key);
     if (mapit == key_to_value_.end()) {
-      size_t approx_bytes{};
+      int64_t approx_bytes{};
       if (value_to_bytes_ != nullptr) {
         approx_bytes = value_to_bytes_(value);
         if (approx_bytes > capacity_) {
@@ -279,12 +281,12 @@ private:
 
   ReplacementPolicy policy_;
   // for kLRUSize number of entries kLRUBytes it is byte total
-  size_t capacity_{0};
-  size_t total_bytes_{0};
+  int64_t capacity_{0};
+  int64_t total_bytes_{0};
   // Hit statistics for gets and inserts
   CacheStats cache_stats_;
 
-  std::function<size_t(const Value& value)> value_to_bytes_;
+  std::function<int64_t(const Value& value)> value_to_bytes_;
 };
 
 // The property cache contains properties NOT in use by the graph and never contains a

--- a/libsupport/test/cache.cpp
+++ b/libsupport/test/cache.cpp
@@ -109,7 +109,7 @@ TestLRUExplicit(const std::vector<katana::Uri>& keys) {
 
   KATANA_LOG_ASSERT(keyit != keys.begin());
   cache.Insert(*keyit--, SizeOneValue());
-  size_t key_count = std::distance(keyit, keys.end()) - 1;
+  int64_t key_count = std::distance(keyit, keys.end()) - 1;
   KATANA_LOG_ASSERT(cache.size() == key_count);
 
   KATANA_LOG_ASSERT(keyit != keys.begin());
@@ -152,8 +152,8 @@ TestLRUExplicit(const std::vector<katana::Uri>& keys) {
 
 void
 TestLRUBytes(const std::vector<katana::Uri>& keys) {
-  size_t byte_size = 4;
-  KATANA_LOG_ASSERT((byte_size + 1) < keys.size());
+  int64_t byte_size = 4;
+  KATANA_LOG_ASSERT((byte_size + 1) < static_cast<int64_t>(keys.size()));
   katana::Cache<CacheValue> cache(
       byte_size, [](const CacheValue& value) { return BytesInValue(value); });
 
@@ -184,7 +184,7 @@ TestLRUBytes(const std::vector<katana::Uri>& keys) {
 }
 
 void
-TestLRUSize(size_t lru_size, const std::vector<katana::Uri>& keys) {
+TestLRUSize(int64_t lru_size, const std::vector<katana::Uri>& keys) {
   katana::Cache<CacheValue> cache(lru_size);
   KATANA_LOG_VASSERT(
       cache.capacity() == lru_size, "capcity {} allocated {}", cache.capacity(),
@@ -200,7 +200,7 @@ TestLRUSize(size_t lru_size, const std::vector<katana::Uri>& keys) {
       cache.size() == lru_size, "size {} allocated {}", cache.size(), lru_size);
 
   // Make sure we have the LRU elements and only them.
-  KATANA_LOG_ASSERT((lru_size + 1) < keys.size());
+  KATANA_LOG_ASSERT((lru_size + 1) < static_cast<int64_t>(keys.size()));
 
   AssertLRUElements(keys.end(), lru_size, cache);
 
@@ -214,7 +214,7 @@ TestLRUSize(size_t lru_size, const std::vector<katana::Uri>& keys) {
 
 int
 main(int argc, char** argv) {
-  constexpr size_t lru_size = 10;
+  constexpr int64_t lru_size = 10;
 
   uint64_t size = 11 * lru_size;
   if (argc > 1) {

--- a/libtsuba/src/AddProperties.cpp
+++ b/libtsuba/src/AddProperties.cpp
@@ -136,6 +136,13 @@ katana::AddProperties(
           katana::MemorySupervisor::Get().GetPropertyManager();
       if (is_property) {
         pm->PropertyLoadedActive(props);
+      } else {
+        katana::GetTracer().GetActiveSpan().Log(
+            "addproperties property cache callback non-property",
+            {
+                {"name", prop->name()},
+                {"file_name", prop->path()},
+            });
       }
       return katana::CopyableResultSuccess();
     };


### PR DESCRIPTION
We provide four memory management policies (null, performance, meek, and
minimal). And a framework for evaluating them while reading a sequence of
"property" files consisting of large arrow tables.

The memory supervisor no longer tracks active memory, we rely on the OS
for that.  The problem with tracking active memory is that a property
might become active, then change size, then get returned to the
supervisor, making bookkeeping difficult.

Use MemoryAvailable from the OS, correct PutProperty, fix louvain_clustering.