### PR TITLE
Use shared pointers to PropertyGraph in PropertyGraph views [KAT-3405]

### DIFF
--- a/libgraph/include/katana/TypedPropertyGraph.h
+++ b/libgraph/include/katana/TypedPropertyGraph.h
@@ -34,13 +34,14 @@ class TypedPropertyGraph {
   using NodeView = PropertyViewTuple<NodeProps>;
   using EdgeView = PropertyViewTuple<EdgeProps>;
 
-  PropertyGraph* pg_;
+  std::shared_ptr<PropertyGraph> pg_;
 
   NodeView node_view_;
   EdgeView edge_view_;
 
-  TypedPropertyGraph(PropertyGraph* pg, NodeView node_view, EdgeView edge_view)
-      : pg_(pg),
+  TypedPropertyGraph(
+      std::shared_ptr<PropertyGraph> pg, NodeView node_view, EdgeView edge_view)
+      : pg_(std::move(pg)),
         node_view_(std::move(node_view)),
         edge_view_(std::move(edge_view)) {}
 
@@ -181,10 +182,11 @@ public:
 
   // Graph constructors
   static Result<TypedPropertyGraph<NodeProps, EdgeProps>> Make(
-      PropertyGraph* pg, const std::vector<std::string>& node_properties,
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::vector<std::string>& node_properties,
       const std::vector<std::string>& edge_properties);
   static Result<TypedPropertyGraph<NodeProps, EdgeProps>> Make(
-      PropertyGraph* pg);
+      const std::shared_ptr<PropertyGraph>& pg);
 };
 
 template <typename PGView, typename NodeProps, typename EdgeProps>
@@ -286,10 +288,11 @@ public:
   }
 
   static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(
-      PropertyGraph* pg, const std::vector<std::string>& node_properties,
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::vector<std::string>& node_properties,
       const std::vector<std::string>& edge_properties);
   static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(
-      PropertyGraph* pg);
+      const std::shared_ptr<PropertyGraph>& pg);
   static Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>> Make(
       const PGView& pg_view, const std::vector<std::string>& node_properties,
       const std::vector<std::string>& edge_properties);
@@ -318,16 +321,17 @@ FindEdgeSortedByDest(
 template <typename NodeProps, typename EdgeProps>
 Result<TypedPropertyGraph<NodeProps, EdgeProps>>
 TypedPropertyGraph<NodeProps, EdgeProps>::Make(
-    PropertyGraph* pg, const std::vector<std::string>& node_properties,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::vector<std::string>& node_properties,
     const std::vector<std::string>& edge_properties) {
   auto node_view_result =
-      internal::MakeNodePropertyViews<NodeProps>(pg, node_properties);
+      internal::MakeNodePropertyViews<NodeProps>(pg.get(), node_properties);
   if (!node_view_result) {
     return node_view_result.error();
   }
 
   auto edge_view_result =
-      internal::MakeEdgePropertyViews<EdgeProps>(pg, edge_properties);
+      internal::MakeEdgePropertyViews<EdgeProps>(pg.get(), edge_properties);
   if (!edge_view_result) {
     return edge_view_result.error();
   }
@@ -339,7 +343,8 @@ TypedPropertyGraph<NodeProps, EdgeProps>::Make(
 
 template <typename NodeProps, typename EdgeProps>
 Result<TypedPropertyGraph<NodeProps, EdgeProps>>
-TypedPropertyGraph<NodeProps, EdgeProps>::Make(PropertyGraph* pg) {
+TypedPropertyGraph<NodeProps, EdgeProps>::Make(
+    const std::shared_ptr<PropertyGraph>& pg) {
   return TypedPropertyGraph<NodeProps, EdgeProps>::Make(
       pg, pg->loaded_node_schema()->field_names(),
       pg->loaded_edge_schema()->field_names());
@@ -348,22 +353,23 @@ TypedPropertyGraph<NodeProps, EdgeProps>::Make(PropertyGraph* pg) {
 template <typename PGView, typename NodeProps, typename EdgeProps>
 Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>>
 TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
-    PropertyGraph* pg, const std::vector<std::string>& node_properties,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::vector<std::string>& node_properties,
     const std::vector<std::string>& edge_properties) {
-  auto pg_view = pg->BuildView<PGView>();
   KATANA_LOG_DEBUG_ASSERT(pg);
   auto node_view_result =
-      internal::MakeNodePropertyViews<NodeProps>(pg, node_properties);
+      internal::MakeNodePropertyViews<NodeProps>(pg.get(), node_properties);
   if (!node_view_result) {
     return node_view_result.error();
   }
 
   auto edge_view_result =
-      internal::MakeEdgePropertyViews<EdgeProps>(pg, edge_properties);
+      internal::MakeEdgePropertyViews<EdgeProps>(pg.get(), edge_properties);
   if (!edge_view_result) {
     return edge_view_result.error();
   }
 
+  auto pg_view = pg->BuildView<PGView>();
   return TypedPropertyGraphView(
       pg_view, std::move(node_view_result.value()),
       std::move(edge_view_result.value()));
@@ -371,7 +377,8 @@ TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
 
 template <typename PGView, typename NodeProps, typename EdgeProps>
 Result<TypedPropertyGraphView<PGView, NodeProps, EdgeProps>>
-TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(PropertyGraph* pg) {
+TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
+    const std::shared_ptr<PropertyGraph>& pg) {
   auto pg_view = pg->BuildView<PGView>();
   return TypedPropertyGraphView<PGView, NodeProps, EdgeProps>::Make(
       pg_view, pg->loaded_node_schema()->field_names(),

--- a/libgraph/include/katana/analytics/ClusteringImplementationBase.h
+++ b/libgraph/include/katana/analytics/ClusteringImplementationBase.h
@@ -502,7 +502,8 @@ struct ClusteringImplementationBase {
  */
   template <typename GraphViewTy>
   static katana::Result<void> CopyEdgeProperty(
-      katana::PropertyGraph* pfg_from, katana::PropertyGraph* pfg_to,
+      const std::shared_ptr<katana::PropertyGraph>& pfg_from,
+      const std::shared_ptr<katana::PropertyGraph>& pfg_to,
       const std::string& new_edge_property_name, katana::TxnContext* txn_ctx) {
     // Remove the existing edge property
     if (pfg_to->HasEdgeProperty(new_edge_property_name)) {
@@ -548,7 +549,7 @@ struct ClusteringImplementationBase {
   template <
       typename NodeData, typename EdgeData, typename EdgeWeightType,
       typename CommunityIDType>
-  static katana::Result<std::unique_ptr<katana::PropertyGraph>> GraphCoarsening(
+  static katana::Result<std::shared_ptr<katana::PropertyGraph>> GraphCoarsening(
       const Graph& graph, katana::PropertyGraph* pfg_mutable,
       uint64_t num_unique_clusters,
       const std::vector<std::string>& temp_node_property_names,
@@ -686,7 +687,7 @@ struct ClusteringImplementationBase {
     if (!pfg_next_res) {
       return pfg_next_res.error();
     }
-    std::unique_ptr<katana::PropertyGraph> pfg_next =
+    std::shared_ptr<katana::PropertyGraph> pfg_next =
         std::move(pfg_next_res.value());
 
     if (auto result = pfg_next->ConstructNodeProperties<NodeData>(
@@ -701,7 +702,7 @@ struct ClusteringImplementationBase {
       return result.error();
     }
 
-    auto graph_result = Graph::Make(pfg_next.get());
+    auto graph_result = Graph::Make(pfg_next);
     if (!graph_result) {
       return graph_result.error();
     }
@@ -716,7 +717,7 @@ struct ClusteringImplementationBase {
         katana::no_stats());
 
     TimerGraphBuild.stop();
-    return std::unique_ptr<katana::PropertyGraph>(std::move(pfg_next));
+    return pfg_next;
   }
 
   /**

--- a/libgraph/include/katana/analytics/Utils.h
+++ b/libgraph/include/katana/analytics/Utils.h
@@ -117,7 +117,8 @@ KATANA_EXPORT void SplitStringByComma(
 template <typename EdgeWeightType>
 static katana::Result<void>
 AddDefaultEdgeWeight(
-    katana::PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const EdgeWeightType& default_val, katana::TxnContext* txn_ctx) {
   struct EdgeWt : public katana::PODProperty<EdgeWeightType> {};
   using EdgeData = std::tuple<EdgeWt>;
@@ -138,7 +139,7 @@ AddDefaultEdgeWeight(
       },
       katana::steal(), katana::loopname("SetDefaultWeight"));
   return katana::ResultSuccess();
+}
 
-}  // namespace katana::analytics
 }  // namespace katana::analytics
 #endif

--- a/libgraph/include/katana/analytics/betweenness_centrality/betweenness_centrality.h
+++ b/libgraph/include/katana/analytics/betweenness_centrality/betweenness_centrality.h
@@ -80,8 +80,8 @@ KATANA_EXPORT extern const BetweennessCentralitySources
 ///          nodes; if this is an int process that number of source nodes.
 /// @param plan
 KATANA_EXPORT Result<void> BetweennessCentrality(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const BetweennessCentralitySources& sources =
         kBetweennessCentralityAllNodes,
     BetweennessCentralityPlan plan = {});
@@ -102,7 +102,8 @@ struct KATANA_EXPORT BetweennessCentralityStatistics {
   void Print(std::ostream& os = std::cout);
 
   static katana::Result<BetweennessCentralityStatistics> Compute(
-      PropertyGraph* pg, const std::string& output_property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& output_property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/bfs/bfs.h
+++ b/libgraph/include/katana/analytics/bfs/bfs.h
@@ -76,7 +76,7 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Bfs(
-    PropertyGraph* pg, uint32_t start_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t start_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     BfsPlan algo = {});
 
@@ -85,7 +85,8 @@ KATANA_EXPORT Result<void> Bfs(
 /// @return a failure if the BFS results do not pass validation or if there is a
 ///     failure during checking.
 KATANA_EXPORT Result<void> BfsAssertValid(
-    PropertyGraph* pg, uint32_t source, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t source,
+    const std::string& property_name);
 
 /// Statistics about a graph that can be extracted from the results of BFS.
 struct KATANA_EXPORT BfsStatistics {
@@ -97,7 +98,8 @@ struct KATANA_EXPORT BfsStatistics {
 
   /// Compute the statistics of BFS results stored in property_name.
   static katana::Result<BfsStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/cdlp/cdlp.h
+++ b/libgraph/include/katana/analytics/cdlp/cdlp.h
@@ -98,9 +98,10 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Cdlp(
-    PropertyGraph* pg, const std::string& output_property_name,
-    size_t max_iterations, katana::TxnContext* txn_ctx,
-    const bool& is_symmetric = false, CdlpPlan plan = CdlpPlan());
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, size_t max_iterations,
+    katana::TxnContext* txn_ctx, const bool& is_symmetric = false,
+    CdlpPlan plan = CdlpPlan());
 
 /// TODO (Yasin): This Struct (Compute function) is now being used by louvain,
 /// cc, and cdlp, basically everything which is calculating communities. Explore
@@ -120,7 +121,8 @@ struct KATANA_EXPORT CdlpStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<CdlpStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/connected_components/connected_components.h
+++ b/libgraph/include/katana/analytics/connected_components/connected_components.h
@@ -158,12 +158,13 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> ConnectedComponents(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, const bool& is_symmetric = false,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    const bool& is_symmetric = false,
     ConnectedComponentsPlan plan = ConnectedComponentsPlan());
 
 KATANA_EXPORT Result<void> ConnectedComponentsAssertValid(
-    PropertyGraph* pg, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, const std::string& property_name);
 
 struct KATANA_EXPORT ConnectedComponentsStatistics {
   /// Total number of unique components in the graph.
@@ -179,7 +180,8 @@ struct KATANA_EXPORT ConnectedComponentsStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<ConnectedComponentsStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/independent_set/independent_set.h
+++ b/libgraph/include/katana/analytics/independent_set/independent_set.h
@@ -57,11 +57,12 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call. The created property has type uint8_t.
 KATANA_EXPORT Result<void> IndependentSet(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, IndependentSetPlan plan = {});
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    IndependentSetPlan plan = {});
 
 KATANA_EXPORT Result<void> IndependentSetAssertValid(
-    PropertyGraph* pg, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, const std::string& property_name);
 
 struct KATANA_EXPORT IndependentSetStatistics {
   /// The number of nodes in the independent set.
@@ -71,7 +72,8 @@ struct KATANA_EXPORT IndependentSetStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<IndependentSetStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/jaccard/jaccard.h
+++ b/libgraph/include/katana/analytics/jaccard/jaccard.h
@@ -58,12 +58,13 @@ using JaccardSimilarity = katana::PODProperty<double>;
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Jaccard(
-    PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     JaccardPlan plan = {});
 
 KATANA_EXPORT Result<void> JaccardAssertValid(
-    PropertyGraph* pg, uint32_t compare_node, const std::string& property_name);
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
+    const std::string& property_name);
 
 struct KATANA_EXPORT JaccardStatistics {
   /// The maximum similarity excluding the comparison node.
@@ -77,7 +78,7 @@ struct KATANA_EXPORT JaccardStatistics {
   void Print(std::ostream& os = std::cout);
 
   static katana::Result<JaccardStatistics> Compute(
-      katana::PropertyGraph* pg, uint32_t compare_node,
+      const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
       const std::string& property_name);
 };
 

--- a/libgraph/include/katana/analytics/k_core/k_core.h
+++ b/libgraph/include/katana/analytics/k_core/k_core.h
@@ -48,12 +48,12 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> KCore(
-    PropertyGraph* pg, uint32_t k_core_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric = false, KCorePlan plan = KCorePlan());
 
 KATANA_EXPORT Result<void> KCoreAssertValid(
-    PropertyGraph* pg, uint32_t k_core_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
     const std::string& property_name);
 
 struct KATANA_EXPORT KCoreStatistics {
@@ -64,7 +64,7 @@ struct KATANA_EXPORT KCoreStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<KCoreStatistics> Compute(
-      katana::PropertyGraph* pg, uint32_t k_core_number,
+      const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
       const std::string& property_name);
 };
 

--- a/libgraph/include/katana/analytics/k_shortest_paths/ksssp.h
+++ b/libgraph/include/katana/analytics/k_shortest_paths/ksssp.h
@@ -87,9 +87,10 @@ public:
 /// The algorithm and delta stepping
 /// parameter can be specified, but have reasonable defaults.
 KATANA_EXPORT Result<void> Ksssp(
-    katana::PropertyGraph* pg, const std::string& edge_weight_property_name,
-    size_t start_node, size_t report_node, size_t num_paths,
-    const bool& is_symmetric, katana::TxnContext* txn_ctx, KssspPlan plan = {});
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name, size_t start_node,
+    size_t report_node, size_t num_paths, const bool& is_symmetric,
+    katana::TxnContext* txn_ctx, KssspPlan plan = {});
 }  // namespace katana::analytics
 
 #endif

--- a/libgraph/include/katana/analytics/k_truss/k_truss.h
+++ b/libgraph/include/katana/analytics/k_truss/k_truss.h
@@ -50,11 +50,12 @@ public:
 ///
 /// @warning This algorithm will reorder nodes and edges in the graph.
 KATANA_EXPORT Result<void> KTruss(
-    katana::TxnContext* txn_ctx, PropertyGraph* pg, uint32_t k_truss_number,
-    const std::string& output_property_name, KTrussPlan plan = KTrussPlan());
+    katana::TxnContext* txn_ctx, const std::shared_ptr<katana::PropertyGraph>&,
+    uint32_t k_truss_number, const std::string& output_property_name,
+    KTrussPlan plan = KTrussPlan());
 
 KATANA_EXPORT Result<void> KTrussAssertValid(
-    PropertyGraph* pg, uint32_t k_truss_number,
+    const std::shared_ptr<katana::PropertyGraph>& pg, uint32_t k_truss_number,
     const std::string& property_name);
 
 struct KATANA_EXPORT KTrussStatistics {
@@ -65,7 +66,7 @@ struct KATANA_EXPORT KTrussStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<KTrussStatistics> Compute(
-      katana::PropertyGraph* pg, uint32_t k_truss_number,
+      const std::shared_ptr<katana::PropertyGraph>& pg, uint32_t k_truss_number,
       const std::string& property_name);
 };
 

--- a/libgraph/include/katana/analytics/leiden_clustering/leiden_clustering.h
+++ b/libgraph/include/katana/analytics/leiden_clustering/leiden_clustering.h
@@ -143,12 +143,14 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> LeidenClustering(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric = false, LeidenClusteringPlan plan = {});
 
 KATANA_EXPORT Result<void> LeidenClusteringAssertValid(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name);
 
 struct KATANA_EXPORT LeidenClusteringStatistics {
@@ -167,7 +169,8 @@ struct KATANA_EXPORT LeidenClusteringStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<LeidenClusteringStatistics> Compute(
-      PropertyGraph* pg, const std::string& edge_weight_property_name,
+      const std::shared_ptr<katana::PropertyGraph>& pg,
+      const std::string& edge_weight_property_name,
       const std::string& output_property_name, katana::TxnContext* txn_ctx);
 };
 

--- a/libgraph/include/katana/analytics/local_clustering_coefficient/local_clustering_coefficient.h
+++ b/libgraph/include/katana/analytics/local_clustering_coefficient/local_clustering_coefficient.h
@@ -82,8 +82,9 @@ public:
  * @warning This algorithm will reorder nodes and edges in the graph.
  */
 KATANA_EXPORT Result<void> LocalClusteringCoefficient(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, LocalClusteringCoefficientPlan plan = {});
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    LocalClusteringCoefficientPlan plan = {});
 
 }  // namespace katana::analytics
 

--- a/libgraph/include/katana/analytics/louvain_clustering/louvain_clustering.h
+++ b/libgraph/include/katana/analytics/louvain_clustering/louvain_clustering.h
@@ -120,12 +120,14 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> LouvainClustering(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric, LouvainClusteringPlan plan = {});
 
 KATANA_EXPORT Result<void> LouvainClusteringAssertValid(
-    PropertyGraph* pg, const std::string& edge_weight_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& edge_weight_property_name,
     const std::string& output_property_name);
 
 struct KATANA_EXPORT LouvainClusteringStatistics {
@@ -144,7 +146,8 @@ struct KATANA_EXPORT LouvainClusteringStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<LouvainClusteringStatistics> Compute(
-      PropertyGraph* pg, const std::string& edge_weight_property_name,
+      const std::shared_ptr<katana::PropertyGraph>& pg,
+      const std::string& edge_weight_property_name,
       const std::string& output_property_name, katana::TxnContext* txn_ctx);
 };
 

--- a/libgraph/include/katana/analytics/matrix_completion/matrix_completion.h
+++ b/libgraph/include/katana/analytics/matrix_completion/matrix_completion.h
@@ -129,8 +129,8 @@ public:
 /// an ArrayProperty.
 /// The plan controls the algorithm and parameters used to compute the latent vectors.
 KATANA_EXPORT Result<void> MatrixCompletion(
-    katana::PropertyGraph* pg, katana::TxnContext* txn_ctx,
-    MatrixCompletionPlan plan = {});
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    katana::TxnContext* txn_ctx, MatrixCompletionPlan plan = {});
 
 }  // namespace katana::analytics
 

--- a/libgraph/include/katana/analytics/pagerank/pagerank.h
+++ b/libgraph/include/katana/analytics/pagerank/pagerank.h
@@ -109,11 +109,13 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Pagerank(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, PagerankPlan plan = {});
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    PagerankPlan plan = {});
 
 KATANA_EXPORT Result<void> PagerankAssertValid(
-    PropertyGraph* pg, const std::string& property_name);
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name);
 
 struct KATANA_EXPORT PagerankStatistics {
   /// The maximum similarity excluding the comparison node.
@@ -127,7 +129,8 @@ struct KATANA_EXPORT PagerankStatistics {
   void Print(std::ostream& os = std::cout);
 
   static katana::Result<PagerankStatistics> Compute(
-      katana::PropertyGraph* pg, const std::string& property_name);
+      const std::shared_ptr<katana::PropertyGraph>& pg,
+      const std::string& property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/random_walks/random_walks.h
+++ b/libgraph/include/katana/analytics/random_walks/random_walks.h
@@ -138,9 +138,11 @@ public:
 /// parameters are used by the algorithms. The generated random-walks generated
 /// are returned as a vector of vectors.
 KATANA_EXPORT Result<std::vector<std::vector<uint32_t>>> RandomWalks(
-    PropertyGraph* pg, RandomWalksPlan plan = RandomWalksPlan());
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    RandomWalksPlan plan = RandomWalksPlan());
 
-KATANA_EXPORT Result<void> RandomWalksAssertValid(PropertyGraph* pg);
+KATANA_EXPORT Result<void> RandomWalksAssertValid(
+    const std::shared_ptr<katana::PropertyGraph>& pg);
 
 }  // namespace katana::analytics
 #endif

--- a/libgraph/include/katana/analytics/sssp/sssp.h
+++ b/libgraph/include/katana/analytics/sssp/sssp.h
@@ -122,13 +122,13 @@ public:
 /// The property named output_property_name is created by this function and may
 /// not exist before the call.
 KATANA_EXPORT Result<void> Sssp(
-    PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     SsspPlan plan = {});
 
 KATANA_EXPORT Result<void> SsspAssertValid(
-    PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx);
 
@@ -144,7 +144,8 @@ struct KATANA_EXPORT SsspStatistics {
   void Print(std::ostream& os = std::cout) const;
 
   static katana::Result<SsspStatistics> Compute(
-      PropertyGraph* pg, const std::string& output_property_name);
+      const std::shared_ptr<katana::PropertyGraph>& pg,
+      const std::string& output_property_name);
 };
 
 }  // namespace katana::analytics

--- a/libgraph/include/katana/analytics/subgraph_extraction/subgraph_extraction.h
+++ b/libgraph/include/katana/analytics/subgraph_extraction/subgraph_extraction.h
@@ -54,7 +54,7 @@ public:
  */
 KATANA_EXPORT katana::Result<std::unique_ptr<katana::PropertyGraph>>
 SubGraphExtraction(
-    katana::PropertyGraph* pg,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
     const std::vector<katana::PropertyGraph::Node>& node_vec,
     SubGraphExtractionPlan plan = {});
 // const std::vector<std::string>& node_properties_to_copy, const std::vector<std::string>& edge_properties_to_copy);

--- a/libgraph/include/katana/analytics/triangle_count/triangle_count.h
+++ b/libgraph/include/katana/analytics/triangle_count/triangle_count.h
@@ -102,7 +102,8 @@ public:
  * @param plan
  */
 KATANA_EXPORT katana::Result<uint64_t> TriangleCount(
-    PropertyGraph* pg, TriangleCountPlan plan = {});
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    TriangleCountPlan plan = {});
 
 }  // namespace katana::analytics
 

--- a/libgraph/src/analytics/betweenness_centrality/betweenness_centrality.cpp
+++ b/libgraph/src/analytics/betweenness_centrality/betweenness_centrality.cpp
@@ -27,8 +27,9 @@ const BetweennessCentralitySources
 
 katana::Result<void>
 katana::analytics::BetweennessCentrality(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, const BetweennessCentralitySources& sources,
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    const BetweennessCentralitySources& sources,
     BetweennessCentralityPlan plan) {
   switch (plan.algorithm()) {
     //TODO (gill) Needs bidirectional graph (CSR_CSC)
@@ -57,7 +58,8 @@ BetweennessCentralityStatistics::Print(std::ostream& os) {
 
 katana::Result<BetweennessCentralityStatistics>
 BetweennessCentralityStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& output_property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name) {
   auto values_result = pg->GetNodePropertyTyped<float>(output_property_name);
   if (!values_result) {
     return values_result.error();

--- a/libgraph/src/analytics/betweenness_centrality/betweenness_centrality_impl.h
+++ b/libgraph/src/analytics/betweenness_centrality/betweenness_centrality_impl.h
@@ -5,14 +5,14 @@
 #include "katana/analytics/betweenness_centrality/betweenness_centrality.h"
 
 katana::Result<void> BetweennessCentralityOuter(
-    katana::PropertyGraph* pg,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
     katana::analytics::BetweennessCentralitySources sources,
     const std::string& output_property_name,
     [[maybe_unused]] katana::analytics::BetweennessCentralityPlan plan,
     katana::TxnContext* txn_ctx);
 
 katana::Result<void> BetweennessCentralityLevel(
-    katana::PropertyGraph* pg,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
     katana::analytics::BetweennessCentralitySources sources,
     const std::string& output_property_name,
     katana::analytics::BetweennessCentralityPlan plan,

--- a/libgraph/src/analytics/betweenness_centrality/level.cpp
+++ b/libgraph/src/analytics/betweenness_centrality/level.cpp
@@ -216,7 +216,8 @@ LevelBackwardBrandes(
 //! property graph for use by stats/output verification
 katana::Result<void>
 ExtractBC(
-    katana::PropertyGraph* pg, const LevelGraph& array_of_struct_graph,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const LevelGraph& array_of_struct_graph,
     const BCLevelNodeDataArray& graph_data,
     const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   // construct the new property
@@ -246,7 +247,7 @@ ExtractBC(
 
 katana::Result<void>
 BetweennessCentralityLevel(
-    katana::PropertyGraph* pg,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
     katana::analytics::BetweennessCentralitySources sources,
     const std::string& output_property_name,
     katana::analytics::BetweennessCentralityPlan plan [[maybe_unused]],

--- a/libgraph/src/analytics/betweenness_centrality/outer.cpp
+++ b/libgraph/src/analytics/betweenness_centrality/outer.cpp
@@ -246,7 +246,8 @@ struct HasOut {
 
 katana::Result<void>
 BetweennessCentralityOuter(
-    katana::PropertyGraph* pg, BetweennessCentralitySources sources,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    BetweennessCentralitySources sources,
     const std::string& output_property_name,
     BetweennessCentralityPlan plan [[maybe_unused]],
     katana::TxnContext* txn_ctx) {

--- a/libgraph/src/analytics/bfs/bfs.cpp
+++ b/libgraph/src/analytics/bfs/bfs.cpp
@@ -451,25 +451,15 @@ BfsImpl(
 
 katana::Result<void>
 katana::analytics::Bfs(
-    PropertyGraph* pg, GNode start_node,
+    const std::shared_ptr<PropertyGraph>& pg, GNode start_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     BfsPlan algo) {
-  if (auto result = pg->ConstructNodeProperties<std::tuple<BfsNodeParent>>(
-          txn_ctx, {output_property_name});
-      !result) {
-    return result.error();
-  }
+  KATANA_CHECKED(pg->ConstructNodeProperties<std::tuple<BfsNodeParent>>(
+      txn_ctx, {output_property_name}));
 
   auto graph = KATANA_CHECKED(Graph::Make(pg, {output_property_name}, {}));
   auto bidir_view =
       KATANA_CHECKED(BiDirGraphView::Make(pg, {output_property_name}, {}));
-
-  /*
-  auto pg_result = Graph::Make(pg, {output_property_name}, {});
-  if (!pg_result) {
-    return pg_result.error();
-  }
-  */
 
   return BfsImpl(&graph, bidir_view, start_node, algo);
 }
@@ -610,7 +600,7 @@ CheckParentByLevel(
 
 katana::Result<void>
 katana::analytics::BfsAssertValid(
-    PropertyGraph* pg, const GNode source,
+    const std::shared_ptr<PropertyGraph>& pg, const GNode source,
     const std::string& output_property_name) {
   auto graph = KATANA_CHECKED(Graph::Make(pg, {output_property_name}, {}));
   auto bidir_view =
@@ -629,7 +619,8 @@ katana::analytics::BfsAssertValid(
 
 katana::Result<BfsStatistics>
 katana::analytics::BfsStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   auto pg_result = BfsImplementation::Graph::Make(pg, {property_name}, {});
   if (!pg_result) {
     return pg_result.error();

--- a/libgraph/src/analytics/cdlp/cdlp.cpp
+++ b/libgraph/src/analytics/cdlp/cdlp.cpp
@@ -136,7 +136,7 @@ struct CdlpAsynchronousAlgo : CdlpAlgo<GraphViewTy> {
 template <typename Algorithm>
 static katana::Result<void>
 CdlpWithWrap(
-    katana::PropertyGraph* pg, std::string output_property_name,
+    std::shared_ptr<katana::PropertyGraph> pg, std::string output_property_name,
     size_t max_iterations, katana::TxnContext* txn_ctx) {
   katana::EnsurePreallocated(
       2, pg->topology().NumNodes() * sizeof(typename Algorithm::NodeCommunity));
@@ -169,9 +169,9 @@ CdlpWithWrap(
 
 katana::Result<void>
 katana::analytics::Cdlp(
-    PropertyGraph* pg, const std::string& output_property_name,
-    size_t max_iterations, katana::TxnContext* txn_ctx,
-    const bool& is_symmetric, CdlpPlan plan) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, size_t max_iterations,
+    katana::TxnContext* txn_ctx, const bool& is_symmetric, CdlpPlan plan) {
   switch (plan.algorithm()) {
   case CdlpPlan::kSynchronous:
     if (is_symmetric)
@@ -200,7 +200,8 @@ katana::analytics::Cdlp(
 /// to avoid code duplication.
 katana::Result<CdlpStatistics>
 katana::analytics::CdlpStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   using CommunityType = uint64_t;
   struct NodeCommunity : public katana::PODProperty<CommunityType> {};
 

--- a/libgraph/src/analytics/connected_components/connected_components.cpp
+++ b/libgraph/src/analytics/connected_components/connected_components.cpp
@@ -1137,7 +1137,7 @@ struct ConnectedComponentsEdgeTiledAfforestAlgo {
 template <typename Algorithm>
 static katana::Result<void>
 ConnectedComponentsWithWrap(
-    katana::PropertyGraph* pg, std::string output_property_name,
+    std::shared_ptr<katana::PropertyGraph> pg, std::string output_property_name,
     katana::TxnContext* txn_ctx, ConnectedComponentsPlan plan) {
   katana::EnsurePreallocated(
       2, pg->topology().NumNodes() * sizeof(typename Algorithm::NodeComponent));
@@ -1173,8 +1173,9 @@ ConnectedComponentsWithWrap(
 template <typename GraphViewTy>
 katana::Result<void>
 ConnectedComponentsSelectAlgorithm(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, ConnectedComponentsPlan plan) {
+    std::shared_ptr<katana::PropertyGraph> pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    ConnectedComponentsPlan plan) {
   switch (plan.algorithm()) {
   case ConnectedComponentsPlan::kSerial:
     return ConnectedComponentsWithWrap<
@@ -1224,9 +1225,9 @@ ConnectedComponentsSelectAlgorithm(
 
 katana::Result<void>
 katana::analytics::ConnectedComponents(
-    PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, const bool& is_symmetric,
-    ConnectedComponentsPlan plan) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    const bool& is_symmetric, ConnectedComponentsPlan plan) {
   if (is_symmetric) {
     using GraphView = katana::PropertyGraphViews::Default;
     return ConnectedComponentsSelectAlgorithm<GraphView>(
@@ -1240,7 +1241,8 @@ katana::analytics::ConnectedComponents(
 
 katana::Result<void>
 katana::analytics::ConnectedComponentsAssertValid(
-    PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   using ComponentType = uint64_t;
   struct NodeComponent : public katana::PODProperty<ComponentType> {};
 
@@ -1284,7 +1286,8 @@ katana::analytics::ConnectedComponentsAssertValid(
 
 katana::Result<ConnectedComponentsStatistics>
 katana::analytics::ConnectedComponentsStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   using ComponentType = uint64_t;
   struct NodeComponent : public katana::PODProperty<ComponentType> {};
 

--- a/libgraph/src/analytics/independent_set/independent_set.cpp
+++ b/libgraph/src/analytics/independent_set/independent_set.cpp
@@ -599,8 +599,8 @@ struct IsBad {
 
 template <typename Algo>
 katana::Result<void>
-Run(katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx) {
+Run(const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   using Graph = typename Algo::Graph;
   using GNode = typename Graph::Node;
   auto result = pg->ConstructNodeProperties<typename Algo::NodeData>(
@@ -663,8 +663,9 @@ Run(katana::PropertyGraph* pg, const std::string& output_property_name,
 
 katana::Result<void>
 katana::analytics::IndependentSet(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, IndependentSetPlan plan) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    IndependentSetPlan plan) {
   switch (plan.algorithm()) {
   case IndependentSetPlan::kSerial:
     return Run<SerialAlgo>(pg, output_property_name, txn_ctx);
@@ -681,7 +682,8 @@ katana::analytics::IndependentSet(
 
 katana::Result<void>
 katana::analytics::IndependentSetAssertValid(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   auto pg_result =
       katana::TypedPropertyGraph<IsBad::NodeData, IsBad::EdgeData>::Make(
           pg, {property_name}, {});
@@ -706,7 +708,8 @@ katana::analytics::IndependentSetStatistics::Print(std::ostream& os) const {
 
 katana::Result<IndependentSetStatistics>
 katana::analytics::IndependentSetStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& property_name) {
   auto property_result = pg->GetNodePropertyTyped<uint8_t>(property_name);
   if (!property_result) {
     return property_result.error();

--- a/libgraph/src/analytics/jaccard/jaccard.cpp
+++ b/libgraph/src/analytics/jaccard/jaccard.cpp
@@ -138,7 +138,7 @@ JaccardImpl(Graph& graph, size_t compare_node, JaccardPlan /*plan*/) {
 
 katana::Result<void>
 katana::analytics::Jaccard(
-    PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     JaccardPlan plan) {
   if (auto result = pg->ConstructNodeProperties<NodeData>(
@@ -169,7 +169,7 @@ constexpr static const double EPSILON = 1e-6;
 
 katana::Result<void>
 katana::analytics::JaccardAssertValid(
-    katana::PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& property_name) {
   Graph graph = KATANA_CHECKED(Graph::Make(pg, {property_name}, {}));
   ;
@@ -196,7 +196,7 @@ katana::analytics::JaccardAssertValid(
 
 katana::Result<JaccardStatistics>
 katana::analytics::JaccardStatistics::Compute(
-    katana::PropertyGraph* pg, uint32_t compare_node,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t compare_node,
     const std::string& property_name) {
   Graph graph = KATANA_CHECKED(Graph::Make(pg, {property_name}, {}));
   ;

--- a/libgraph/src/analytics/k_core/k_core.cpp
+++ b/libgraph/src/analytics/k_core/k_core.cpp
@@ -227,7 +227,7 @@ KCoreImpl(GraphTy* graph, KCorePlan algo, uint32_t k_core_number) {
 
 katana::Result<void>
 katana::analytics::KCore(
-    katana::PropertyGraph* pg, uint32_t k_core_number,
+    const std::shared_ptr<PropertyGraph>& pg, uint32_t k_core_number,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     const bool& is_symmetric, KCorePlan plan) {
   katana::analytics::TemporaryPropertyGuard temporary_property{
@@ -271,7 +271,7 @@ katana::analytics::KCore(
 // TODO (gill) Add a validity routine.
 katana::Result<void>
 katana::analytics::KCoreAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg,
+    [[maybe_unused]] const std::shared_ptr<PropertyGraph>& pg,
     [[maybe_unused]] uint32_t k_core_number,
     [[maybe_unused]] const std::string& property_name) {
   return katana::ResultSuccess();
@@ -279,8 +279,8 @@ katana::analytics::KCoreAssertValid(
 
 katana::Result<KCoreStatistics>
 katana::analytics::KCoreStatistics::Compute(
-    katana::PropertyGraph* pg, [[maybe_unused]] uint32_t k_core_number,
-    const std::string& property_name) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    [[maybe_unused]] uint32_t k_core_number, const std::string& property_name) {
   using Graph =
       katana::TypedPropertyGraph<std::tuple<KCoreNodeAlive>, std::tuple<>>;
   using GNode = Graph::Node;

--- a/libgraph/src/analytics/k_shortest_paths/ksssp.cpp
+++ b/libgraph/src/analytics/k_shortest_paths/ksssp.cpp
@@ -442,9 +442,10 @@ KssspImpl(
 template <typename Weight>
 katana::Result<void>
 kSSSPWithWrap(
-    katana::PropertyGraph* pg, const std::string& edge_weight_property_name,
-    size_t start_node, size_t report_node, size_t num_paths,
-    const bool& is_symmetric, katana::TxnContext* txn_ctx, KssspPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& edge_weight_property_name, size_t start_node,
+    size_t report_node, size_t num_paths, const bool& is_symmetric,
+    katana::TxnContext* txn_ctx, KssspPlan plan) {
   static_assert(std::is_integral_v<Weight> || std::is_floating_point_v<Weight>);
 
   std::vector<TemporaryPropertyGuard> temp_node_properties(2);
@@ -496,9 +497,10 @@ kSSSPWithWrap(
  */
 katana::Result<void>
 katana::analytics::Ksssp(
-    katana::PropertyGraph* pg, const std::string& edge_weight_property_name,
-    size_t start_node, size_t report_node, size_t num_paths,
-    const bool& is_symmetric, katana::TxnContext* txn_ctx, KssspPlan plan) {
+    const std::shared_ptr<PropertyGraph>& pg,
+    const std::string& edge_weight_property_name, size_t start_node,
+    size_t report_node, size_t num_paths, const bool& is_symmetric,
+    katana::TxnContext* txn_ctx, KssspPlan plan) {
   if (!edge_weight_property_name.empty() &&
       !pg->HasEdgeProperty(edge_weight_property_name)) {
     return KATANA_ERROR(

--- a/libgraph/src/analytics/k_truss/k_truss.cpp
+++ b/libgraph/src/analytics/k_truss/k_truss.cpp
@@ -346,9 +346,9 @@ BSPCoreThenTrussAlgo(SortedGraphView* g, uint32_t k) {
 
 katana::Result<void>
 katana::analytics::KTruss(
-    katana::TxnContext* txn_ctx, katana::PropertyGraph* pg,
-    uint32_t k_truss_number, const std::string& output_property_name,
-    KTrussPlan plan) {
+    katana::TxnContext* txn_ctx,
+    const std::shared_ptr<katana::PropertyGraph>& pg, uint32_t k_truss_number,
+    const std::string& output_property_name, KTrussPlan plan) {
   katana::ReportPageAllocGuard page_alloc;
 
   KATANA_CHECKED(
@@ -380,7 +380,7 @@ katana::analytics::KTruss(
 // TODO (gill) Add a validity routine.
 katana::Result<void>
 katana::analytics::KTrussAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg,
+    [[maybe_unused]] const std::shared_ptr<katana::PropertyGraph>& pg,
     [[maybe_unused]] uint32_t k_truss_number,
     [[maybe_unused]] const std::string& property_name) {
   return katana::ResultSuccess();
@@ -388,7 +388,8 @@ katana::analytics::KTrussAssertValid(
 
 katana::Result<KTrussStatistics>
 katana::analytics::KTrussStatistics::Compute(
-    katana::PropertyGraph* pg, [[maybe_unused]] uint32_t k_truss_number,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    [[maybe_unused]] uint32_t k_truss_number,
     const std::string& property_name) {
   auto graph = KATANA_CHECKED(Graph::Make(pg, {}, {property_name}));
 

--- a/libgraph/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
+++ b/libgraph/src/analytics/local_clustering_coefficient/local_clustering_coefficient.cpp
@@ -242,8 +242,8 @@ struct LocalClusteringCoefficientPerThread {
 template <typename Algorithm>
 katana::Result<void>
 LocalClusteringCoefficientWithWrap(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   if (auto result = pg->ConstructNodeProperties<NodeData>(
           txn_ctx, {output_property_name});
       !result) {
@@ -258,8 +258,9 @@ LocalClusteringCoefficientWithWrap(
 
 katana::Result<void>
 katana::analytics::LocalClusteringCoefficient(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, LocalClusteringCoefficientPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    LocalClusteringCoefficientPlan plan) {
   katana::StatTimer timer_graph_read(
       "GraphReadingTime", "LocalClusteringCoefficient");
   katana::StatTimer timer_auto_algo(

--- a/libgraph/src/analytics/matrix_completion/matrix_completion.cpp
+++ b/libgraph/src/analytics/matrix_completion/matrix_completion.cpp
@@ -370,7 +370,7 @@ public:
 
 template <typename Algo>
 katana::Result<void>
-Run(katana::PropertyGraph* pg, MatrixCompletionPlan plan,
+Run(const std::shared_ptr<katana::PropertyGraph>& pg, MatrixCompletionPlan plan,
     katana::TxnContext* txn_ctx) {
   KATANA_CHECKED(pg->ConstructNodeProperties<NodeData>(txn_ctx));
   Graph graph = KATANA_CHECKED(Graph::Make(pg));
@@ -398,8 +398,8 @@ Run(katana::PropertyGraph* pg, MatrixCompletionPlan plan,
 
 katana::Result<void>
 katana::analytics::MatrixCompletion(
-    katana::PropertyGraph* pg, katana::TxnContext* txn_ctx,
-    MatrixCompletionPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    katana::TxnContext* txn_ctx, MatrixCompletionPlan plan) {
   switch (plan.algorithm()) {
   case MatrixCompletionPlan::kSGDByItems:
     return Run<SGDItemsAlgo>(pg, plan, txn_ctx);

--- a/libgraph/src/analytics/pagerank/pagerank-impl.h
+++ b/libgraph/src/analytics/pagerank/pagerank-impl.h
@@ -34,19 +34,23 @@ typedef float PRTy;
 using NodeValue = katana::PODProperty<PRTy>;
 
 katana::Result<void> PagerankPullTopological(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 katana::Result<void> PagerankPullResidual(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 katana::Result<void> PagerankPushAsynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 katana::Result<void> PagerankPushSynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx);
 
 #endif

--- a/libgraph/src/analytics/pagerank/pagerank-pull.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank-pull.cpp
@@ -300,7 +300,8 @@ ComputePRTopological(
 
 katana::Result<void>
 PagerankPullTopological(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   KATANA_CHECKED(pg->ConstructNodeProperties<std::tuple<NodeValue>>(
       txn_ctx, {output_property_name}));
@@ -322,7 +323,8 @@ PagerankPullTopological(
 
 katana::Result<void>
 PagerankPullResidual(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   KATANA_CHECKED(
       pg->ConstructNodeProperties<NodeData>(txn_ctx, {output_property_name}));

--- a/libgraph/src/analytics/pagerank/pagerank-push.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank-push.cpp
@@ -54,7 +54,8 @@ InitializeNodeResidual(
 
 katana::Result<void>
 PagerankPushAsynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   katana::EnsurePreallocated(5, 5 * pg->NumNodes() * sizeof(NodeData));
   katana::ReportPageAllocGuard page_alloc;
@@ -110,7 +111,8 @@ PagerankPushAsynchronous(
 
 katana::Result<void>
 PagerankPushSynchronous(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name,
     katana::analytics::PagerankPlan plan, katana::TxnContext* txn_ctx) {
   katana::EnsurePreallocated(5, 5 * pg->NumNodes() * sizeof(NodeData));
   katana::ReportPageAllocGuard page_alloc;

--- a/libgraph/src/analytics/pagerank/pagerank.cpp
+++ b/libgraph/src/analytics/pagerank/pagerank.cpp
@@ -22,8 +22,9 @@
 
 katana::Result<void>
 katana::analytics::Pagerank(
-    katana::PropertyGraph* pg, const std::string& output_property_name,
-    katana::TxnContext* txn_ctx, katana::analytics::PagerankPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name, katana::TxnContext* txn_ctx,
+    katana::analytics::PagerankPlan plan) {
   switch (plan.algorithm()) {
   case PagerankPlan::kPullResidual:
     return PagerankPullResidual(pg, output_property_name, plan, txn_ctx);
@@ -41,7 +42,7 @@ katana::analytics::Pagerank(
 /// \cond DO_NOT_DOCUMENT
 katana::Result<void>
 katana::analytics::PagerankAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg,
+    [[maybe_unused]] const std::shared_ptr<katana::PropertyGraph>& pg,
     [[maybe_unused]] const std::string& property_name) {
   // TODO(gill): This should have real checks. amp has no idea what to check.
   return katana::ResultSuccess();
@@ -57,7 +58,8 @@ katana::analytics::PagerankStatistics::Print(std::ostream& os) {
 
 katana::Result<katana::analytics::PagerankStatistics>
 katana::analytics::PagerankStatistics::Compute(
-    katana::PropertyGraph* pg, const std::string& property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& property_name) {
   auto graph_result =
       TypedPropertyGraph<std::tuple<NodeValue>, std::tuple<>>::Make(
           pg, {property_name}, {});

--- a/libgraph/src/analytics/random_walks/random_walks.cpp
+++ b/libgraph/src/analytics/random_walks/random_walks.cpp
@@ -504,7 +504,8 @@ RandomWalksWithWrap(
 }
 
 katana::Result<std::vector<std::vector<uint32_t>>>
-katana::analytics::RandomWalks(PropertyGraph* pg, RandomWalksPlan plan) {
+katana::analytics::RandomWalks(
+    const std::shared_ptr<katana::PropertyGraph>& pg, RandomWalksPlan plan) {
   switch (plan.algorithm()) {
   case RandomWalksPlan::kNode2Vec: {
     auto graph =
@@ -525,7 +526,7 @@ katana::analytics::RandomWalks(PropertyGraph* pg, RandomWalksPlan plan) {
 /// \cond DO_NOT_DOCUMENT
 katana::Result<void>
 katana::analytics::RandomWalksAssertValid(
-    [[maybe_unused]] katana::PropertyGraph* pg) {
+    [[maybe_unused]] const std::shared_ptr<katana::PropertyGraph>& pg) {
   // TODO(gill): This should have real checks.
   return katana::ResultSuccess();
 }

--- a/libgraph/src/analytics/sssp/sssp.cpp
+++ b/libgraph/src/analytics/sssp/sssp.cpp
@@ -514,7 +514,7 @@ Sssp(
 template <typename Weight>
 static katana::Result<void>
 SSSPWithWrap(
-    katana::PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, SsspPlan plan,
     katana::TxnContext* txn_ctx) {
@@ -545,7 +545,7 @@ SSSPWithWrap(
 
 katana::Result<void>
 katana::analytics::Sssp(
-    PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx,
     SsspPlan plan) {
@@ -609,7 +609,7 @@ namespace {
 template <typename Weight>
 static katana::Result<void>
 SsspValidateImpl(
-    katana::PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name) {
   using Impl = SsspImplementation<Weight>;
@@ -642,7 +642,7 @@ SsspValidateImpl(
 
 katana::Result<void>
 katana::analytics::SsspAssertValid(
-    katana::PropertyGraph* pg, size_t start_node,
+    const std::shared_ptr<katana::PropertyGraph>& pg, size_t start_node,
     const std::string& edge_weight_property_name,
     const std::string& output_property_name, katana::TxnContext* txn_ctx) {
   if (!edge_weight_property_name.empty() &&
@@ -698,7 +698,8 @@ namespace {
 template <typename Weight>
 static katana::Result<SsspStatistics>
 ComputeStatistics(
-    katana::PropertyGraph* pg, const std::string& output_property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name) {
   auto pg_result = katana::TypedPropertyGraph<
       typename SsspImplementation<Weight>::NodeData,
       std::tuple<>>::Make(pg, {output_property_name}, {});
@@ -736,7 +737,8 @@ ComputeStatistics(
 
 katana::Result<SsspStatistics>
 SsspStatistics::Compute(
-    PropertyGraph* pg, const std::string& output_property_name) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::string& output_property_name) {
   switch (
       KATANA_CHECKED(pg->GetNodeProperty(output_property_name))->type()->id()) {
   case arrow::UInt32Type::type_id:

--- a/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
+++ b/libgraph/src/analytics/subgraph_extraction/subgraph_extraction.cpp
@@ -94,8 +94,8 @@ SubGraphNodeSet(
 
 katana::Result<std::unique_ptr<katana::PropertyGraph>>
 katana::analytics::SubGraphExtraction(
-    katana::PropertyGraph* pg, const std::vector<Node>& node_vec,
-    SubGraphExtractionPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg,
+    const std::vector<Node>& node_vec, SubGraphExtractionPlan plan) {
   // Remove duplicates from the node vector
   std::unordered_set<uint32_t> set;
   std::vector<uint32_t> dedup_node_vec;

--- a/libgraph/src/analytics/triangle_count/triangle_count.cpp
+++ b/libgraph/src/analytics/triangle_count/triangle_count.cpp
@@ -268,7 +268,7 @@ EdgeIteratingAlgo(const SortedGraphView* graph) {
 
 katana::Result<uint64_t>
 katana::analytics::TriangleCount(
-    katana::PropertyGraph* pg, TriangleCountPlan plan) {
+    const std::shared_ptr<katana::PropertyGraph>& pg, TriangleCountPlan plan) {
   katana::StatTimer timer_graph_read("GraphReadingTime", "TriangleCount");
   katana::StatTimer timer_auto_algo("AutoRelabel", "TriangleCount");
 

--- a/libgraph/test/TestTypedPropertyGraph.h
+++ b/libgraph/test/TestTypedPropertyGraph.h
@@ -63,7 +63,7 @@ public:
 ///
 /// \tparam ValueType is the type of column data
 template <typename ValueType>
-std::unique_ptr<katana::PropertyGraph>
+std::shared_ptr<katana::PropertyGraph>
 MakeFileGraph(
     size_t num_nodes, size_t num_properties, Policy* policy,
     katana::TxnContext* txn_ctx) {
@@ -83,7 +83,7 @@ MakeFileGraph(
   auto g_res = katana::PropertyGraph::Make(std::move(topo));
   KATANA_LOG_ASSERT(g_res);
 
-  std::unique_ptr<katana::PropertyGraph> g = std::move(g_res.value());
+  std::shared_ptr<katana::PropertyGraph> g = std::move(g_res.value());
 
   size_t num_edges = dests.size();
 

--- a/libgraph/test/property-graph-bench.cpp
+++ b/libgraph/test/property-graph-bench.cpp
@@ -68,7 +68,8 @@ struct PropertyTuple<10> {
 
 template <size_t num_properties>
 void
-IterateProperty(benchmark::State& state, katana::PropertyGraph* g) {
+IterateProperty(
+    benchmark::State& state, const std::shared_ptr<katana::PropertyGraph>& g) {
   using P = typename PropertyTuple<num_properties>::type;
 
   auto r = katana::TypedPropertyGraph<P, P>::Make(g);
@@ -95,18 +96,18 @@ IterateProperty(benchmark::State& state) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, num_properties, &policy, &txn_ctx);
 
   switch (num_properties) {
   case 1:
-    return IterateProperty<1>(state, g.get());
+    return IterateProperty<1>(state, g);
   case 4:
-    return IterateProperty<4>(state, g.get());
+    return IterateProperty<4>(state, g);
   case 7:
-    return IterateProperty<7>(state, g.get());
+    return IterateProperty<7>(state, g);
   case 10:
-    return IterateProperty<10>(state, g.get());
+    return IterateProperty<10>(state, g);
   default:
     KATANA_LOG_FATAL("unexpected number of properties: {}", num_properties);
   }
@@ -121,7 +122,7 @@ IterateBaseline(benchmark::State& state) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, num_properties, &policy, &txn_ctx);
 
   for (auto _ : state) {

--- a/libgraph/test/property-graph-optional-topology-generation.cpp
+++ b/libgraph/test/property-graph-optional-topology-generation.cpp
@@ -26,12 +26,12 @@ TestOptionalTopologyGenerationEdgeShuffleTopology(const katana::URI& rdg_dir) {
   KATANA_LOG_DEBUG("##### Testing EdgeShuffleTopology Generation #####");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(rdg_dir);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(rdg_dir);
 
   // Build a EdgeSortedByDestID view, which uses GraphTopology EdgeShuffleTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgesSortedByDestID;
 
-  pg.BuildView<SortedGraphView>();
+  pg->BuildView<SortedGraphView>();
 }
 
 void
@@ -39,13 +39,13 @@ TestOptionalTopologyGenerationShuffleTopology(const katana::URI& rdg_dir) {
   KATANA_LOG_DEBUG("##### Testing ShuffleTopology Generation #####");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(rdg_dir);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(rdg_dir);
 
   // Build a NodesSortedByDegreeEdgesSortedByDestID view, which uses GraphTopology ShuffleTopology in the background
   using SortedGraphView =
       katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID;
 
-  pg.BuildView<SortedGraphView>();
+  pg->BuildView<SortedGraphView>();
 }
 
 void
@@ -54,12 +54,12 @@ TestOptionalTopologyGenerationEdgeTypeAwareTopology(
   KATANA_LOG_DEBUG("##### Testing EdgeTypeAware Topology Generation ######");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(rdg_dir);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(rdg_dir);
 
   // Build a EdgeTypeAwareBiDir view, which uses GraphTopology EdgeTypeAwareTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgeTypeAwareBiDir;
 
-  pg.BuildView<SortedGraphView>();
+  pg->BuildView<SortedGraphView>();
 }
 
 int

--- a/libgraph/test/property-graph-transposed-view.cpp
+++ b/libgraph/test/property-graph-transposed-view.cpp
@@ -22,7 +22,8 @@ TestTransposedView() {
     builder_tr.AddEdge(n2, n1);
   }
 
-  auto pg = KATANA_CHECKED(PropertyGraph::Make(builder.ConvertToCSR()));
+  auto pg = std::shared_ptr<katana::PropertyGraph>(
+      KATANA_CHECKED(PropertyGraph::Make(builder.ConvertToCSR())));
   TransposedGraphView pg_tr_view = pg->BuildView<TransposedGraphView>();
 
   auto pg_tr = KATANA_CHECKED(PropertyGraph::Make(builder_tr.ConvertToCSR()));

--- a/libgraph/test/property-graph-undirected-view.cpp
+++ b/libgraph/test/property-graph-undirected-view.cpp
@@ -8,7 +8,7 @@ struct NodeLabel : public katana::PODProperty<uint32_t> {};
 struct DegreeSum : public katana::PODProperty<uint32_t> {};
 
 void
-TestDegreeSum(std::unique_ptr<katana::PropertyGraph>&& pg) noexcept {
+TestDegreeSum(const std::shared_ptr<katana::PropertyGraph>& pg) noexcept {
   katana::TxnContext txn_ctx;
   katana::Result<void> res = katana::AddNodeProperties(
       pg.get(), &txn_ctx,
@@ -28,7 +28,7 @@ TestDegreeSum(std::unique_ptr<katana::PropertyGraph>&& pg) noexcept {
   using Node = UndirectedView::Node;
   using Edge = UndirectedView::Edge;
 
-  auto view_res = UndirectedView::Make(pg.get(), {"label", "deg_sum"}, {});
+  auto view_res = UndirectedView::Make(pg, {"label", "deg_sum"}, {});
   KATANA_LOG_VASSERT(
       view_res, "Failed to create Undirected View. Error msg: {}",
       view_res.error());

--- a/libgraph/test/property-graph.cpp
+++ b/libgraph/test/property-graph.cpp
@@ -35,10 +35,10 @@ TestIterate1(size_t num_nodes, size_t line_width) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, num_properties, &policy, &txn_ctx);
 
-  auto r = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(g.get());
+  auto r = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(g);
   if (!r) {
     KATANA_LOG_FATAL("could not make property graph: {}", r.error());
   }
@@ -66,10 +66,10 @@ TestIterate3(size_t num_nodes, size_t line_width) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, num_properties, &policy, &txn_ctx);
 
-  auto r = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(g.get());
+  auto r = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(g);
   if (!r) {
     KATANA_LOG_FATAL("could not make property graph: {}", r.error());
   }
@@ -93,11 +93,11 @@ TestIterate4(size_t num_nodes, size_t line_width) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, 5, &policy, &txn_ctx);
 
   auto r = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(
-      g.get(), {"1", "3"}, {"0", "4"});
+      g, {"1", "3"}, {"0", "4"});
   if (!r) {
     KATANA_LOG_FATAL("could not make property graph: {}", r.error());
   }
@@ -119,17 +119,17 @@ TestError1(size_t num_nodes, size_t line_width) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, 5, &policy, &txn_ctx);
 
   auto r1 = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(
-      g.get(), {"1", "3"}, {"0", "noexist"});
+      g, {"1", "3"}, {"0", "noexist"});
   KATANA_LOG_VASSERT(
       r1.error() == katana::ErrorCode::PropertyNotFound,
       "Should return PropertyNotFound when edge property doesn't exist.");
 
   auto r2 = katana::TypedPropertyGraph<NodeType, EdgeType>::Make(
-      g.get(), {"noexist", "3"}, {"0", "2"});
+      g, {"noexist", "3"}, {"0", "2"});
   KATANA_LOG_VASSERT(
       r2.error() == katana::ErrorCode::PropertyNotFound,
       "Should return PropertyNotFound when node property doesn't exist.");

--- a/libgraph/test/property-index.cpp
+++ b/libgraph/test/property-index.cpp
@@ -143,7 +143,7 @@ TestPrimitiveIndex(size_t num_nodes, size_t line_width) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<DataType>(num_nodes, 0, &policy, &txn_ctx);
 
   std::shared_ptr<arrow::Table> uniform_prop =
@@ -215,7 +215,7 @@ TestStringIndex(size_t num_nodes, size_t line_width) {
 
   katana::TxnContext txn_ctx;
 
-  std::unique_ptr<katana::PropertyGraph> g =
+  std::shared_ptr<katana::PropertyGraph> g =
       MakeFileGraph<int>(num_nodes, 0, &policy, &txn_ctx);
 
   std::shared_ptr<arrow::Table> uniform_prop = CreateStringProperty(

--- a/libgraph/test/storage-format-version-entity-type-ids.h
+++ b/libgraph/test/storage-format-version-entity-type-ids.h
@@ -139,20 +139,21 @@ TestConvertGraphStorageFormat(const katana::URI& input_rdg) {
 
   katana::TxnContext txn_ctx;
 
-  katana::PropertyGraph g = LoadGraph(input_rdg);
+  std::shared_ptr<katana::PropertyGraph> g = LoadGraph(input_rdg);
   ValidateLDBC003EntityTypeManagers(
-      g.GetNodeTypeManager(), g.GetEdgeTypeManager());
+      g->GetNodeTypeManager(), g->GetEdgeTypeManager());
 
-  auto g2_rdg_file = StoreGraph(&g);
-  katana::PropertyGraph g2 = LoadGraph(g2_rdg_file);
+  auto g2_rdg_file = StoreGraph(g.get());
+  std::shared_ptr<katana::PropertyGraph> g2 = LoadGraph(g2_rdg_file);
+
   ValidateLDBC003EntityTypeManagers(
-      g2.GetNodeTypeManager(), g2.GetEdgeTypeManager());
+      g2->GetNodeTypeManager(), g2->GetEdgeTypeManager());
 
   // This takes ~20 seconds
-  KATANA_LOG_WARN("{}", g.ReportDiff(&g2));
+  KATANA_LOG_WARN("{}", g->ReportDiff(g2.get()));
 
   // Equals takes over a minute
-  KATANA_LOG_ASSERT(g.Equals(&g2));
+  KATANA_LOG_ASSERT(g->Equals(g2.get()));
 }
 
 void
@@ -173,25 +174,27 @@ TestRoundTripNewStorageFormat(const katana::URI& input_rdg) {
   katana::TxnContext txn_ctx;
 
   // first cycle converts old->new
-  katana::PropertyGraph g = LoadGraph(input_rdg);
+  std::shared_ptr<katana::PropertyGraph> g = LoadGraph(input_rdg);
   ValidateLDBC003EntityTypeManagers(
-      g.GetNodeTypeManager(), g.GetEdgeTypeManager());
+      g->GetNodeTypeManager(), g->GetEdgeTypeManager());
 
-  auto g2_rdg_file = StoreGraph(&g);
-  katana::PropertyGraph g2 = LoadGraph(g2_rdg_file);
+  auto g2_rdg_file = StoreGraph(g.get());
+  std::shared_ptr<katana::PropertyGraph> g2 = LoadGraph(g2_rdg_file);
+
   ValidateLDBC003EntityTypeManagers(
-      g2.GetNodeTypeManager(), g2.GetEdgeTypeManager());
+      g2->GetNodeTypeManager(), g2->GetEdgeTypeManager());
 
   // second cycle doesn't do any conversion, but tests storing/loading a "new format" graph
-  auto g3_rdg_file = StoreGraph(&g2);
-  katana::PropertyGraph g3 = LoadGraph(g3_rdg_file);
+  auto g3_rdg_file = StoreGraph(g2.get());
+  std::shared_ptr<katana::PropertyGraph> g3 = LoadGraph(g3_rdg_file);
+
   ValidateLDBC003EntityTypeManagers(
-      g3.GetNodeTypeManager(), g3.GetEdgeTypeManager());
+      g3->GetNodeTypeManager(), g3->GetEdgeTypeManager());
 
   // This takes ~20 seconds
-  KATANA_LOG_WARN("{}", g.ReportDiff(&g3));
+  KATANA_LOG_WARN("{}", g->ReportDiff(g3.get()));
   // Equals takes over a minute
-  KATANA_LOG_ASSERT(g.Equals(&g3));
+  KATANA_LOG_ASSERT(g->Equals(g3.get()));
 }
 
 #endif

--- a/libgraph/test/storage-format-version-optional-topologies.h
+++ b/libgraph/test/storage-format-version-optional-topologies.h
@@ -35,19 +35,19 @@ TestOptionalTopologyStorageEdgeShuffleTopology(const katana::URI& inputFile) {
   KATANA_LOG_WARN("***** Testing EdgeShuffleTopology *****");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(inputFile);
 
   // Build a EdgeSortedByDestID view, which uses GraphTopology EdgeShuffleTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgesSortedByDestID;
 
-  SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
+  SortedGraphView generated_sorted_view = pg->BuildView<SortedGraphView>();
   // TODO: ensure this view was generated, not loaded
   // generated_sorted_view.Print();
 
-  auto g2_rdg_file = StoreGraph(&pg);
-  katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file);
+  auto g2_rdg_file = StoreGraph(pg.get());
+  std::shared_ptr<katana::PropertyGraph> pg2 = LoadGraph(g2_rdg_file);
 
-  SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
+  SortedGraphView loaded_sorted_view = pg2->BuildView<SortedGraphView>();
 
   //TODO: emcginnis need some way to verify we loaded this view, vs just generating it again
 
@@ -59,20 +59,20 @@ TestOptionalTopologyStorageShuffleTopology(const katana::URI& inputFile) {
   KATANA_LOG_WARN("***** Testing ShuffleTopology *****");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(inputFile);
 
   // Build a NodesSortedByDegreeEdgesSortedByDestID view, which uses GraphTopology ShuffleTopology in the background
   using SortedGraphView =
       katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID;
 
-  SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
+  SortedGraphView generated_sorted_view = pg->BuildView<SortedGraphView>();
   // TODO: ensure this view was generated, not loaded
   // generated_sorted_view.Print();
 
-  auto g2_rdg_file = StoreGraph(&pg);
-  katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file);
+  auto g2_rdg_file = StoreGraph(pg.get());
+  std::shared_ptr<katana::PropertyGraph> pg2 = LoadGraph(g2_rdg_file);
 
-  SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
+  SortedGraphView loaded_sorted_view = pg2->BuildView<SortedGraphView>();
 
   //TODO: emcginnis need some way to verify we loaded this view, vs just generating it again
 
@@ -84,18 +84,18 @@ TestOptionalTopologyStorageEdgeTypeAwareTopology(const katana::URI& inputFile) {
   KATANA_LOG_WARN("***** Testing EdgeTypeAware Topology *****");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(inputFile);
 
   // Build a EdgeTypeAwareBiDir view, which uses GraphTopology EdgeTypeAwareTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgeTypeAwareBiDir;
 
-  SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
+  SortedGraphView generated_sorted_view = pg->BuildView<SortedGraphView>();
   // generated_sorted_view.Print();
 
-  auto g2_rdg_file = StoreGraph(&pg);
-  katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file);
+  auto g2_rdg_file = StoreGraph(pg.get());
+  std::shared_ptr<katana::PropertyGraph> pg2 = LoadGraph(g2_rdg_file);
 
-  SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
+  SortedGraphView loaded_sorted_view = pg2->BuildView<SortedGraphView>();
 
   //TODO: emcginnis need some way to verify we loaded this view, vs just generating it again
 

--- a/libgraph/test/storage-format-version.h
+++ b/libgraph/test/storage-format-version.h
@@ -4,7 +4,7 @@
 #include "katana/Logging.h"
 #include "katana/PropertyGraph.h"
 
-katana::PropertyGraph
+std::shared_ptr<katana::PropertyGraph>
 LoadGraph(const katana::URI& rdg_file) {
   KATANA_LOG_ASSERT(!rdg_file.empty());
   katana::TxnContext txn_ctx;
@@ -14,8 +14,7 @@ LoadGraph(const katana::URI& rdg_file) {
   if (!g_res) {
     KATANA_LOG_FATAL("making result: {}", g_res.error());
   }
-  katana::PropertyGraph g = std::move(*g_res.value());
-  return g;
+  return {std::move(g_res.value())};
 }
 
 katana::URI

--- a/libgraph/test/transformation-view-optional-topology.cpp
+++ b/libgraph/test/transformation-view-optional-topology.cpp
@@ -39,34 +39,37 @@ SplitString(std::string& str, std::vector<std::string>* vec) {
 }
 
 void
-TestOptionalTopologyGenerationEdgeShuffleTopology(katana::PropertyGraph& pg) {
+TestOptionalTopologyGenerationEdgeShuffleTopology(
+    std::shared_ptr<katana::PropertyGraph>& pg) {
   KATANA_LOG_DEBUG("##### Testing EdgeShuffleTopology Generation #####");
 
   // Build a EdgeSortedByDestID view, which uses GraphTopology EdgeShuffleTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgesSortedByDestID;
 
-  pg.BuildView<SortedGraphView>();
+  pg->BuildView<SortedGraphView>();
 }
 
 void
-TestOptionalTopologyGenerationShuffleTopology(katana::PropertyGraph& pg) {
+TestOptionalTopologyGenerationShuffleTopology(
+    std::shared_ptr<katana::PropertyGraph>& pg) {
   KATANA_LOG_DEBUG("##### Testing ShuffleTopology Generation #####");
 
   // Build a NodesSortedByDegreeEdgesSortedByDestID view, which uses GraphTopology ShuffleTopology in the background
   using SortedGraphView =
       katana::PropertyGraphViews::NodesSortedByDegreeEdgesSortedByDestID;
 
-  pg.BuildView<SortedGraphView>();
+  pg->BuildView<SortedGraphView>();
 }
 
 void
-TestOptionalTopologyGenerationEdgeTypeAwareTopology(katana::PropertyGraph& pg) {
+TestOptionalTopologyGenerationEdgeTypeAwareTopology(
+    std::shared_ptr<katana::PropertyGraph>& pg) {
   KATANA_LOG_DEBUG("##### Testing EdgeTypeAware Topology Generation ######");
 
   // Build a EdgeTypeAwareBiDir view, which uses GraphTopology EdgeTypeAwareTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgeTypeAwareBiDir;
 
-  pg.BuildView<SortedGraphView>();
+  pg->BuildView<SortedGraphView>();
 }
 
 int
@@ -80,7 +83,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  katana::PropertyGraph pg = LoadGraph(inputURI);
+  std::shared_ptr<katana::PropertyGraph> pg = LoadGraph(inputURI);
 
   std::vector<std::string> node_types;
   SplitString(nodeTypes, &node_types);
@@ -94,10 +97,11 @@ main(int argc, char** argv) {
   if (!pg_view_res) {
     KATANA_LOG_FATAL("Failed to construct projection: {}", pg_view_res.error());
   }
-  auto pg_view = std::move(pg_view_res.value());
+  std::shared_ptr<katana::PropertyGraph> pg_view =
+      std::move(pg_view_res.value());
 
-  TestOptionalTopologyGenerationEdgeShuffleTopology(*pg_view);
-  TestOptionalTopologyGenerationShuffleTopology(*pg_view);
-  TestOptionalTopologyGenerationEdgeTypeAwareTopology(*pg_view);
+  TestOptionalTopologyGenerationEdgeShuffleTopology(pg_view);
+  TestOptionalTopologyGenerationShuffleTopology(pg_view);
+  TestOptionalTopologyGenerationEdgeTypeAwareTopology(pg_view);
   return 0;
 }

--- a/libgraph/test/verify-cdlp.cpp
+++ b/libgraph/test/verify-cdlp.cpp
@@ -6,17 +6,17 @@ using namespace katana::analytics;
 
 void
 RunCdlp(
-    std::unique_ptr<katana::PropertyGraph>&& pg, const bool& is_symmetric,
+    const std::shared_ptr<katana::PropertyGraph>& pg, const bool& is_symmetric,
     const CdlpStatistics cdlp_expected_statistics) noexcept {
   using Plan = CdlpPlan;
   Plan plan = Plan::Synchronous();
   const std::string property_name = "community";
 
   katana::TxnContext txn_ctx;
-  auto cdlp = Cdlp(pg.get(), property_name, 10, &txn_ctx, is_symmetric, plan);
+  auto cdlp = Cdlp(pg, property_name, 10, &txn_ctx, is_symmetric, plan);
   KATANA_LOG_VASSERT(cdlp, " CDLP failed and returned error {}", cdlp.error());
 
-  auto stats_result = CdlpStatistics::Compute(pg.get(), property_name);
+  auto stats_result = CdlpStatistics::Compute(pg, property_name);
   KATANA_LOG_VASSERT(
       stats_result, "Failed to compute Cdlp statistics: {}",
       stats_result.error());

--- a/libgraph/test/verify-triangle-counting.cpp
+++ b/libgraph/test/verify-triangle-counting.cpp
@@ -4,7 +4,7 @@
 
 void
 RunTriCount(
-    std::unique_ptr<katana::PropertyGraph>&& pg,
+    const std::shared_ptr<katana::PropertyGraph>& pg,
     const size_t num_expected_triangles) noexcept {
   using Plan = katana::analytics::TriangleCountPlan;
   std::vector<Plan> plans{
@@ -12,8 +12,7 @@ RunTriCount(
       Plan::OrderedCount(Plan::kRelabel)};
 
   for (const auto& p : plans) {
-    katana::Result<size_t> num_tri =
-        katana::analytics::TriangleCount(pg.get(), p);
+    katana::Result<size_t> num_tri = katana::analytics::TriangleCount(pg, p);
     KATANA_LOG_VASSERT(num_tri, "TriangleCount failed and returned error");
     KATANA_LOG_VASSERT(
         num_tri.value() == num_expected_triangles,

--- a/libkatana_python_native/src/PropertyGraph.cpp
+++ b/libkatana_python_native/src/PropertyGraph.cpp
@@ -127,7 +127,7 @@ class GraphBaseEdgeSourceAccessor final
 public:
   virtual ~GraphBaseEdgeSourceAccessor();
 
-  GraphBaseEdgeSourceAccessor(katana::PropertyGraph* pg)
+  GraphBaseEdgeSourceAccessor(std::shared_ptr<katana::PropertyGraph> pg)
       : view_(pg->BuildView<katana::PropertyGraphViews::BiDirectional>()) {}
 
   katana::PropertyGraph::Node at_typed(ssize_t i) const final {
@@ -402,12 +402,12 @@ DefPropertyGraph(py::module& m) {
 
   cls.def(
       "project",
-      [](PropertyGraph& self, py::object node_types,
+      [](std::shared_ptr<PropertyGraph> self, py::object node_types,
          py::object edge_types) -> std::shared_ptr<PropertyGraph> {
         std::optional<katana::SetOfEntityTypeIDs> node_type_ids;
         if (!node_types.is_none()) {
           node_type_ids = katana::SetOfEntityTypeIDs();
-          node_type_ids->resize(self.GetNodeTypeManager().GetNumEntityTypes());
+          node_type_ids->resize(self->GetNodeTypeManager().GetNumEntityTypes());
           for (auto& t : node_types) {
             node_type_ids->set(py::cast<EntityType>(t).type_id);
           }
@@ -415,7 +415,7 @@ DefPropertyGraph(py::module& m) {
         std::optional<katana::SetOfEntityTypeIDs> edge_type_ids;
         if (!edge_types.is_none()) {
           edge_type_ids = katana::SetOfEntityTypeIDs();
-          edge_type_ids->resize(self.GetEdgeTypeManager().GetNumEntityTypes());
+          edge_type_ids->resize(self->GetEdgeTypeManager().GetNumEntityTypes());
           for (auto& t : edge_types) {
             edge_type_ids->set(py::cast<EntityType>(t).type_id);
           }
@@ -463,8 +463,8 @@ DefPropertyGraph(py::module& m) {
   // GetLocalEdgeID(InEdgeHandle) -> LocalEdgeID  - local edge ID
   cls.def(
       "get_local_edge_id_from_in_edge",
-      [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-        return self.BuildView<PropertyGraphViews::BiDirectional>()
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::BiDirectional>()
             .GetLocalEdgeIDFromInEdge(e);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -472,8 +472,8 @@ DefPropertyGraph(py::module& m) {
   // GetLocalEdgeID(UndirectedEdgeHandle) -> LocalEdgeID  - local edge ID
   cls.def(
       "get_local_edge_id_from_undirected_edge",
-      [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-        return self.BuildView<PropertyGraphViews::Undirected>()
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::Undirected>()
             .GetLocalEdgeIDFromUndirectedEdge(e);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -486,8 +486,8 @@ DefPropertyGraph(py::module& m) {
   // GetEdgePropertyIndex(InEdgeHandle) -> EdgePropertyIndex  - index into the property table for an edge
   cls.def(
       "get_edge_property_index_from_in_edge",
-      [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-        return self.BuildView<PropertyGraphViews::BiDirectional>()
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::BiDirectional>()
             .GetEdgePropertyIndexFromInEdge(e);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -495,8 +495,8 @@ DefPropertyGraph(py::module& m) {
   // GetEdgePropertyIndex(UndirectedEdgeHandle) -> EdgePropertyIndex  - index into the property table for an edge
   cls.def(
       "get_edge_property_index_from_undirected_edge",
-      [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-        return self.BuildView<PropertyGraphViews::Undirected>()
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::Undirected>()
             .GetEdgePropertyIndexFromUndirectedEdge(e);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -560,9 +560,9 @@ DefPropertyGraph(py::module& m) {
 
     cls.def(
         "out_edge_ids",
-        [](PropertyGraph& self, GraphTopologyTypes::Node n,
+        [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node n,
            const EntityType& ty) {
-          return self.BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
+          return self->BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
               .OutEdges(n, ty.type_id);
         },
         py::call_guard<py::gil_scoped_release>());
@@ -613,9 +613,9 @@ DefPropertyGraph(py::module& m) {
     // OutDegree(NodeHandle, EdgeEntityTypeID)-> size_t  - number of out-edges of a type for a node
     cls.def(
         "out_degree",
-        [](PropertyGraph& self, GraphTopologyTypes::Node n,
+        [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node n,
            const EntityType& ty) {
-          return self.BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
+          return self->BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
               .OutDegree(n, ty.type_id);
         },
         py::call_guard<py::gil_scoped_release>());
@@ -685,8 +685,8 @@ DefPropertyGraph(py::module& m) {
 
     cls.def(
         "in_edge_ids",
-        [](PropertyGraph& self) {
-          return self.BuildView<PropertyGraphViews::Transposed>().OutEdges();
+        [](std::shared_ptr<PropertyGraph> self) {
+          return self->BuildView<PropertyGraphViews::Transposed>().OutEdges();
         },
         py::call_guard<py::gil_scoped_release>(),
         R"""(
@@ -722,8 +722,8 @@ DefPropertyGraph(py::module& m) {
     // InEdges(NodeHandle)-> InEdgeHandle iterator - iterator over in-edges for a node
     cls.def(
         "in_edge_ids",
-        [](PropertyGraph& self, GraphTopologyTypes::Node n) {
-          return self.BuildView<PropertyGraphViews::Transposed>().OutEdges(n);
+        [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node n) {
+          return self->BuildView<PropertyGraphViews::Transposed>().OutEdges(n);
         },
         py::call_guard<py::gil_scoped_release>());
     cls.attr("in_edge_ids_for_node") = cls.attr("in_edge_ids");
@@ -735,9 +735,9 @@ DefPropertyGraph(py::module& m) {
     // InEdges(NodeHandle, EdgeEntityTypeID)-> InEdgeHandle iterator - iterator over in-edges of a type for a node
     cls.def(
         "in_edge_ids",
-        [](PropertyGraph& self, GraphTopologyTypes::Node n,
+        [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node n,
            const EntityType& ty) {
-          return self.BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
+          return self->BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
               .InEdges(n, ty.type_id);
         },
         py::call_guard<py::gil_scoped_release>());
@@ -750,8 +750,8 @@ DefPropertyGraph(py::module& m) {
 
     cls.def(
         "in_degree",
-        [](PropertyGraph& self, GraphTopologyTypes::Node n) {
-          return self.BuildView<PropertyGraphViews::Transposed>().OutDegree(n);
+        [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node n) {
+          return self->BuildView<PropertyGraphViews::Transposed>().OutDegree(n);
         },
         py::call_guard<py::gil_scoped_release>(),
         R"""(
@@ -782,9 +782,9 @@ DefPropertyGraph(py::module& m) {
 
     cls.def(
         "in_degree",
-        [](PropertyGraph& self, GraphTopologyTypes::Node n,
+        [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node n,
            const EntityType& ty) {
-          return self.BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
+          return self->BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
               .InDegree(n, ty.type_id);
         },
         py::call_guard<py::gil_scoped_release>());
@@ -797,8 +797,8 @@ DefPropertyGraph(py::module& m) {
   // InEdgeSrc(InEdgeHandle)-> NodeHandle - source of an in-edge
   cls.def(
       "in_edge_src",
-      [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-        return self.BuildView<PropertyGraphViews::Transposed>().OutEdgeDst(e);
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::Transposed>().OutEdgeDst(e);
       },
       py::call_guard<py::gil_scoped_release>());
 
@@ -808,9 +808,9 @@ DefPropertyGraph(py::module& m) {
   // FindAllEdges(NodeHandle src_node, NodeHandle dst_node) -> LocalEdgeID iterator - iterator over out-edges between src and dst nodes
   cls.def(
       "find_all_edge_ids",
-      [](PropertyGraph& self, GraphTopologyTypes::Node src,
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node src,
          GraphTopologyTypes::Node dst) {
-        return self.BuildView<PropertyGraphViews::EdgesSortedByDestID>()
+        return self->BuildView<PropertyGraphViews::EdgesSortedByDestID>()
             .FindAllEdges(src, dst);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -818,9 +818,9 @@ DefPropertyGraph(py::module& m) {
   // FindAllEdges(NodeHandle src_node, NodeHandle dst_node, EdgeEntityTypeID)-> LocalEdgeID iterator - iterator over out-edges of a type between src and dst nodes
   cls.def(
       "find_all_edge_ids",
-      [](PropertyGraph& self, GraphTopologyTypes::Node src,
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node src,
          GraphTopologyTypes::Node dst, const EntityType& ty) {
-        return self.BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
+        return self->BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
             .FindAllEdges(src, dst, ty.type_id);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -828,19 +828,19 @@ DefPropertyGraph(py::module& m) {
   // HasEdge(NodeHandle src, NodeHandle dst) -> bool  - are source and destination nodes connected by some edge
   cls.def(
       "has_edge",
-      [](PropertyGraph& self, GraphTopologyTypes::Node src,
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node src,
          GraphTopologyTypes::Node dst) {
-        return self.BuildView<PropertyGraphViews::EdgesSortedByDestID>()
+        return self->BuildView<PropertyGraphViews::EdgesSortedByDestID>()
             .HasEdge(src, dst);
       },
       py::call_guard<py::gil_scoped_release>());
   // HasEdge(NodeHandle src, NodeHandle dst, EdgeEntityTypeID)-> bool - are source and destination nodes connected by some edge of a given type
   cls.def(
       "has_edge",
-      [](PropertyGraph& self, GraphTopologyTypes::Node src,
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Node src,
          GraphTopologyTypes::Node dst, const EntityType& ty) {
-        return self.BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>().HasEdge(
-            src, dst, ty.type_id);
+        return self->BuildView<PropertyGraphViews::EdgeTypeAwareBiDir>()
+            .HasEdge(src, dst, ty.type_id);
       },
       py::call_guard<py::gil_scoped_release>());
 
@@ -849,8 +849,8 @@ DefPropertyGraph(py::module& m) {
   // GetEdgeSrc(LocalEdgeID)-> NodeHandle - source of an edge
   cls.def(
       "get_edge_src",
-      [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-        return self.BuildView<PropertyGraphViews::BiDirectional>().GetEdgeSrc(
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::BiDirectional>().GetEdgeSrc(
             e);
       },
       py::call_guard<py::gil_scoped_release>());
@@ -858,9 +858,12 @@ DefPropertyGraph(py::module& m) {
       cls_numba_replacement, "get_edge_src");
 
   // GetEdgeDst(LocalEdgeID)-> NodeHandle - destination of an edge
-  cls.def("get_edge_dst", [](PropertyGraph& self, GraphTopologyTypes::Edge e) {
-    return self.BuildView<PropertyGraphViews::BiDirectional>().OutEdgeDst(e);
-  });
+  cls.def(
+      "get_edge_dst",
+      [](std::shared_ptr<PropertyGraph> self, GraphTopologyTypes::Edge e) {
+        return self->BuildView<PropertyGraphViews::BiDirectional>().OutEdgeDst(
+            e);
+      });
   katana::DefWithNumba<&PropertyGraphNumbaReplacement::OutEdgeDst>(
       cls_numba_replacement, "get_edge_dst");
 
@@ -1053,9 +1056,17 @@ DefPropertyGraph(py::module& m) {
       :param command_line: Lineage information in the form of a command line.
       :type command_line: str
       )""");
+
   cls.def_property_readonly("path", [](PropertyGraph& self) -> std::string {
     return self.rdg_dir().string();
   });
+
+  cls.def_property_readonly(
+      "_shared_ptr_address",
+      [](std::shared_ptr<katana::PropertyGraph> self) {
+        return (uintptr_t)(new std::shared_ptr<katana::PropertyGraph>(self));
+      },
+      "Katana Internal. Used for passing objects into Cython.");
 }
 
 template <typename node_or_edge>
@@ -1151,7 +1162,7 @@ DefAccessors(py::module& m) {
       .def("__getitem__", &GraphBaseEdgeDestAccessor::at)
       .def("array", &GraphBaseEdgeDestAccessor::array);
   py::class_<GraphBaseEdgeSourceAccessor>(m, "GraphBaseEdgeSourceAccessor")
-      .def(py::init<katana::PropertyGraph*>())
+      .def(py::init<std::shared_ptr<katana::PropertyGraph>>())
       .def("__getitem__", &GraphBaseEdgeSourceAccessor::at)
       .def("array", &GraphBaseEdgeSourceAccessor::array);
 }

--- a/lonestar/analytics/cpu/betweennesscentrality/betweenness_centrality_cli.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/betweenness_centrality_cli.cpp
@@ -102,13 +102,13 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -162,14 +162,13 @@ main(int argc, char** argv) {
             << " sources\n";
   katana::TxnContext txn_ctx;
   if (auto r = BetweennessCentrality(
-          pg_projected_view.get(), "betweenness_centrality", &txn_ctx, sources,
-          plan);
+          pg_projected_view, "betweenness_centrality", &txn_ctx, sources, plan);
       !r) {
     KATANA_LOG_FATAL("Couldn't run algorithm: {}", r.error());
   }
 
   auto stats_result = BetweennessCentralityStatistics::Compute(
-      pg_projected_view.get(), "betweenness_centrality");
+      pg_projected_view, "betweenness_centrality");
   if (!stats_result) {
     KATANA_LOG_FATAL("Failed to compute statistics: {}", stats_result.error());
   }

--- a/lonestar/analytics/cpu/cdlp/cdlp_cli.cpp
+++ b/lonestar/analytics/cpu/cdlp/cdlp_cli.cpp
@@ -94,7 +94,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
@@ -102,7 +102,7 @@ main(int argc, char** argv) {
 
   std::cout << "Running " << AlgorithmName(algo) << " algorithm\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -128,14 +128,13 @@ main(int argc, char** argv) {
 
   katana::TxnContext txn_ctx;
   auto pg_result = Cdlp(
-      pg_projected_view.get(), property_name, maxIterations, &txn_ctx,
-      symmetricGraph, plan);
+      pg_projected_view, property_name, maxIterations, &txn_ctx, symmetricGraph,
+      plan);
   if (!pg_result) {
     KATANA_LOG_FATAL("Failed to run Cdlp: {}", pg_result.error());
   }
 
-  auto stats_result =
-      CdlpStatistics::Compute(pg_projected_view.get(), property_name);
+  auto stats_result = CdlpStatistics::Compute(pg_projected_view, property_name);
   if (!stats_result) {
     KATANA_LOG_FATAL(
         "Failed to compute Cdlp statistics: {}", stats_result.error());

--- a/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
+++ b/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
@@ -142,13 +142,13 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -219,14 +219,14 @@ main(int argc, char** argv) {
 
   katana::TxnContext txn_ctx;
   auto pg_result = ConnectedComponents(
-      pg_projected_view.get(), "component", &txn_ctx, symmetricGraph, plan);
+      pg_projected_view, "component", &txn_ctx, symmetricGraph, plan);
   if (!pg_result) {
     KATANA_LOG_FATAL(
         "Failed to run ConnectedComponents: {}", pg_result.error());
   }
 
-  auto stats_result = ConnectedComponentsStatistics::Compute(
-      pg_projected_view.get(), "component");
+  auto stats_result =
+      ConnectedComponentsStatistics::Compute(pg_projected_view, "component");
   if (!stats_result) {
     KATANA_LOG_FATAL(
         "Failed to compute ConnectedComponents statistics: {}",
@@ -236,7 +236,7 @@ main(int argc, char** argv) {
   stats.Print();
 
   if (!skipVerify) {
-    if (ConnectedComponentsAssertValid(pg_projected_view.get(), "component")) {
+    if (ConnectedComponentsAssertValid(pg_projected_view, "component")) {
       std::cout << "Verification successful.\n";
     } else {
       KATANA_LOG_FATAL("verification failed");

--- a/lonestar/analytics/cpu/independentset/independent_set_cli.cpp
+++ b/lonestar/analytics/cpu/independentset/independent_set_cli.cpp
@@ -86,7 +86,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->NumNodes() << " nodes, " << pg->NumEdges()
@@ -95,11 +95,11 @@ main(int argc, char** argv) {
   IndependentSetPlan plan = IndependentSetPlan::FromAlgorithm(algo);
 
   katana::TxnContext txn_ctx;
-  if (auto r = IndependentSet(pg.get(), "indicator", &txn_ctx, plan); !r) {
+  if (auto r = IndependentSet(pg, "indicator", &txn_ctx, plan); !r) {
     KATANA_LOG_FATAL("Failed to run algorithm: {}", r.error());
   }
 
-  auto stats_result = IndependentSetStatistics::Compute(pg.get(), "indicator");
+  auto stats_result = IndependentSetStatistics::Compute(pg, "indicator");
   if (!stats_result) {
     KATANA_LOG_FATAL("Failed to compute statistics: {}", stats_result.error());
   }
@@ -107,7 +107,7 @@ main(int argc, char** argv) {
   stats.Print();
 
   if (!skipVerify) {
-    if (IndependentSetAssertValid(pg.get(), "indicator")) {
+    if (IndependentSetAssertValid(pg, "indicator")) {
       std::cout << "Verification successful.\n";
     } else {
       KATANA_LOG_FATAL("verification failed");

--- a/lonestar/analytics/cpu/k-core/kcore_cli.cpp
+++ b/lonestar/analytics/cpu/k-core/kcore_cli.cpp
@@ -92,7 +92,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
@@ -100,7 +100,7 @@ main(int argc, char** argv) {
 
   std::cout << "Running " << AlgorithmName(algo) << "\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -121,14 +121,14 @@ main(int argc, char** argv) {
 
   katana::TxnContext txn_ctx;
   if (auto r = KCore(
-          pg_projected_view.get(), kCoreNumber, "node-in-core", &txn_ctx,
+          pg_projected_view, kCoreNumber, "node-in-core", &txn_ctx,
           symmetricGraph, plan);
       !r) {
     KATANA_LOG_FATAL("Failed to compute k-core: {}", r.error());
   }
 
-  auto stats_result = KCoreStatistics::Compute(
-      pg_projected_view.get(), kCoreNumber, "node-in-core");
+  auto stats_result =
+      KCoreStatistics::Compute(pg_projected_view, kCoreNumber, "node-in-core");
   if (!stats_result) {
     KATANA_LOG_FATAL(
         "Failed to compute KCore statistics: {}", stats_result.error());
@@ -137,8 +137,7 @@ main(int argc, char** argv) {
   stats.Print();
 
   if (!skipVerify) {
-    if (KCoreAssertValid(
-            pg_projected_view.get(), kCoreNumber, "node-in-core")) {
+    if (KCoreAssertValid(pg_projected_view, kCoreNumber, "node-in-core")) {
       std::cout << "Verification successful.\n";
     } else {
       KATANA_LOG_FATAL("verification failed");

--- a/lonestar/analytics/cpu/k-shortest-paths/ksssp_cli.cpp
+++ b/lonestar/analytics/cpu/k-shortest-paths/ksssp_cli.cpp
@@ -123,13 +123,13 @@ main(int argc, char** argv) {
   }
   auto uri = res.value();
 
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(uri, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -176,8 +176,8 @@ main(int argc, char** argv) {
   katana::TxnContext txn_ctx;
 
   auto pg_result = Ksssp(
-      pg_projected_view.get(), edge_property_name, startNode, reportNode,
-      numPaths, symmetricGraph, &txn_ctx, plan);
+      pg_projected_view, edge_property_name, startNode, reportNode, numPaths,
+      symmetricGraph, &txn_ctx, plan);
 
   if (!pg_result) {
     KATANA_LOG_FATAL("failed to run ksssp: {}", pg_result.error());

--- a/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
+++ b/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
@@ -476,7 +476,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   katana::TxnContext txn_ctx;
@@ -485,8 +485,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("failed to construct node properties: {}", result.error());
   }
 
-  auto pg_result =
-      katana::TypedPropertyGraph<NodeData, EdgeData>::Make(pg.get());
+  auto pg_result = katana::TypedPropertyGraph<NodeData, EdgeData>::Make(pg);
   if (!pg_result) {
     KATANA_LOG_FATAL("could not make property graph: {}", pg_result.error());
   }

--- a/lonestar/analytics/cpu/leiden_clustering/leiden_clustering_cli.cpp
+++ b/lonestar/analytics/cpu/leiden_clustering/leiden_clustering_cli.cpp
@@ -113,7 +113,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
@@ -121,7 +121,7 @@ main(int argc, char** argv) {
 
   std::cout << "Running " << AlgorithmName(algo) << " algorithm\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -146,14 +146,14 @@ main(int argc, char** argv) {
 
   katana::TxnContext txn_ctx;
   auto pg_result = LeidenClustering(
-      pg_projected_view.get(), edge_property_name, "clusterId", &txn_ctx,
+      pg_projected_view, edge_property_name, "clusterId", &txn_ctx,
       symmetricGraph, plan);
   if (!pg_result) {
     KATANA_LOG_FATAL("Failed to run LeidenClustering: {}", pg_result.error());
   }
 
   auto stats_result = LeidenClusteringStatistics::Compute(
-      pg_projected_view.get(), edge_property_name, "clusterId", &txn_ctx);
+      pg_projected_view, edge_property_name, "clusterId", &txn_ctx);
   if (!stats_result) {
     KATANA_LOG_FATAL(
         "Failed to compute LeidenClustering statistics: {}",
@@ -164,7 +164,7 @@ main(int argc, char** argv) {
 
   if (!skipVerify) {
     if (LeidenClusteringAssertValid(
-            pg_projected_view.get(), edge_property_name, "clusterId")) {
+            pg_projected_view, edge_property_name, "clusterId")) {
       std::cout << "Verification successful.\n";
     } else {
       KATANA_LOG_FATAL("verification failed");

--- a/lonestar/analytics/cpu/local_clustering_coefficient/local_clustering_coefficient_cli.cpp
+++ b/lonestar/analytics/cpu/local_clustering_coefficient/local_clustering_coefficient_cli.cpp
@@ -69,13 +69,13 @@ main(int argc, char** argv) {
   }
   auto uri = res.value();
 
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(uri, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -102,7 +102,7 @@ main(int argc, char** argv) {
 
   katana::TxnContext txn_ctx;
   auto lcc_result = LocalClusteringCoefficient(
-      pg_projected_view.get(), "localClusteringCoefficient", &txn_ctx, plan);
+      pg_projected_view, "localClusteringCoefficient", &txn_ctx, plan);
   if (!lcc_result) {
     KATANA_LOG_FATAL("Failed to run algorithm: {}", lcc_result.error());
   }

--- a/lonestar/analytics/cpu/louvain_clustering/louvain_clustering_cli.cpp
+++ b/lonestar/analytics/cpu/louvain_clustering/louvain_clustering_cli.cpp
@@ -104,7 +104,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
@@ -112,7 +112,7 @@ main(int argc, char** argv) {
 
   std::cout << "Running " << AlgorithmName(algo) << " algorithm\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -137,14 +137,14 @@ main(int argc, char** argv) {
 
   katana::TxnContext txn_ctx;
   auto pg_result = LouvainClustering(
-      pg_projected_view.get(), edge_property_name, "clusterId", &txn_ctx,
+      pg_projected_view, edge_property_name, "clusterId", &txn_ctx,
       symmetricGraph, plan);
   if (!pg_result) {
     KATANA_LOG_FATAL("Failed to run LouvainClustering: {}", pg_result.error());
   }
 
   auto stats_result = LouvainClusteringStatistics::Compute(
-      pg_projected_view.get(), edge_property_name, "clusterId", &txn_ctx);
+      pg_projected_view, edge_property_name, "clusterId", &txn_ctx);
   if (!stats_result) {
     KATANA_LOG_FATAL(
         "Failed to compute LouvainClustering statistics: {}",
@@ -155,7 +155,7 @@ main(int argc, char** argv) {
 
   if (!skipVerify) {
     if (LouvainClusteringAssertValid(
-            pg_projected_view.get(), edge_property_name, "clusterId")) {
+            pg_projected_view, edge_property_name, "clusterId")) {
       std::cout << "Verification successful.\n";
     } else {
       KATANA_LOG_FATAL("verification failed");

--- a/lonestar/analytics/cpu/matrix-completion/matrix_completion_sgd_cli.cpp
+++ b/lonestar/analytics/cpu/matrix-completion/matrix_completion_sgd_cli.cpp
@@ -139,7 +139,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->NumNodes() << " nodes, " << pg->NumEdges()
@@ -159,7 +159,7 @@ main(int argc, char** argv) {
   }
 
   katana::TxnContext txn_ctx;
-  if (auto r = MatrixCompletion(pg.get(), &txn_ctx, plan); !r) {
+  if (auto r = MatrixCompletion(pg, &txn_ctx, plan); !r) {
     KATANA_LOG_FATAL("Failed to run algorithm: {}", r.error());
   }
 

--- a/lonestar/analytics/cpu/random-walks/random_walks_cli.cpp
+++ b/lonestar/analytics/cpu/random-walks/random_walks_cli.cpp
@@ -116,7 +116,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
@@ -139,7 +139,7 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("Invalid algorithm");
   }
 
-  auto walks_result = RandomWalks(pg.get(), plan);
+  auto walks_result = RandomWalks(pg, plan);
   if (!walks_result) {
     KATANA_LOG_FATAL("Failed to run RandomWalks: {}", walks_result.error());
   }

--- a/lonestar/analytics/cpu/subgraph_extraction/subgraph_extraction_cli.cpp
+++ b/lonestar/analytics/cpu/subgraph_extraction/subgraph_extraction_cli.cpp
@@ -64,13 +64,13 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto uri = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(uri, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -99,8 +99,7 @@ main(int argc, char** argv) {
   std::cout << "INFO: This is extracting the topology containing nodes from "
                "the user defined node set.\n";
 
-  auto subgraph_result =
-      SubGraphExtraction(pg_projected_view.get(), node_vec, plan);
+  auto subgraph_result = SubGraphExtraction(pg_projected_view, node_vec, plan);
   if (!subgraph_result) {
     KATANA_LOG_FATAL("Failed to run algorithm: {}", subgraph_result.error());
   }

--- a/lonestar/analytics/cpu/triangle-counting/triangle_counting_cli.cpp
+++ b/lonestar/analytics/cpu/triangle-counting/triangle_counting_cli.cpp
@@ -69,13 +69,13 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("URI from string {} failed: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";
 
-  std::unique_ptr<katana::PropertyGraph> pg_projected_view =
+  std::shared_ptr<katana::PropertyGraph> pg_projected_view =
       ProjectPropertyGraphForArguments(pg);
 
   std::cout << "Projected graph has: "
@@ -104,7 +104,7 @@ main(int argc, char** argv) {
     std::cerr << "Unknown algo: " << algo << "\n";
   }
 
-  auto num_triangles_result = TriangleCount(pg_projected_view.get(), plan);
+  auto num_triangles_result = TriangleCount(pg_projected_view, plan);
   if (!num_triangles_result) {
     KATANA_LOG_FATAL(
         "failed to run algorithm: {}", num_triangles_result.error());

--- a/lonestar/liblonestar/include/Lonestar/BoilerPlate.h
+++ b/lonestar/liblonestar/include/Lonestar/BoilerPlate.h
@@ -46,6 +46,6 @@ std::unique_ptr<katana::SharedMemSys> LonestarStart(
     llvm::cl::opt<std::string>* input);
 std::unique_ptr<katana::SharedMemSys> LonestarStart(int argc, char** argv);
 
-std::unique_ptr<katana::PropertyGraph> ProjectPropertyGraphForArguments(
-    const std::unique_ptr<katana::PropertyGraph>& pg);
+std::shared_ptr<katana::PropertyGraph> ProjectPropertyGraphForArguments(
+    const std::shared_ptr<katana::PropertyGraph>& pg);
 #endif

--- a/lonestar/liblonestar/include/Lonestar/Utils.h
+++ b/lonestar/liblonestar/include/Lonestar/Utils.h
@@ -28,7 +28,7 @@
 #include "katana/RDG.h"
 #include "katana/analytics/Utils.h"
 
-inline std::unique_ptr<katana::PropertyGraph>
+inline std::shared_ptr<katana::PropertyGraph>
 MakeFileGraph(
     const katana::URI& rdg_name, const std::string& edge_property_name) {
   std::vector<std::string> edge_properties;

--- a/lonestar/liblonestar/src/BoilerPlate.cpp
+++ b/lonestar/liblonestar/src/BoilerPlate.cpp
@@ -125,9 +125,9 @@ LonestarStart(
   return shared_mem_sys;
 }
 
-std::unique_ptr<katana::PropertyGraph>
+std::shared_ptr<katana::PropertyGraph>
 ProjectPropertyGraphForArguments(
-    const std::unique_ptr<katana::PropertyGraph>& pg) {
+    const std::shared_ptr<katana::PropertyGraph>& pg) {
   std::vector<std::string> vec_node_types;
   if (node_types != "") {
     katana::analytics::SplitStringByComma(node_types, &vec_node_types);
@@ -139,7 +139,7 @@ ProjectPropertyGraphForArguments(
   }
 
   auto pg_view_res = katana::PropertyGraph::MakeProjectedGraph(
-      *pg.get(),
+      pg,
       vec_node_types.empty() ? std::nullopt
                              : std::make_optional(vec_node_types),
       vec_edge_types.empty() ? std::nullopt
@@ -147,6 +147,6 @@ ProjectPropertyGraphForArguments(
   if (!pg_view_res) {
     KATANA_LOG_FATAL("Failed to construct projection: {}", pg_view_res.error());
   }
-  auto pg_projected_view = std::move(pg_view_res.value());
-  return pg_projected_view;
+
+  return std::move(pg_view_res.value());
 }

--- a/lonestar/tutorial_examples/ExampleTriangleCount.cpp
+++ b/lonestar/tutorial_examples/ExampleTriangleCount.cpp
@@ -274,11 +274,10 @@ main(int argc, char** argv) {
     KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
   }
   auto inputURI = res.value();
-  std::unique_ptr<katana::PropertyGraph> pg =
+  std::shared_ptr<katana::PropertyGraph> pg =
       MakeFileGraph(inputURI, edge_property_name);
 
-  auto pg_result =
-      katana::TypedPropertyGraph<NodeData, EdgeData>::Make(pg.get());
+  auto pg_result = katana::TypedPropertyGraph<NodeData, EdgeData>::Make(pg);
   if (!pg_result) {
     KATANA_LOG_FATAL("could not make property graph: {}", pg_result.error());
   }

--- a/python/katana/local/_graph.pxd
+++ b/python/katana/local/_graph.pxd
@@ -7,6 +7,7 @@ from katana.cpp.libsupport.result cimport Result
 
 
 cdef _PropertyGraph* underlying_property_graph(graph) nogil
+cdef shared_ptr[_PropertyGraph] underlying_property_graph_shared_ptr(graph) nogil
 cdef CTxnContext* underlying_txn_context(txn_context) nogil
 
 cdef shared_ptr[_PropertyGraph] handle_result_PropertyGraph(Result[unique_ptr[_PropertyGraph]] res) nogil except *

--- a/python/katana/local/_graph.pyx
+++ b/python/katana/local/_graph.pyx
@@ -1,4 +1,6 @@
+from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
+from libcpp.memory cimport shared_ptr
 from pyarrow.lib cimport to_shared
 
 from katana.cpp.libsupport.result cimport Result, raise_error_code
@@ -8,11 +10,24 @@ cdef _PropertyGraph* underlying_property_graph(graph) nogil:
     with gil:
         return <_PropertyGraph*><uintptr_t>graph.__katana_address__
 
+
+cdef shared_ptr[_PropertyGraph] underlying_property_graph_shared_ptr(graph) nogil:
+    cdef shared_ptr[_PropertyGraph]* transfer_ptr
+    cdef shared_ptr[_PropertyGraph] r
+
+    with gil:
+        transfer_ptr = <shared_ptr[_PropertyGraph]*><uintptr_t>graph._shared_ptr_address
+        r = deref(transfer_ptr)
+        del transfer_ptr
+        return r
+
+
 cdef CTxnContext* underlying_txn_context(txn_context) nogil:
     with gil:
         if txn_context:
             return <CTxnContext*><uintptr_t>txn_context.__katana_address__
         return NULL
+
 
 cdef shared_ptr[_PropertyGraph] handle_result_PropertyGraph(Result[unique_ptr[_PropertyGraph]] res) nogil except *:
     if not res.has_value():

--- a/python/katana/local/analytics/_ksssp.pyx
+++ b/python/katana/local/analytics/_ksssp.pyx
@@ -11,6 +11,7 @@ from enum import Enum
 from libc.stddef cimport ptrdiff_t
 from libc.stdint cimport uint32_t
 from libcpp cimport bool
+from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
 
 from katana.cpp.libgalois.graphs.Graph cimport TxnContext as CTxnContext
@@ -19,7 +20,7 @@ from katana.cpp.libsupport.result cimport Result, handle_result_void
 
 from katana.local import Graph, TxnContext
 
-from katana.local._graph cimport underlying_property_graph, underlying_txn_context
+from katana.local._graph cimport underlying_property_graph, underlying_property_graph_shared_ptr, underlying_txn_context
 from katana.local.analytics.plan cimport Plan, _Plan
 
 
@@ -53,7 +54,7 @@ cdef extern from "katana/analytics/k_shortest_paths/ksssp.h" namespace "katana::
     unsigned kDefaultDelta "katana::analytics::KssspPlan::kDefaultDelta"
     ptrdiff_t kDefaultEdgeTileSize "katana::analytics::KssspPlan::kDefaultEdgeTileSize"
 
-    Result[void] Ksssp(_PropertyGraph* pg, const string& edge_weight_property_name,
+    Result[void] Ksssp(const shared_ptr[_PropertyGraph]& pg, const string& edge_weight_property_name,
                        size_t start_node, size_t report_node, size_t num_paths,
                        const bool& is_symmetric, CTxnContext* txn_ctx,
                        _KssspPlan plan)
@@ -204,6 +205,6 @@ def ksssp(pg, str edge_weight_property_name, size_t start_node,
     cdef string edge_weight_property_name_str = bytes(edge_weight_property_name, "utf-8")
     txn_ctx = txn_ctx or TxnContext()
     with nogil:
-        handle_result_void(Ksssp(underlying_property_graph(pg), edge_weight_property_name_str,
+        handle_result_void(Ksssp(underlying_property_graph_shared_ptr(pg), edge_weight_property_name_str,
                                  start_node, report_node, num_paths, is_symmetric,
                                  underlying_txn_context(txn_ctx), plan.underlying_))

--- a/python/katana/local/analytics/_local_clustering_coefficient.pyx
+++ b/python/katana/local/analytics/_local_clustering_coefficient.pyx
@@ -11,6 +11,7 @@ Local Clustering Coefficient
 .. autofunction:: katana.local.analytics.local_clustering_coefficient
 """
 from libcpp cimport bool
+from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
 
 from katana.cpp.libgalois.graphs.Graph cimport TxnContext as CTxnContext
@@ -19,7 +20,7 @@ from katana.cpp.libsupport.result cimport Result, handle_result_void
 
 from katana.local import Graph, TxnContext
 
-from katana.local._graph cimport underlying_property_graph, underlying_txn_context
+from katana.local._graph cimport underlying_property_graph_shared_ptr, underlying_txn_context
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -58,7 +59,7 @@ cdef extern from "katana/analytics/local_clustering_coefficient/local_clustering
     _LocalClusteringCoefficientPlan.Relabeling kDefaultRelabeling "katana::analytics::LocalClusteringCoefficientPlan::kDefaultRelabeling"
     bool kDefaultEdgesSorted "katana::analytics::LocalClusteringCoefficientPlan::kDefaultEdgesSorted"
 
-    Result[void] LocalClusteringCoefficient(_PropertyGraph* pfg, const string& output_property_name, CTxnContext* txn_ctx, _LocalClusteringCoefficientPlan plan)
+    Result[void] LocalClusteringCoefficient(const shared_ptr[_PropertyGraph]& pfg, const string& output_property_name, CTxnContext* txn_ctx, _LocalClusteringCoefficientPlan plan)
 
 
 class _LocalClusteringCoefficientPlanAlgorithm(Enum):
@@ -157,4 +158,4 @@ def local_clustering_coefficient(pg, str output_property_name, LocalClusteringCo
     cdef string output_property_name_str = bytes(output_property_name, "utf-8")
     txn_ctx = txn_ctx or TxnContext()
     with nogil:
-        handle_result_void(LocalClusteringCoefficient(underlying_property_graph(pg), output_property_name_str, underlying_txn_context(txn_ctx), plan.underlying_))
+        handle_result_void(LocalClusteringCoefficient(underlying_property_graph_shared_ptr(pg), output_property_name_str, underlying_txn_context(txn_ctx), plan.underlying_))

--- a/python/katana/local/analytics/_subgraph_extraction.pyx
+++ b/python/katana/local/analytics/_subgraph_extraction.pyx
@@ -15,7 +15,7 @@ from pyarrow.lib cimport to_shared
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, raise_error_code
 from katana.local import Graph, TxnContext
-from katana.local._graph cimport underlying_property_graph
+from katana.local._graph cimport underlying_property_graph_shared_ptr
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -34,7 +34,7 @@ cdef extern from "katana/analytics/subgraph_extraction/subgraph_extraction.h" na
         _SubGraphExtractionPlan NodeSet(
             )
 
-    Result[unique_ptr[_PropertyGraph]] SubGraphExtraction(_PropertyGraph* pfg, const vector[uint32_t]& node_vec, _SubGraphExtractionPlan plan)
+    Result[unique_ptr[_PropertyGraph]] SubGraphExtraction(const shared_ptr[_PropertyGraph]& pfg, const vector[uint32_t]& node_vec, _SubGraphExtractionPlan plan)
 
 
 class _SubGraphExtractionPlanAlgorithm(Enum):
@@ -87,5 +87,5 @@ def subgraph_extraction(pg, node_vec, SubGraphExtractionPlan plan = SubGraphExtr
     """
     cdef vector[uint32_t] vec = [<uint32_t>n for n in node_vec]
     with nogil:
-        v = handle_result_property_graph(SubGraphExtraction(underlying_property_graph(pg), vec, plan.underlying_))
+        v = handle_result_property_graph(SubGraphExtraction(underlying_property_graph_shared_ptr(pg), vec, plan.underlying_))
     return Graph._make_from_address_shared(<uintptr_t>&v)

--- a/python/katana/local/analytics/_triangle_count.pyx
+++ b/python/katana/local/analytics/_triangle_count.pyx
@@ -15,11 +15,12 @@ Triangle Counting
 """
 from libc.stdint cimport uint64_t
 from libcpp cimport bool
+from libcpp.memory cimport shared_ptr
 
 from katana.cpp.libgalois.graphs.Graph cimport _PropertyGraph
 from katana.cpp.libsupport.result cimport Result, handle_result_assert, handle_result_void, raise_error_code
 from katana.local import Graph, TxnContext
-from katana.local._graph cimport underlying_property_graph
+from katana.local._graph cimport underlying_property_graph_shared_ptr
 from katana.local.analytics.plan cimport Plan, _Plan
 
 from enum import Enum
@@ -54,7 +55,7 @@ cdef extern from "katana/analytics/triangle_count/triangle_count.h" namespace "k
     _TriangleCountPlan.Relabeling kDefaultRelabeling "katana::analytics::TriangleCountPlan::kDefaultRelabeling"
     bool kDefaultEdgeSorted "katana::analytics::TriangleCountPlan::kDefaultEdgeSorted"
 
-    Result[uint64_t] TriangleCount(_PropertyGraph* pg, _TriangleCountPlan plan)
+    Result[uint64_t] TriangleCount(const shared_ptr[_PropertyGraph]& pg, _TriangleCountPlan plan)
 
 
 class _TriangleCountPlanAlgorithm(Enum):
@@ -202,5 +203,5 @@ def triangle_count(pg,  TriangleCountPlan plan = TriangleCountPlan()) -> int:
 
     """
     with nogil:
-        v = handle_result_int(TriangleCount(underlying_property_graph(pg), plan.underlying_))
+        v = handle_result_int(TriangleCount(underlying_property_graph_shared_ptr(pg), plan.underlying_))
     return v


### PR DESCRIPTION
This is the open portion of KAT-3405. I still need to update the `DistPropertyGraph` accordingly.