### PR TITLE
libgalois: fix DynamicBitset count/not bug

### DIFF
--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -52,6 +52,24 @@ private:  // variables
   katana::PODVector<TItem> bitvec_;
   size_t num_bits_{0};
 
+  /// DynamicBitset must maintain the invariant that the unused bits in the last
+  /// element of bitvec_ are 0. This invariant is required for count() to return
+  /// the correct value and also simplifies resizing bitsets to larger sizes.
+  /// Most mutating methods maintain this invariant (for example, bitwise_and()
+  /// will bitwise and the last entries of its operands together and if the
+  /// inputs both have 0s in the unused bits the output will as well) but
+  /// bitwise_not() must explicitly restore this invariant.
+  void RestoreTrailingBitsInvariant() {
+    if (size() > 0) {
+      KATANA_LOG_DEBUG_ASSERT(!bitvec_.empty());
+
+      size_t last_entry_offset =
+          size() % (CHAR_BIT * sizeof(decltype(bitvec_)::value_type));
+      uint64_t last_entry_mask = (1UL << last_entry_offset) - 1;
+      bitvec_.back() = bitvec_.back() & last_entry_mask;
+    }
+  }
+
 public:
   static constexpr uint32_t kNumBitsInUint64 = sizeof(uint64_t) * CHAR_BIT;
 

--- a/libgalois/src/DynamicBitset.cpp
+++ b/libgalois/src/DynamicBitset.cpp
@@ -41,6 +41,8 @@ katana::DynamicBitset::bitwise_not() {
   katana::do_all(
       katana::iterate(size_t{0}, bitvec_.size()),
       [&](size_t i) { bitvec_[i] = ~bitvec_[i]; }, katana::no_stats());
+
+  RestoreTrailingBitsInvariant();
 }
 
 void

--- a/libgalois/test/CMakeLists.txt
+++ b/libgalois/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_test_unit(acquire)
 add_test_unit(bandwidth)
 add_test_unit(barriers 1024 2)
+add_test_unit(dynamic-bitset-unit)
 add_test_unit(flatmap)
 add_test_unit(floating-point-errors)
 add_test_unit(foreach)

--- a/libgalois/test/dynamic-bitset-unit.cpp
+++ b/libgalois/test/dynamic-bitset-unit.cpp
@@ -1,0 +1,69 @@
+#include "katana/DynamicBitset.h"
+#include "katana/Result.h"
+
+namespace {
+using TestCaseGenerator = std::function<katana::DynamicBitset()>;
+using Invariant = std::function<katana::Result<void>(katana::DynamicBitset*)>;
+
+const TestCaseGenerator TestBitsetEmpty = []() {
+  katana::DynamicBitset test;
+  return test;
+};
+
+const TestCaseGenerator TestBitsetOne = []() {
+  katana::DynamicBitset test;
+  test.resize(32);
+  test.reset();
+
+  for (size_t i = 0; i < test.size(); i += 3) {
+    test.set(i);
+  }
+
+  return test;
+};
+
+const std::vector<TestCaseGenerator> test_case_generators = {
+    TestBitsetEmpty, TestBitsetOne};
+
+const Invariant NotAndCount =
+    [](katana::DynamicBitset* test) -> katana::Result<void> {
+  size_t size = test->size();
+  size_t count_before = test->count();
+  test->bitwise_not();
+  size_t count_after = test->count();
+
+  if (size != count_before + count_after) {
+    return KATANA_ERROR(
+        katana::ErrorCode::AssertionFailed,
+        "count of bitset and count of complement did not sum to size of "
+        "bitset "
+        "- size of bitset: {}, count of bitset: {}, count of complement: {}",
+        size, count_before, count_after);
+  }
+
+  return katana::ResultSuccess();
+};
+
+const std::vector<Invariant> invariants = {NotAndCount};
+
+katana::Result<void>
+TestAll() {
+  for (const auto& generator : test_case_generators) {
+    for (const auto& invariant : invariants) {
+      auto bitset = generator();
+      KATANA_CHECKED(invariant(&bitset));
+    }
+  }
+
+  return katana::ResultSuccess();
+}
+}  // namespace
+
+int
+main() {
+  katana::GaloisRuntime Katana_runtime;
+
+  auto res = TestAll();
+  KATANA_LOG_VASSERT(res, "{}", res.error());
+  return 0;
+}

--- a/libsupport/src/DynamicBitsetSlow.cpp
+++ b/libsupport/src/DynamicBitsetSlow.cpp
@@ -30,6 +30,8 @@ katana::DynamicBitsetSlow::bitwise_not() {
   for (size_t i = 0; i < bitvec_.size(); i++) {
     bitvec_[i] = ~bitvec_[i];
   }
+
+  RestoreTrailingBitsInvariant();
 }
 
 void


### PR DESCRIPTION
DynamicBitset::bitwise_not() applies bitwise not to every element in
DynamicBitset's internal vector. DynamicBitset::count() calls popcount
on every element in DynamicBitset's internal vector and takes a sum.

The last element in the vector has some unused bits in it if the size of
the bitset is not a multiple of 64. When the vector is constructed,
these bits are set to 0. So calling popcount on that element gives only
the set and used bits. But once bitwise_not has been called, those
unused bits are set to 1. And calling popcount on the last element gives
the number of set and used bits plus the number of unused bits.

One solution is to change count to not count the unused bits. One
solution is to change bitwise_not to not invert the unused bits. Change
the behavior of not to maintain the invariant that the unused bits are
always 0 because that gives nice semantics when resizing the bitset.