### PR TITLE
Remove ambiguous overload

### DIFF
--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -1163,7 +1163,9 @@ public:
     return Base::out().DoesEdgeTypeExist(edge_type);
   }
 
+  using Base::InDegree;
   using Base::InEdges;
+  using Base::OutDegree;
   using Base::OutEdges;
 
   auto OutEdges(Node N, const EntityTypeID& edge_type) const noexcept {
@@ -1178,13 +1180,9 @@ public:
     return Base::out().OutDegree(N, edge_type);
   }
 
-  auto OutDegree(Node N) const noexcept { return Base::out().OutDegree(N); }
-
   auto InDegree(Node N, const EntityTypeID& edge_type) const noexcept {
     return Base::in().OutDegree(N, edge_type);
   }
-
-  auto InDegree(Node N) const noexcept { return Base::in().OutDegree(N); }
 
   auto FindAllEdges(
       const Node& src, const Node& dst,

--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -1163,19 +1163,16 @@ public:
     return Base::out().DoesEdgeTypeExist(edge_type);
   }
 
+  using Base::InEdges;
   using Base::OutEdges;
 
   auto OutEdges(Node N, const EntityTypeID& edge_type) const noexcept {
     return Base::out().OutEdges(N, edge_type);
   }
 
-  auto OutEdges(Node N) const noexcept { return Base::out().OutEdges(N); }
-
   auto InEdges(Node N, const EntityTypeID& edge_type) const noexcept {
     return Base::in().OutEdges(N, edge_type);
   }
-
-  auto InEdges(Node N) const noexcept { return Base::in().OutEdges(N); }
 
   auto OutDegree(Node N, const EntityTypeID& edge_type) const noexcept {
     return Base::out().OutDegree(N, edge_type);


### PR DESCRIPTION
GetOutEdges(<node>) was implemented in the base class as well as the derived class (with the same implementation). Since the derived class declared `using Base::GetOutEdges` it was getting two indistinguisable declarations for the same function, leading to an compiler error for ambiguity when trying to use that function.