### PR TITLE
python: Set pytest asyncio mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,3 +346,4 @@ min-similarity-lines = 10
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--import-mode append"
+asyncio_mode = "strict"


### PR DESCRIPTION
Setting to some value avoids deprecation warnings like:

  DeprecationWarning: The 'asyncio_mode' default value will change to
  'strict' in future, please explicitly use 'asyncio_mode=strict' or
  'asyncio_mode=auto' in pytest configuration file.