### PR TITLE
build: move minimum cmake version to 3.22.3

### DIFF
--- a/conda_recipe/environment.yml
+++ b/conda_recipe/environment.yml
@@ -22,8 +22,7 @@ dependencies:
  - clang-tools>=10
  - clang-tools>=10
  - clangxx>=10
-   # the aws-sdk cmake is incompatible with version 3.22
- - cmake>=3.17,<3.22a0
+ - cmake>=3.22.3,<4a0
  - conda-build>=3
  - conda-verify>=3
  - coverage>=5.5

--- a/katana_requirements.yaml
+++ b/katana_requirements.yaml
@@ -106,13 +106,13 @@ breathe:
   labels:
     - conda/dev
 cmake:
-  version: [ 3.17, 4 ]
+  version: [ 3.22.3, 4 ]
   labels:
     - apt
     - conda/dev
   version_overrides:
-    conda/dev: ">=3.17,<3.22a0"
-    conda: ">=3.17,<3.22a0"
+    # This  is due to the fact that apt doesn't have a CMake 3.22.3 package available yet
+    apt: ">=3.22,<<4a0"
 conan:
   version: [ 1.40, null ]
   labels:


### PR DESCRIPTION
CMake 3.22.1 had an issue with the aws sdk. 3.22.3 is known to work with
that package so bump to 3.22.3.