### PR TITLE
Fix a UB bug in BuildArray; avoid commiting projected topologies

### DIFF
--- a/libgraph/src/PropertyGraph.cpp
+++ b/libgraph/src/PropertyGraph.cpp
@@ -774,7 +774,9 @@ katana::PropertyGraph::DoWrite(
       rdg_->node_entity_type_id_array_file_storage().Valid(),
       rdg_->edge_entity_type_id_array_file_storage().Valid());
 
-  KATANA_CHECKED(DoWriteTopologies());
+  if (!is_transformed) {
+    KATANA_CHECKED(DoWriteTopologies());
+  }
 
   //TODO(emcginnis): we don't actually have any lifetime tracking for the in memory
   // entity_type_id arrays, which means we don't actually know when the array

--- a/libsupport/include/katana/ArrowInterchange.h
+++ b/libsupport/include/katana/ArrowInterchange.h
@@ -187,9 +187,10 @@ BuildArray(std::vector<T>& data) {
   using Builder = typename arrow::CTypeTraits<T>::BuilderType;
 
   Builder builder;
-  auto append_status = builder.AppendValues(data);
-  KATANA_LOG_ASSERT(append_status.ok());
-
+  if (!data.empty()) {
+    auto append_status = builder.AppendValues(data);
+    KATANA_LOG_ASSERT(append_status.ok());
+  }
   std::shared_ptr<arrow::Array> array;
   auto finish_status = builder.Finish(&array);
   KATANA_LOG_ASSERT(finish_status.ok());


### PR DESCRIPTION
This PR fixes two issues: 
1) It prevents the projected topologies from being committed to the RDG, which would otherwise conflict with the original topologies.
2) It fixes a bug in BuildArray, whereby the `builder.AppendValues()` call could have been passed an empty vector, which causes an UB.