### PR TITLE
Pin markupsafe since 2.1 is not compatible with jinja2.

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -38,6 +38,7 @@ dependencies:
  - isort>=5.9.3,<5.10a0
  - jemalloc>=5.2.1
  - jinja2>=2.11
+ - markupsafe<2.1
  - jupyter>=1
  - jupyter_client>=6,<7a0
  - jupyter_core>=4.7

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - pyarrow {{ arrow_cpp }}
   host:
     - jinja2 {{ jinja2 }}
+    - markupsafe {{ markupsafe }}
     - cython {{ cython }}
     - pyarrow {{ arrow_cpp }}
     - pybind11 {{ pybind11 }}
@@ -129,6 +130,7 @@ outputs:
       host:
         - {{ pin_subpackage('katana-cpp', exact=True) }}
         - jinja2 {{ jinja2 }}
+        - markupsafe {{ markupsafe }}
         - cython {{ cython }}
         - pyarrow {{ arrow_cpp }}
         - numba {{ numba }}

--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -188,6 +188,10 @@ jinja2:
   version: [ 2.11, null ]
   labels:
     - conda/dev
+markupsafe:
+  version: [ 2.0, 2.1 ]
+  labels:
+    - conda/dev
 jupyter:
   version: [ 1, null ]
   labels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
   "wheel",
   "Cython (>=0.29.12)",
   "jinja2",
+  "markupsafe (<2.1)",
   "pyarrow (>=1.0,<3.0.dev)",
   "numpy",
   "packaging",


### PR DESCRIPTION
jinja2 isn't limiting the versions enough. And markupsafe
removed a module in a minor release.

Mirrors: https://github.com/KatanaGraph/katana-enterprise/pull/3398