### PR TITLE
On Open Repo Fix CI Bypass Flake [KAT-4187]

### DIFF
--- a/.github/workflows/cpp_bypass.yaml
+++ b/.github/workflows/cpp_bypass.yaml
@@ -1,10 +1,6 @@
 name: C/C++ CI
 
 on:
-  push:
-    branches:
-      - 'master'
-      - 'release/*'
   pull_request:
     paths:
       - 'docs/**'

--- a/.github/workflows/cpp_bypass.yaml
+++ b/.github/workflows/cpp_bypass.yaml
@@ -13,7 +13,7 @@ on:
 concurrency:
   # Example key: Repository Structure CI-refs/pull/1381/merge
   #   or Repository Structure CI-<owner>-<sha> for pushes
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.repository_owner, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.repository_owner, github.sha) }}_bypass
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Separated the bypass workflows into a different concurrency group so they don't interrupt the main workflow and kept the bypass to PRs only.

[KAT-4187](https://katanagraph.atlassian.net/browse/KAT-4187)