### PR TITLE
Add property view sorted by edge property and refactor edge sorted topology

### DIFF
--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -295,6 +295,10 @@ public:
       const std::vector<std::string>& edge_properties);
   static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(
       const PGView& pg_view);
+  static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(
+      PropertyGraph* pg, const std::vector<std::string>& node_properties,
+      const std::vector<std::string>& edge_properties,
+      const std::string& property_name);
 };
 
 /**
@@ -410,6 +414,32 @@ TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
       pg_view, pg->loaded_node_schema()->field_names(),
       pg->loaded_edge_schema()->field_names());
 }
+
+template <typename PGView, typename NodeProps, typename EdgeProps>
+Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>>
+Make(
+    PropertyGraph* pg, const std::vector<std::string>& node_properties,
+    const std::vector<std::string>& edge_properties,
+    const std::string& prop_name) {
+  auto pg_view = pg->BuildView<PGView>(prop_name);
+  KATANA_LOG_DEBUG_ASSERT(pg);
+  auto node_view_result =
+      internal::MakeNodePropertyViews<NodeProps>(pg, node_properties);
+  if (!node_view_result) {
+    return node_view_result.error();
+  }
+
+  auto edge_view_result =
+      internal::MakeEdgePropertyViews<EdgeProps>(pg, edge_properties);
+  if (!edge_view_result) {
+    return edge_view_result.error();
+  }
+
+  return TypedPropertyGraphView(
+      pg_view, std::move(node_view_result.value()),
+      std::move(edge_view_result.value()));
+}
+
 }  // namespace katana
 
 #endif

--- a/libgraph/test/CMakeLists.txt
+++ b/libgraph/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_test_unit(property-graph-bench NOT_QUICK LINK_LIBRARIES benchmark::benchmark
 add_test_unit(property-graph-in-memory-props)
 add_test_unit(property-graph-topology)
 add_test_unit(property-graph-optional-topology-generation "${RDG_LDBC_003}" LINK_LIBRARIES LLVMSupport)
+add_test_unit(property-graph-sorted-by-edgeprop-then-dest-view)
 add_test_unit(property-graph-transposed-view)
 add_test_unit(property-graph-undirected-view)
 add_test_unit(property-index)

--- a/libgraph/test/property-graph-sorted-by-edgeprop-then-dest-view.cpp
+++ b/libgraph/test/property-graph-sorted-by-edgeprop-then-dest-view.cpp
@@ -1,0 +1,99 @@
+#include "katana/Logging.h"
+#include "katana/SharedMemSys.h"
+#include "katana/TopologyGeneration.h"
+#include "katana/TypedPropertyGraph.h"
+
+using namespace katana;
+using Edge = PropertyGraph::Edge;
+using Node = PropertyGraph::Node;
+using EdgesSortedByPropThenDestIDGraphView =
+    PropertyGraphViews::EdgesSortedByProperty;
+
+struct EdgeDataProp : public katana::PODProperty<uint32_t> {};
+using EdgeData = std::tuple<EdgeDataProp>;
+
+using OrigTypeGraphView = katana::TypedPropertyGraph<std::tuple<>, EdgeData>;
+using SortedTypeGraphView = katana::TypedPropertyGraphView<
+    EdgesSortedByPropThenDestIDGraphView, std::tuple<>, EdgeData>;
+
+template <typename T>
+Result<void>
+TestEdgesSortedByTypeThenDestIDGraphView() {
+  // We build a simple tree-like graph and its sorted graph.
+  // Then we compare the transposed view of the first graph with the second.
+  AsymmetricGraphTopologyBuilder builder;
+
+  builder.AddNodes(7);
+
+  std::vector<std::array<T, 2>> unsorted_edges = {{0, 2}, {0, 1}, {1, 4},
+                                                  {1, 3}, {2, 6}, {2, 5}};
+
+  for (const auto& [n1, n2] : unsorted_edges) {
+    builder.AddEdge(n1, n2);
+  }
+
+  auto pg = KATANA_CHECKED(PropertyGraph::Make(builder.ConvertToCSR()));
+  katana::TxnContext txn_ctx;
+  KATANA_CHECKED(
+      pg->ConstructEdgeProperties<EdgeData>(&txn_ctx, {"edge_weight"}));
+  auto orig_graph =
+      KATANA_CHECKED(OrigTypeGraphView::Make(pg.get(), {}, {"edge_weight"}));
+  orig_graph.template GetEdgeData<EdgeDataProp>(0) = 1;
+  orig_graph.template GetEdgeData<EdgeDataProp>(1) = 1;
+  orig_graph.template GetEdgeData<EdgeDataProp>(2) = 2;
+  orig_graph.template GetEdgeData<EdgeDataProp>(3) = 3;
+  orig_graph.template GetEdgeData<EdgeDataProp>(4) = 5;
+  orig_graph.template GetEdgeData<EdgeDataProp>(5) = 4;
+
+  // Before sorting:
+  // (0, 2, 1), (0, 1, 1), (1, 4, 2), (1, 3, 3), (2, 6, 5), (2, 5, 4)
+
+  // Results should be:
+  // (0, 1, 1), (0, 2, 1), (1, 4, 2), (1, 3, 3), (2, 5, 4), (2, 6, 5)
+
+  EdgesSortedByPropThenDestIDGraphView pg_view =
+      pg->BuildView<EdgesSortedByPropThenDestIDGraphView>("edge_weight");
+  auto sorted_graph =
+      KATANA_CHECKED(SortedTypeGraphView::Make(pg_view, {}, {"edge_weight"}));
+
+  KATANA_LOG_ASSERT(sorted_graph.GetEdgeSrc(0) == 0);
+  KATANA_LOG_ASSERT(sorted_graph.GetEdgeSrc(1) == 0);
+  KATANA_LOG_ASSERT(sorted_graph.GetEdgeSrc(2) == 1);
+  KATANA_LOG_ASSERT(sorted_graph.GetEdgeSrc(3) == 1);
+  KATANA_LOG_ASSERT(sorted_graph.GetEdgeSrc(4) == 2);
+  KATANA_LOG_ASSERT(sorted_graph.GetEdgeSrc(5) == 2);
+  KATANA_LOG_ASSERT(sorted_graph.OutEdgeDst(0) == 1);
+  KATANA_LOG_ASSERT(sorted_graph.OutEdgeDst(1) == 2);
+  KATANA_LOG_ASSERT(sorted_graph.OutEdgeDst(2) == 4);
+  KATANA_LOG_ASSERT(sorted_graph.OutEdgeDst(3) == 3);
+  KATANA_LOG_ASSERT(sorted_graph.OutEdgeDst(4) == 5);
+  KATANA_LOG_ASSERT(sorted_graph.OutEdgeDst(5) == 6);
+  KATANA_LOG_ASSERT(sorted_graph.template GetEdgeData<EdgeDataProp>(0) == 1);
+  KATANA_LOG_ASSERT(sorted_graph.template GetEdgeData<EdgeDataProp>(1) == 1);
+  KATANA_LOG_ASSERT(sorted_graph.template GetEdgeData<EdgeDataProp>(2) == 2);
+  KATANA_LOG_ASSERT(sorted_graph.template GetEdgeData<EdgeDataProp>(3) == 3);
+  KATANA_LOG_ASSERT(sorted_graph.template GetEdgeData<EdgeDataProp>(4) == 4);
+  KATANA_LOG_ASSERT(sorted_graph.template GetEdgeData<EdgeDataProp>(5) == 5);
+
+  return katana::ResultSuccess();
+}
+
+int
+main() {
+  SharedMemSys sys;
+
+  auto uint32_res = TestEdgesSortedByTypeThenDestIDGraphView<uint32_t>();
+  KATANA_LOG_ASSERT(uint32_res);
+  auto int32_res = TestEdgesSortedByTypeThenDestIDGraphView<int32_t>();
+  KATANA_LOG_ASSERT(int32_res);
+  auto uint64_res = TestEdgesSortedByTypeThenDestIDGraphView<uint64_t>();
+  KATANA_LOG_ASSERT(uint64_res);
+  auto int64_res = TestEdgesSortedByTypeThenDestIDGraphView<int64_t>();
+  KATANA_LOG_ASSERT(int64_res);
+  auto float_res = TestEdgesSortedByTypeThenDestIDGraphView<float>();
+  KATANA_LOG_ASSERT(float_res);
+  auto double_res = TestEdgesSortedByTypeThenDestIDGraphView<double>();
+  KATANA_LOG_ASSERT(double_res);
+
+  return 0;
+}

--- a/libtsuba/include/katana/RDGTopology.h
+++ b/libtsuba/include/katana/RDGTopology.h
@@ -37,7 +37,8 @@ public:
     kAny = 0,  // don't care. Sorted or Unsorted
     kSortedByDestID,
     kSortedByEdgeType,
-    kSortedByNodeType
+    kSortedByNodeType,
+    kSortedByProperty
   };
 
   enum class NodeSortKind : int {
@@ -259,6 +260,11 @@ public:
       TopologyKind topology_state, TransposeKind transpose_state,
       EdgeSortKind edge_sort_state, NodeSortKind node_sort_state);
 
+  static katana::RDGTopology MakeShadow(
+      TopologyKind topology_state, TransposeKind transpose_state,
+      EdgeSortKind edge_sort_state, NodeSortKind node_sort_state,
+      const std::string& edge_property_name_for_sorting);
+
   /// Create a shadow RDGTopology with default CSR state
   static katana::RDGTopology MakeShadowCSR();
 
@@ -320,6 +326,7 @@ private:
   TransposeKind transpose_state_{-1};
   EdgeSortKind edge_sort_state_{-1};
   NodeSortKind node_sort_state_{-1};
+  std::string edge_property_name_for_sorting_;
   uint64_t edge_condensed_type_id_map_size_{0};
   uint64_t node_condensed_type_id_map_size_{0};
 

--- a/libtsuba/src/RDGTopology.cpp
+++ b/libtsuba/src/RDGTopology.cpp
@@ -560,6 +560,23 @@ katana::RDGTopology::MakeShadow(
 }
 
 katana::RDGTopology
+katana::RDGTopology::MakeShadow(
+    katana::RDGTopology::TopologyKind topology_state,
+    katana::RDGTopology::TransposeKind transpose_state,
+    katana::RDGTopology::EdgeSortKind edge_sort_state,
+    katana::RDGTopology::NodeSortKind node_sort_state,
+    const std::string& edge_property_name_for_sorting) {
+  RDGTopology topo = RDGTopology();
+
+  topo.topology_state_ = topology_state;
+  topo.transpose_state_ = transpose_state;
+  topo.edge_sort_state_ = edge_sort_state;
+  topo.node_sort_state_ = node_sort_state;
+  topo.edge_property_name_for_sorting_ = edge_property_name_for_sorting;
+  return RDGTopology(std::move(topo));
+}
+
+katana::RDGTopology
 katana::RDGTopology::MakeShadowCSR() {
   // Match on a CSR topology transposed or not transposed, and no sorting
   return MakeShadow(


### PR DESCRIPTION
[Goal]
This PR adds new policy of edge sorting by edge property then edge destination id.
This PR also contains refactoring to support various edge property sorting policies, which was limited.

[Usecase]
Dist-minimum-spanning-tree needs this edge sorting for optimization to reduce edge iterations.

[Problem]
The current `EdgeShuffleTopology` has multiple policies for edge sorting. However, users only could create views of subsets of them since creating a new `PGViewBuilder` for other edge sorting policies was hard.
(https://github.com/KatanaGraph/katana/blob/71e3fd6b14749e0a328f1d1118daa2e035e7f23d/libgraph/include/katana/GraphTopology.h#L1392)
`PGViewEdgesSortedByDestID` is a representative view for `EdgeShuffleTopology`. It means that we cannot create new views like `PGViewEdgesSortedByProperty` or `PGViewEdgesSortedByDegree` as other designs adopted, since they would be the equivalent types and a compiler would complain about redefinition errors. It only assumes the policy of edges sorting by destination id even though `EdgeShuffleTopology` has multiple policies (https://github.com/KatanaGraph/katana/blob/71e3fd6b14749e0a328f1d1118daa2e035e7f23d/libgraph/include/katana/GraphTopology.h#L334)

[This PR's approach]
To distinguish and support multiple edge sorting policy, this PR adds new parameters for policy (and property name if it needs; sorting by edge property needs the target property name) at the existing BuildView().
(https://github.com/KatanaGraph/katana/blob/71e3fd6b14749e0a328f1d1118daa2e035e7f23d/libgraph/include/katana/GraphTopology.h#L1398)

This PR adds execution paths to support this.

[Design detail information]
This PR has some TODOs, which I would like to discuss about.
I was trying to reuse the existing APIs as much as possible.
I tried to avoid duplicated/complex parameters from user side, like property name and property type.
Edge property sorting could be called from both `TypedPropertyGraph` and `PropertyGraph`.
In case of the `PropertyGraph`, it uses the original type that was specified during `ConstructEdgeProperties()`.