### PR TITLE
Remove deprecated errors

### DIFF
--- a/libtsuba/include/katana/tsuba.h
+++ b/libtsuba/include/katana/tsuba.h
@@ -112,13 +112,6 @@ KATANA_EXPORT katana::Result<std::pair<uint64_t, std::vector<RDGView>>>
 ListViewsOfVersion(
     const std::string& rdg_dir, std::optional<uint64_t> version = std::nullopt);
 
-/// duplicate of ListViewsOfVersion maintained for compatibility
-[[deprecated("use ListViewsOfVersion() instead")]] KATANA_EXPORT
-    katana::Result<std::pair<uint64_t, std::vector<RDGView>>>
-    ListAvailableViews(
-        const std::string& rdg_dir,
-        std::optional<uint64_t> version = std::nullopt);
-
 KATANA_EXPORT katana::Result<std::vector<std::pair<katana::URI, katana::URI>>>
 CreateSrcDestFromViewsForCopy(
     const std::string& src_dir, const std::string& dst_dir, uint64_t version);

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -212,12 +212,6 @@ katana::ListViewsOfVersion(
   return std::make_pair(latest_version, views_found);
 }
 
-katana::Result<std::pair<uint64_t, std::vector<katana::RDGView>>>
-katana::ListAvailableViews(
-    const std::string& rdg_dir, std::optional<uint64_t> version) {
-  return ListViewsOfVersion(rdg_dir, version);
-}
-
 katana::Result<std::vector<std::pair<katana::URI, katana::URI>>>
 katana::CreateSrcDestFromViewsForCopy(
     const std::string& src_dir, const std::string& dst_dir, uint64_t version) {


### PR DESCRIPTION
~This time it's much more minimal. I plan on fully running all CI tests locally with the changes in [enterprise](https://github.com/KatanaGraph/katana-enterprise/pull/3527) before merging this one to avoid a debacle.~

I gave up on the arrow error. Went ahead and removed another deprecated function though. It's only called once in enterprise and I have a enterprise PR [here](https://github.com/KatanaGraph/katana-enterprise/pull/3527) that I'll merge first.