### PR TITLE
Storage prefixes always

### DIFF
--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -250,17 +250,31 @@ public:
       const katana::RDGLoadOptions& opts = katana::RDGLoadOptions());
 
   /// Make a property graph from topology
-  // [deprecated("please provide a storage prefix")]
-  static Result<std::unique_ptr<PropertyGraph>> Make(
-      GraphTopology&& topo_to_assign);
-
-  /// Make a property graph from topology
   static Result<std::unique_ptr<PropertyGraph>> Make(
       const URI& rdg_dir, GraphTopology&& topo_to_assign);
 
+  /// Make a property graph from topology and associate it with an ephemeral
+  /// storage prefix. This is approximates an in-memory graph.
+  static Result<std::unique_ptr<PropertyGraph>> MakeEphemeral(
+      GraphTopology&& topo_to_assign);
+
+  /// Make a property graph from topology
+  [[deprecated("please provide a storage prefix")]] static Result<
+      std::unique_ptr<PropertyGraph>>
+  Make(GraphTopology&& topo_to_assign);
+
+  /// Make a property graph from topology and type arrays and associate it with
+  /// an ephemeral storage prefix. This approximates an in-memory graph.
+  static Result<std::unique_ptr<PropertyGraph>> MakeEphemeral(
+      GraphTopology&& topo_to_assign, EntityTypeIDArray&& node_entity_type_ids,
+      EntityTypeIDArray&& edge_entity_type_ids,
+      EntityTypeManager&& node_type_manager,
+      EntityTypeManager&& edge_type_manager);
+
   /// Make a property graph from topology and type arrays
-  // [deprecated("please provide a storage prefix")]
-  static Result<std::unique_ptr<PropertyGraph>> Make(
+  [[deprecated("please provide a storage prefix")]] static Result<
+      std::unique_ptr<PropertyGraph>>
+  Make(
       GraphTopology&& topo_to_assign, EntityTypeIDArray&& node_entity_type_ids,
       EntityTypeIDArray&& edge_entity_type_ids,
       EntityTypeManager&& node_type_manager,

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -493,7 +493,9 @@ struct ClusteringImplementationBase {
     // Thus any property index indirection of the original topology has to be dropped.
     katana::GraphTopology topo_copy =
         GraphTopology::CopyWithoutPropertyIndexes(pfg_from.topology());
-    return katana::PropertyGraph::Make(std::move(topo_copy));
+    // PR question: is this okay? My guess is that this will be written to
+    // rarely if ever?
+    return katana::PropertyGraph::MakeEphemeral(std::move(topo_copy));
   }
 
   /**
@@ -681,7 +683,8 @@ struct ClusteringImplementationBase {
 
     GraphTopology topo_next{
         std::move(prefix_edges_count), std::move(out_dests_next)};
-    auto pfg_next_res = katana::PropertyGraph::Make(std::move(topo_next));
+    auto pfg_next_res =
+        katana::PropertyGraph::MakeEphemeral(std::move(topo_next));
 
     if (!pfg_next_res) {
       return pfg_next_res.error();

--- a/libgraph/src/BuildGraph.cpp
+++ b/libgraph/src/BuildGraph.cpp
@@ -1834,7 +1834,8 @@ ImportData::ValueFromArrowScalar(std::shared_ptr<arrow::Scalar> scalar) {
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::ConvertToPropertyGraph(
     katana::GraphComponents&& graph_comps, katana::TxnContext* txn_ctx) {
-  auto pg_result = katana::PropertyGraph::Make(std::move(graph_comps.topology));
+  auto pg_result =
+      katana::PropertyGraph::MakeEphemeral(std::move(graph_comps.topology));
   if (!pg_result) {
     return pg_result.error().WithContext("adding topology");
   }

--- a/libgraph/src/TopologyGeneration.cpp
+++ b/libgraph/src/TopologyGeneration.cpp
@@ -8,7 +8,7 @@ MakeTopologyImpl(F builder_fun) {
   builder_fun(builder);
 
   katana::GraphTopology topo = builder.ConvertToCSR();
-  auto res = katana::PropertyGraph::Make(std::move(topo));
+  auto res = katana::PropertyGraph::MakeEphemeral(std::move(topo));
   KATANA_LOG_ASSERT(res);
   return std::move(res.value());
 }

--- a/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
+++ b/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
@@ -86,7 +86,7 @@ SubGraphNodeSet(
 
   katana::GraphTopology sub_g_topo{
       std::move(out_indices), std::move(out_dests)};
-  auto sub_g_res = katana::PropertyGraph::Make(std::move(sub_g_topo));
+  auto sub_g_res = katana::PropertyGraph::MakeEphemeral(std::move(sub_g_topo));
 
   return sub_g_res;
 }

--- a/libgraph/test/TestTypedPropertyGraph.h
+++ b/libgraph/test/TestTypedPropertyGraph.h
@@ -80,7 +80,7 @@ MakeFileGraph(
   katana::GraphTopology topo{
       indices.data(), indices.size(), dests.data(), dests.size()};
 
-  auto g_res = katana::PropertyGraph::Make(std::move(topo));
+  auto g_res = katana::PropertyGraph::MakeEphemeral(std::move(topo));
   KATANA_LOG_ASSERT(g_res);
 
   std::unique_ptr<katana::PropertyGraph> g = std::move(g_res.value());

--- a/libgraph/test/property-graph-transposed-view.cpp
+++ b/libgraph/test/property-graph-transposed-view.cpp
@@ -22,10 +22,12 @@ TestTransposedView() {
     builder_tr.AddEdge(n2, n1);
   }
 
-  auto pg = KATANA_CHECKED(PropertyGraph::Make(builder.ConvertToCSR()));
+  auto pg =
+      KATANA_CHECKED(PropertyGraph::MakeEphemeral(builder.ConvertToCSR()));
   TransposedGraphView pg_tr_view = pg->BuildView<TransposedGraphView>();
 
-  auto pg_tr = KATANA_CHECKED(PropertyGraph::Make(builder_tr.ConvertToCSR()));
+  auto pg_tr =
+      KATANA_CHECKED(PropertyGraph::MakeEphemeral(builder_tr.ConvertToCSR()));
 
   for (Edge e : pg_tr_view.OutEdges()) {
     KATANA_LOG_VASSERT(

--- a/libkatana_python_native/src/ImportData.cpp
+++ b/libkatana_python_native/src/ImportData.cpp
@@ -39,7 +39,7 @@ katana::python::InitImportData(py::module& m) {
       [](py::array_t<PropertyGraph::Edge> edge_indices,
          py::array_t<PropertyGraph::Node> edge_destinations)
           -> Result<std::shared_ptr<PropertyGraph>> {
-        return KATANA_CHECKED(katana::PropertyGraph::Make(
+        return KATANA_CHECKED(katana::PropertyGraph::MakeEphemeral(
             TopologyFromCSR(edge_indices, edge_destinations)));
       },
       R"""(
@@ -75,7 +75,7 @@ katana::python::InitImportData(py::module& m) {
             edge_types_owned.begin());
         EntityTypeManager node_type_manager_owned = node_type_manager;
         EntityTypeManager edge_type_manager_owned = edge_type_manager;
-        return KATANA_CHECKED(katana::PropertyGraph::Make(
+        return KATANA_CHECKED(katana::PropertyGraph::MakeEphemeral(
             TopologyFromCSR(edge_indices, edge_destinations),
             std::move(node_types_owned), std::move(edge_types_owned),
             std::move(node_type_manager_owned),

--- a/libsupport/include/katana/Env.h
+++ b/libsupport/include/katana/Env.h
@@ -20,7 +20,7 @@ KATANA_EXPORT bool GetEnv(const std::string& var_name);
 /// \param var_name name of the variable
 /// \param[out] ret where to store the value of environment variable
 /// \return true if environment variable set and value was successfully parsed;
-///   false otherwise
+///   false otherwise (with no change to value pointed to by \p ret)
 KATANA_EXPORT bool GetEnv(const std::string& var_name, bool* ret);
 KATANA_EXPORT bool GetEnv(const std::string& var_name, int* ret);
 KATANA_EXPORT bool GetEnv(const std::string& var_name, double* ret);

--- a/libsupport/include/katana/URI.h
+++ b/libsupport/include/katana/URI.h
@@ -32,6 +32,7 @@ public:
   /// 3. KATANA_TMPDIR
   /// The contents of the "most senior" set variable from this list will be used
   /// if any are set.
+  // TODO (scober): Add a signal handler to clear this directory
   static Result<URI> MakeTempDir();
 
   static std::string JoinPath(const std::string& dir, const std::string& file);
@@ -71,6 +72,15 @@ public:
   URI RandFile(std::string_view prefix) const;
   /// An overload of RandFile provided for clarity at call sites
   URI RandSubdir(std::string_view prefix) const { return RandFile(prefix); }
+
+  bool IsPrefixOf(const URI& other) const {
+    return scheme_ == other.scheme_ &&
+           other.path_.compare(0, path_.size(), path_) == 0;
+  }
+  bool HasAsPrefix(const URI& other) const {
+    return scheme_ == other.scheme_ &&
+           path_.compare(0, other.path_.size(), other.path_) == 0;
+  }
 
   URI operator+(char rhs) const;
   URI operator+(const std::string& rhs) const;

--- a/libsupport/include/katana/URI.h
+++ b/libsupport/include/katana/URI.h
@@ -24,6 +24,15 @@ public:
   static Result<URI> MakeFromFile(const std::string& str);
   /// Append a '-' and then a random string to input
   static Result<URI> MakeRand(const std::string& str);
+  /// Make a URI for a local user-configurable temporary directory
+  /// The URI will encode "/tmp" unless one of the following environment
+  /// variables is set (later list entries overrule previous entries):
+  /// 1. TMP
+  /// 2. TMPDIR
+  /// 3. KATANA_TMPDIR
+  /// The contents of the "most senior" set variable from this list will be used
+  /// if any are set.
+  static Result<URI> MakeTempDir();
 
   static std::string JoinPath(const std::string& dir, const std::string& file);
 
@@ -60,6 +69,8 @@ public:
   /// generate a new uri that is this uri with `prefix-XXXXX` appended where
   /// XXXX is a random alpha numeric string
   URI RandFile(std::string_view prefix) const;
+  /// An overload of RandFile provided for clarity at call sites
+  URI RandSubdir(std::string_view prefix) const { return RandFile(prefix); }
 
   URI operator+(char rhs) const;
   URI operator+(const std::string& rhs) const;

--- a/libsupport/src/URI.cpp
+++ b/libsupport/src/URI.cpp
@@ -9,6 +9,7 @@
 
 #include <fmt/format.h>
 
+#include "katana/Env.h"
 #include "katana/ErrorCode.h"
 #include "katana/Logging.h"
 #include "katana/Random.h"
@@ -269,6 +270,18 @@ katana::URI::MakeRand(const std::string& str) {
     return res.error();
   }
   return res.value();
+}
+
+katana::Result<katana::URI>
+katana::URI::MakeTempDir() {
+  std::string tmp_dir = "/tmp";
+
+  // NB: these are intended to be ordered by increasing specificity
+  GetEnv("TMP", &tmp_dir);
+  GetEnv("TMPDIR", &tmp_dir);
+  GetEnv("KATANA_TMPDIR", &tmp_dir);
+
+  return KATANA_CHECKED(Make(tmp_dir));
 }
 
 std::string

--- a/libsupport/src/URI.cpp
+++ b/libsupport/src/URI.cpp
@@ -281,7 +281,9 @@ katana::URI::MakeTempDir() {
   GetEnv("TMPDIR", &tmp_dir);
   GetEnv("KATANA_TMPDIR", &tmp_dir);
 
-  return KATANA_CHECKED(Make(tmp_dir));
+  auto tmp_uri = KATANA_CHECKED(Make(tmp_dir));
+
+  return tmp_uri.Join("katana-tmp");
 }
 
 std::string

--- a/libsupport/test/uri.cpp
+++ b/libsupport/test/uri.cpp
@@ -75,6 +75,22 @@ TestDecode() {
       katana::URI::Decode("host%3A8020/path") == "host:8020/path");
 }
 
+void
+TestPrefix() {
+  katana::URI full = Str2Uri("abc/def/ghi");
+  katana::URI prefix = Str2Uri("abc/d");
+  katana::URI not_prefix = Str2Uri("jkl/mn");
+  katana::URI other_not_prefix = Str2Uri("s3://abc/def");
+
+  KATANA_LOG_ASSERT(prefix.IsPrefixOf(full));
+  KATANA_LOG_ASSERT(full.HasAsPrefix(prefix));
+
+  KATANA_LOG_ASSERT(!not_prefix.IsPrefixOf(full));
+  KATANA_LOG_ASSERT(!full.HasAsPrefix(not_prefix));
+  KATANA_LOG_ASSERT(!other_not_prefix.IsPrefixOf(full));
+  KATANA_LOG_ASSERT(!full.HasAsPrefix(other_not_prefix));
+}
+
 }  // namespace
 
 int
@@ -86,6 +102,8 @@ main() {
   TestEncode();
 
   TestDecode();
+
+  TestPrefix();
 
   return 0;
 }

--- a/libtsuba/include/katana/EphemeralStoragePrefix.h
+++ b/libtsuba/include/katana/EphemeralStoragePrefix.h
@@ -1,0 +1,76 @@
+#ifndef KATANA_LIBTSUBA_KATANA_EPHEMERALSTORAGEPREFIX_H_
+#define KATANA_LIBTSUBA_KATANA_EPHEMERALSTORAGEPREFIX_H_
+
+#include <memory>
+
+#include "katana/URI.h"
+#include "katana/file.h"
+
+namespace katana {
+
+/// EphemeralStoragePrefix uses RAII to manage ephemeral storage locations. It
+/// creates a URI under the katana temporary storage prefix and when the object
+/// is destroyed it deletes all files under that prefix.
+///
+/// It does not allow construction with arbitrary prefixes under the assumption
+/// that only prefixes under the katana temporary storage prefix would need to
+/// be ephemeral.
+///
+/// NB: There are situations in which this destructor won't be called. The
+/// fail-safe is a (not yet written) signal handler that will clear the entire
+/// katana temporary storage prefix in as many cases as possible.
+/// NB: it would be useful if this recursively deleted all files in all
+/// subdirectories (a 'rm -rf'-like operation).
+class EphemeralStoragePrefix {
+public:
+  ~EphemeralStoragePrefix() {
+    std::vector<std::string> files;
+    auto list_future = FileListAsync(prefix_.path(), &files);
+    if (!list_future.valid()) {
+      KATANA_LOG_WARN(
+          "unable to list files, not cleaning up ephemeral storage");
+      return;
+    }
+
+    auto list_future_res = list_future.get();
+    if (!list_future_res) {
+      KATANA_LOG_WARN(
+          "unable to list files, not cleaning up ephemeral storage: {}",
+          list_future_res.error());
+    }
+
+    std::unordered_set deletable_files(files.begin(), files.end());
+    auto delete_res = FileDelete(prefix_.path(), deletable_files);
+    if (!delete_res) {
+      KATANA_LOG_WARN(
+          "unable to delete files, not cleaning up ephemeral storage: {}",
+          delete_res.error());
+    }
+  }
+
+  static Result<std::unique_ptr<EphemeralStoragePrefix>> Make() {
+    auto tmp_prefix = KATANA_CHECKED(URI::MakeTempDir());
+    return std::unique_ptr<EphemeralStoragePrefix>(
+        new EphemeralStoragePrefix(tmp_prefix.RandSubdir("ephemeral")));
+  }
+
+  // there should be a single object associated with any one ephemeral storage
+  // prefix
+  EphemeralStoragePrefix(EphemeralStoragePrefix& no_copy) = delete;
+  EphemeralStoragePrefix& operator=(EphemeralStoragePrefix& no_copy) = delete;
+
+  EphemeralStoragePrefix(EphemeralStoragePrefix&& other) noexcept = default;
+  EphemeralStoragePrefix& operator=(EphemeralStoragePrefix&& other) noexcept =
+      default;
+
+  const URI& uri() { return prefix_; }
+
+private:
+  EphemeralStoragePrefix(URI prefix) : prefix_(std::move(prefix)) {}
+
+  URI prefix_;
+};
+
+}  // namespace katana
+
+#endif

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -3011,7 +3011,12 @@ struct Gr2Kg : public Conversion {
     }
 
     katana::GraphTopology topo{std::move(out_indices), std::move(out_dests)};
-    auto pg_res = katana::PropertyGraph::Make(std::move(topo));
+    auto rdg_dir_res = katana::URI::Make(out_file_name);
+    if (!rdg_dir_res) {
+      KATANA_LOG_FATAL("Failed to create PropertyGraph storage URI");
+    }
+    auto pg_res =
+        katana::PropertyGraph::Make(rdg_dir_res.value(), std::move(topo));
     if (!pg_res) {
       KATANA_LOG_FATAL("Failed to create PropertyGraph");
     }
@@ -3030,7 +3035,7 @@ struct Gr2Kg : public Conversion {
     katana::gPrint(
         "Node Schema : ", pg->loaded_node_schema()->ToString(), "\n");
 
-    if (auto r = pg->Write(out_file_name, "cmd", &txn_ctx); !r) {
+    if (auto r = pg->Commit("cmd", &txn_ctx); !r) {
       KATANA_LOG_FATAL("Failed to write property file graph: {}", r.error());
     }
     printStatus(graph.size(), graph.sizeEdges());


### PR DESCRIPTION
I propose (via PR) complicating both `RDG` and `PropertyGraph`. They can both now optionally be constructed as "ephemeral". An ephemeral graph is backed by a storage location that will be deleted when the in-memory graph goes out of scope. It cannot be committed to that location but it can be written to another location. An existing graph can not be made ephemeral but an ephemeral graph can be made non-ephemeral by writing it to a new location. This functionality is used in three primary places:
1. By users directly via the `katana.local.Graph` python class
2. By analytics functions like the clusterers that create `PropertyGraph`s on the fly as intermediate state
3. By tests