### PR TITLE
libgalois: fix DynamicBitset bug

### DIFF
--- a/libgalois/include/katana/DynamicBitset.h
+++ b/libgalois/include/katana/DynamicBitset.h
@@ -65,8 +65,10 @@ private:  // variables
 
       size_t last_entry_offset =
           size() % (CHAR_BIT * sizeof(decltype(bitvec_)::value_type));
-      uint64_t last_entry_mask = (1UL << last_entry_offset) - 1;
-      bitvec_.back() = bitvec_.back() & last_entry_mask;
+      if (last_entry_offset != 0) {
+        uint64_t last_entry_mask = (1UL << last_entry_offset) - 1;
+        bitvec_.back() = bitvec_.back() & last_entry_mask;
+      }
     }
   }
 

--- a/libsupport/include/katana/DynamicBitsetSlow.h
+++ b/libsupport/include/katana/DynamicBitsetSlow.h
@@ -127,8 +127,10 @@ class KATANA_EXPORT DynamicBitsetSlow {
 
       size_t last_entry_offset =
           size() % (CHAR_BIT * sizeof(decltype(bitvec_)::value_type));
-      uint64_t last_entry_mask = (1UL << last_entry_offset) - 1;
-      bitvec_.back() = bitvec_.back() & last_entry_mask;
+      if (last_entry_offset != 0) {
+        uint64_t last_entry_mask = (1UL << last_entry_offset) - 1;
+        bitvec_.back() = bitvec_.back() & last_entry_mask;
+      }
     }
   }
 


### PR DESCRIPTION
RestoreTrailingBitsInvariant was constructing a mask of all zeroes in
the case that the size of the bitset was a mutliple of 64. This resulted
in masking off the entire last element in the vector.

Fix this bug and add some more unit tests that give broader coverage of
DynamicBitset and act as a regression test for this bug in particular.