### PR TITLE
experimental: use string lookup rather than a static variable [KAT-4123]

### DIFF
--- a/libtsuba/CMakeLists.txt
+++ b/libtsuba/CMakeLists.txt
@@ -17,6 +17,7 @@ set(sources
   src/LocalStorage.cpp
   src/ParquetReader.cpp
   src/ParquetWriter.cpp
+  src/PartitionTopologyMetadata.cpp
   src/RDG.cpp
   src/RDGCore.cpp
   src/RDGHandleImpl.cpp
@@ -25,13 +26,13 @@ set(sources
   src/RDGPartHeader.cpp
   src/RDGPrefix.cpp
   src/RDGSlice.cpp
+  src/RDGStorageFormatVersion.cpp
   src/RDGTopology.cpp
   src/RDGTopologyManager.cpp
-  src/PartitionTopologyMetadata.cpp
   src/ReadGroup.cpp
-  src/tsuba.cpp
   src/TxnContext.cpp
   src/WriteGroup.cpp
+  src/tsuba.cpp
 )
 
 target_sources(katana_tsuba PRIVATE ${sources})

--- a/libtsuba/include/katana/RDGStorageFormatVersion.h
+++ b/libtsuba/include/katana/RDGStorageFormatVersion.h
@@ -22,23 +22,4 @@ static const uint32_t kLatestPartitionStorageFormatVersion =
 
 };  // namespace katana
 
-/// The feature flag determines the capabilities of the software,
-/// while the unstable_storage_format_ flag determines the state of the RDG
-/// If "UnstableRDGStorageFormat" is found in the envar "KATANA_ENABLE_EXPERIMENTAL":
-///   1) katana software will store RDGs
-///     - as "latest_storage_format_version"
-///     - with the "unstable_storage_format" part header flag set
-///   2) RDGs with the "unstable_storage_format" flag will be allowed to be loaded
-/// When "UnstableRDGStorageFormat" is not found:
-///   1) RDGs will be stored as the "latest_storage_format_version"
-///   2) RDGs with the "unstable_storage_format" flag will not be allowed to be loaded
-///
-/// This feature flag can be set in the environment:
-/// KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"
-///
-/// This feature flag can be checked by using
-/// KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);
-///
-KATANA_EXPERIMENTAL_FEATURE(UnstableRDGStorageFormat);
-
 #endif

--- a/libtsuba/include/katana/tsuba.h
+++ b/libtsuba/include/katana/tsuba.h
@@ -113,7 +113,7 @@ ListViewsOfVersion(
     const std::string& rdg_dir, std::optional<uint64_t> version = std::nullopt);
 
 /// duplicate of ListViewsOfVersion maintained for compatibility
-[[deprecated]] KATANA_EXPORT
+[[deprecated("use ListViewsOfVersion() instead")]] KATANA_EXPORT
     katana::Result<std::pair<uint64_t, std::vector<RDGView>>>
     ListAvailableViews(
         const std::string& rdg_dir,

--- a/libtsuba/src/RDGStorageFormatVersion.cpp
+++ b/libtsuba/src/RDGStorageFormatVersion.cpp
@@ -1,0 +1,20 @@
+#include "katana/RDGStorageFormatVersion.h"
+
+/// The feature flag determines the capabilities of the software,
+/// while the unstable_storage_format_ flag determines the state of the RDG
+/// If "UnstableRDGStorageFormat" is found in the envar "KATANA_ENABLE_EXPERIMENTAL":
+///   1) katana software will store RDGs
+///     - as "latest_storage_format_version"
+///     - with the "unstable_storage_format" part header flag set
+///   2) RDGs with the "unstable_storage_format" flag will be allowed to be loaded
+/// When "UnstableRDGStorageFormat" is not found:
+///   1) RDGs will be stored as the "latest_storage_format_version"
+///   2) RDGs with the "unstable_storage_format" flag will not be allowed to be loaded
+///
+/// This feature flag can be set in the environment:
+/// KATANA_ENABLE_EXPERIMENTAL="UnstableRDGStorageFormat"
+///
+/// This feature flag can be checked by using
+/// KATANA_EXPERIMENTAL_ENABLED(UnstableRDGStorageFormat);
+///
+KATANA_EXPERIMENTAL_FEATURE(UnstableRDGStorageFormat);

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -224,7 +224,7 @@ katana::CreateSrcDestFromViewsForCopy(
   std::vector<std::pair<katana::URI, katana::URI>> src_dst_files;
 
   // List out all the files in a given view
-  auto rdg_views = KATANA_CHECKED(katana::ListAvailableViews(src_dir, version));
+  auto rdg_views = KATANA_CHECKED(ListViewsOfVersion(src_dir, version));
   for (const auto& rdg_view : rdg_views.second) {
     auto rdg_view_uri = KATANA_CHECKED(katana::URI::Make(rdg_view.view_path));
     auto rdg_manifest_res = katana::RDGManifest::Make(rdg_view_uri);
@@ -238,7 +238,7 @@ katana::CreateSrcDestFromViewsForCopy(
     auto rdg_manifest = std::move(rdg_manifest_res.value());
 
     auto fnames = KATANA_CHECKED(rdg_manifest.FileNames());
-    for (auto fname : fnames) {
+    for (const auto& fname : fnames) {
       auto src_file_path = katana::URI::JoinPath(src_dir, fname);
       auto src_file_uri = KATANA_CHECKED(katana::URI::Make(src_file_path));
 
@@ -264,7 +264,7 @@ katana::CreateSrcDestFromViewsForCopy(
         auto dst_file_path = katana::URI::JoinPath(dst_dir, fname);
         dst_file_uri = KATANA_CHECKED(katana::URI::Make(dst_file_path));
       }
-      src_dst_files.push_back(std::make_pair(src_file_uri, dst_file_uri));
+      src_dst_files.emplace_back(std::make_pair(src_file_uri, dst_file_uri));
     }
 
     // We add the manifest file to the vector
@@ -278,7 +278,7 @@ katana::CreateSrcDestFromViewsForCopy(
         katana::URI::JoinPath(dst_dir, rdg_manifest.FileName().BaseName());
     auto dst_rdg_manifest_uri =
         KATANA_CHECKED(katana::URI::Make(dst_rdg_manifest_path));
-    src_dst_files.push_back(
+    src_dst_files.emplace_back(
         std::make_pair(rdg_manifest_uri, dst_rdg_manifest_uri));
   }
   return src_dst_files;


### PR DESCRIPTION
experimental: switch to global variables and a string registry

    At first, we avoided this method because I wanted to prioritize failing
    to compile when the developer mistyped a feature flag. That caused some
    problems with multiple declarations that we decided were more important.

    This version will cause a debug build to fail when a developer uses a
    flag that was not registered.


Signed-off-by: Tyler Hunt <thunt@katanagraph.com>