### PR TITLE
Fix copying a projected PG detached from original properties [KAT-4107]

### DIFF
--- a/libgraph/include/katana/GraphTopology.h
+++ b/libgraph/include/katana/GraphTopology.h
@@ -82,6 +82,9 @@ public:
 
   static GraphTopology Copy(const GraphTopology& that) noexcept;
 
+  static GraphTopology CopyWithoutPropertyIndexes(
+      const GraphTopology& that) noexcept;
+
   uint64_t NumNodes() const noexcept { return adj_indices_.size(); }
 
   uint64_t NumEdges() const noexcept { return dests_.size(); }

--- a/libgraph/include/katana/Properties.h
+++ b/libgraph/include/katana/Properties.h
@@ -439,6 +439,8 @@ public:
     return array_.IsValid(i);
   }
 
+  size_t size() const { return array_.length(); }
+
   value_type GetValue(size_t i) const {
     KATANA_LOG_DEBUG_ASSERT(IsValid(i));
     return array_.Value(i);
@@ -471,6 +473,8 @@ public:
   }
 
   bool IsValid(size_t i) const { return array_.IsValid(i); }
+
+  size_t size() const { return array_.length(); }
 
   value_type GetValue(size_t i) const {
     KATANA_LOG_DEBUG_ASSERT(IsValid(i));
@@ -631,6 +635,8 @@ public:
         array, internal::GetMutableValuesWorkAround<T>(
                    double_array_pointer->data(), 1, 0));
   }
+
+  size_t size() const { return array_.length(); }
 
   reference GetValue(size_t index) {
     return ArrayRef(ptr_ + array_.value_offset(index), N);

--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -76,9 +76,12 @@ public:
   template <typename NodeIndex>
   PropertyReferenceType<NodeIndex> GetData(const Node& node) {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
-    return std::get<prop_col_index>(node_view_)
-        .GetValue(pg_->GetNodePropertyIndex(node));
+    auto& property = std::get<prop_col_index>(node_view_);
+    auto idx = pg_->GetNodePropertyIndex(node);
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
+
   template <typename NodeIndex>
   PropertyReferenceType<NodeIndex> GetData(const node_iterator& node) {
     return GetData<NodeIndex>(*node);
@@ -93,9 +96,12 @@ public:
   template <typename NodeIndex>
   PropertyConstReferenceType<NodeIndex> GetData(const Node& node) const {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
-    return std::get<prop_col_index>(node_view_)
-        .GetValue(pg_->GetNodePropertyIndex(node));
+    const auto& property = std::get<prop_col_index>(node_view_);
+    auto idx = pg_->GetNodePropertyIndex(node);
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
+
   template <typename NodeIndex>
   PropertyConstReferenceType<NodeIndex> GetData(
       const node_iterator& node) const {
@@ -111,8 +117,10 @@ public:
   template <typename EdgeIndex>
   PropertyReferenceType<EdgeIndex> GetEdgeData(const edge_iterator& edge) {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
-    return std::get<prop_col_index>(edge_view_)
-        .GetValue(pg_->GetEdgePropertyIndexFromOutEdge(*edge));
+    auto& property = std::get<prop_col_index>(edge_view_);
+    auto idx = pg_->GetEdgePropertyIndexFromOutEdge(*edge);
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
 
   /**
@@ -125,8 +133,10 @@ public:
   PropertyConstReferenceType<EdgeIndex> GetEdgeData(
       const edge_iterator& edge) const {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
-    return std::get<prop_col_index>(edge_view_)
-        .GetValue(pg_->GetEdgePropertyIndexFromOutEdge(*edge));
+    const auto& property = std::get<prop_col_index>(edge_view_);
+    auto idx = pg_->GetEdgePropertyIndexFromOutEdge(*edge);
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
 
   /**
@@ -210,8 +220,10 @@ public:
   template <typename NodeIndex>
   PropertyReferenceType<NodeIndex> GetData(const Node& node) {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
-    return std::get<prop_col_index>(node_view_)
-        .GetValue(PGView::GetNodePropertyIndex(node));
+    auto& property = std::get<prop_col_index>(node_view_);
+    auto idx = PGView::GetNodePropertyIndex(node);
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
 
   /**
@@ -223,8 +235,10 @@ public:
   template <typename NodeIndex>
   PropertyConstReferenceType<NodeIndex> GetData(const Node& node) const {
     constexpr size_t prop_col_index = find_trait<NodeIndex, NodeProps>();
-    return std::get<prop_col_index>(node_view_)
-        .GetValue(PGView::GetNodePropertyIndex(node));
+    const auto& property = std::get<prop_col_index>(node_view_);
+    auto idx = PGView::GetNodePropertyIndex(node);
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
 
   /**
@@ -236,14 +250,17 @@ public:
   template <typename EdgeIndex>
   PropertyReferenceType<EdgeIndex> GetEdgeData(const Edge& edge) {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
+    auto& property = std::get<prop_col_index>(edge_view_);
 
+    typename PGView::PropertyIndex idx = 0;
     if constexpr (katana::is_detected_v<has_undirected_t, PGView>) {
-      return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetEdgePropertyIndexFromUndirectedEdge(edge));
+      idx = PGView::GetEdgePropertyIndexFromUndirectedEdge(edge);
     } else {
-      return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetEdgePropertyIndexFromOutEdge(edge));
+      idx = PGView::GetEdgePropertyIndexFromOutEdge(edge);
     }
+
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
 
   /**
@@ -255,14 +272,17 @@ public:
   template <typename EdgeIndex>
   PropertyConstReferenceType<EdgeIndex> GetEdgeData(const Edge& edge) const {
     constexpr size_t prop_col_index = find_trait<EdgeIndex, EdgeProps>();
+    const auto& property = std::get<prop_col_index>(edge_view_);
 
+    typename PGView::PropertyIndex idx = 0;
     if constexpr (katana::is_detected_v<has_undirected_t, PGView>) {
-      return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetEdgePropertyIndexFromUndirectedEdge(edge));
+      idx = PGView::GetEdgePropertyIndexFromUndirectedEdge(edge);
     } else {
-      return std::get<prop_col_index>(edge_view_)
-          .GetValue(PGView::GetEdgePropertyIndexFromOutEdge(edge));
+      idx = PGView::GetEdgePropertyIndexFromOutEdge(edge);
     }
+
+    KATANA_LOG_DEBUG_ASSERT(idx < property.size());
+    return property.GetValue(idx);
   }
 
   static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -489,16 +489,11 @@ struct ClusteringImplementationBase {
  */
   static katana::Result<std::unique_ptr<katana::PropertyGraph>>
   DuplicateGraphWithSameTopo(const katana::PropertyGraph& pfg_from) {
-    const katana::GraphTopology& topology_from = pfg_from.topology();
-
-    katana::GraphTopology topo_copy = GraphTopology::Copy(topology_from);
-
-    auto pfg_to_res = katana::PropertyGraph::Make(std::move(topo_copy));
-    if (!pfg_to_res) {
-      return pfg_to_res.error();
-    }
-    return std::unique_ptr<katana::PropertyGraph>(
-        std::move(pfg_to_res.value()));
+    // The resulting PropertyGraph is detached from the property table of the input graph.
+    // Thus any property index indirection of the original topology has to be dropped.
+    katana::GraphTopology topo_copy =
+        GraphTopology::CopyWithoutPropertyIndexes(pfg_from.topology());
+    return katana::PropertyGraph::Make(std::move(topo_copy));
   }
 
   /**

--- a/libgraph/src/GraphTopology.cpp
+++ b/libgraph/src/GraphTopology.cpp
@@ -83,6 +83,14 @@ katana::GraphTopology::Copy(const GraphTopology& that) noexcept {
       that.node_prop_indices_.data());
 }
 
+katana::GraphTopology
+katana::GraphTopology::CopyWithoutPropertyIndexes(
+    const GraphTopology& that) noexcept {
+  return katana::GraphTopology(
+      that.adj_indices_.data(), that.adj_indices_.size(), that.dests_.data(),
+      that.dests_.size(), nullptr, nullptr);
+}
+
 katana::GraphTopology::PropertyIndex
 katana::GraphTopology::GetEdgePropertyIndexFromOutEdge(
     const Edge& eid) const noexcept {

--- a/lonestar/analytics/cpu/leiden_clustering/CMakeLists.txt
+++ b/lonestar/analytics/cpu/leiden_clustering/CMakeLists.txt
@@ -11,4 +11,4 @@ add_test_scale(small leiden-clustering-cpu NO_VERIFY INPUT rmat10 INPUT_URI "${R
 ## Test TranformView
 add_test_scale(small leiden-clustering-cpu NO_VERIFY INPUT ldbc003 INPUT_URI "${RDG_LDBC_003}" --node_types=Person --algo=Deterministic) 
 #FIXME: Hangs in node property construction with edge projection
-#add_test_scale(small leiden-clustering-cpu NO_VERIFY INPUT ldbc003 INPUT_URI "${RDG_LDBC_003}" --edge_types=CONTAINER_OF --algo=Deterministic) 
+add_test_scale(small leiden-clustering-cpu NO_VERIFY INPUT ldbc003 INPUT_URI "${RDG_LDBC_003}" --edge_types=CONTAINER_OF --algo=Deterministic) 


### PR DESCRIPTION
Clustering operations require copying a property graph to the new purely in-memory instance that only contains the topology. To do it correctly, we have to discard any property index indirection when copying the topology.

I also added bounds checking to `TypedPropertyGraph` and `TypedPropertyGraphView` methods, which would have caught this issue.