### PR TITLE
build numeric arrays in-place

### DIFF
--- a/libgraph/include/katana/ArrowRandomAccessBuilder.h
+++ b/libgraph/include/katana/ArrowRandomAccessBuilder.h
@@ -17,6 +17,8 @@ public:
 
   katana::Result<void> Resize(size_t length) {
     KATANA_CHECKED(data_.Resize(length));
+    data_.bytes_builder()->UnsafeAdvance(
+        data_.bytes_builder()->capacity() - data_.bytes_builder()->length());
     valid_.resize(length, false);
     return katana::ResultSuccess();
   }
@@ -155,7 +157,7 @@ template <typename ArrowType>
 class ArrowRandomAccessBuilder
     : public internal::BuilderTraits<ArrowType>::Type {
 public:
-  ArrowRandomAccessBuilder(size_t length) {
+  explicit ArrowRandomAccessBuilder(size_t length) {
     KATANA_LOG_ASSERT(this->Resize(length));
   }
 };

--- a/libgraph/include/katana/ArrowRandomAccessBuilder.h
+++ b/libgraph/include/katana/ArrowRandomAccessBuilder.h
@@ -8,69 +8,76 @@
 
 namespace katana {
 
-namespace {
+namespace internal {
 
-/// NoNullBuilder uses std::vector for storage
-/// Finalize() makes a copy of the data
-/// Does not support null values
-template <typename ValueType, typename StorageType, typename ArrowType>
-class NoNullBuilder {
+template <typename ArrowType>
+class NumberBuilder {
 public:
-  using value_type = ValueType;
-  using reference = ValueType&;
+  using value_type = typename ArrowType::c_type;
 
-  NoNullBuilder(size_t length) : data_(length) {
-    static_assert(sizeof(ValueType) == sizeof(StorageType));
-  }
-
-  reference operator[](size_t index) {
-    KATANA_LOG_DEBUG_VASSERT(
-        index < size(), "index: {}, size: {}", index, size());
-    return static_cast<ValueType*>(data_.data())[index];
-  }
-
-  bool IsValid(size_t) { return true; }
-
-  size_t size() const { return data_.size(); }
-
-  katana::Result<std::shared_ptr<arrow::Array>> Finalize() const {
-    using ArrowBuilder = typename arrow::TypeTraits<ArrowType>::BuilderType;
-    ArrowBuilder builder;
-    if (data_.size() > 0) {
-      if (auto r = builder.AppendValues(data_); !r.ok()) {
-        KATANA_LOG_DEBUG("arrow error: {}", r);
-        return katana::ErrorCode::ArrowError;
-      }
-    }
-    std::shared_ptr<arrow::Array> array;
-    if (auto r = builder.Finish(&array); !r.ok()) {
-      KATANA_LOG_DEBUG("arrow error: {}", r);
-      return katana::ErrorCode::ArrowError;
-    }
-    return array;
-  }
-
-private:
-  std::vector<StorageType> data_;
-};
-
-/// NullableBuilder uses std::vector for storage
-/// Finalize() makes a copy of the data
-/// Supports null values
-template <typename ValueType, typename StorageType, typename ArrowType>
-class NullableBuilder {
-public:
-  using value_type = ValueType;
-  using reference = ValueType&;
-
-  NullableBuilder(size_t length) : data_(length), valid_(length, false) {
-    static_assert(sizeof(ValueType) == sizeof(StorageType));
+  katana::Result<void> Resize(size_t length) {
+    KATANA_CHECKED(data_.Resize(length));
+    valid_.resize(length, false);
+    return katana::ResultSuccess();
   }
 
   // NOTE this operator has side-effects. It can safely be used in two ways:
   // 1) builder[index] = value; where it creates a non-null entry
   // 2) value = builder[index]; ONLY IF option 1 has already used that index
-  reference operator[](size_t index) {
+  value_type& operator[](size_t index) {
+    KATANA_LOG_DEBUG_VASSERT(
+        index < size(), "index: {}, size: {}", index, size());
+    valid_[index] = true;
+    return reinterpret_cast<value_type*>(data_.mutable_data())[index];
+  }
+
+  void UnsetValue(size_t index) {
+    KATANA_LOG_DEBUG_ASSERT(index < size());
+    valid_[index] = false;
+  }
+
+  bool IsValid(size_t index) { return valid_[index]; }
+
+  size_t size() const { return data_.length(); }
+
+  katana::Result<void> Finalize(std::shared_ptr<arrow::Array>* array) {
+    using ArrayType = typename arrow::TypeTraits<ArrowType>::ArrayType;
+    int64_t length = data_.length();
+
+    arrow::TypedBufferBuilder<bool> bitmask_builder;
+    KATANA_CHECKED(bitmask_builder.Append(valid_.data(), length));
+    std::shared_ptr<arrow::Buffer> bitmask =
+        KATANA_CHECKED(bitmask_builder.Finish());
+    valid_ = std::vector<uint8_t>(0);
+
+    std::shared_ptr<arrow::Buffer> values = KATANA_CHECKED(data_.Finish());
+    data_.Reset();
+
+    *array = std::make_shared<ArrayType>(
+        length, std::move(values), std::move(bitmask));
+    return katana::ResultSuccess();
+  }
+
+private:
+  arrow::TypedBufferBuilder<value_type> data_;
+  std::vector<uint8_t> valid_;
+};
+
+template <typename ValueType, typename StorageType, typename ArrowType>
+class VectorBackedBuilder {
+public:
+  using value_type = ValueType;
+
+  katana::Result<void> Resize(size_t length) {
+    data_.resize(length);
+    valid_.resize(length, false);
+    return katana::ResultSuccess();
+  }
+
+  // NOTE this operator has side-effects. It can safely be used in two ways:
+  // 1) builder[index] = value; where it creates a non-null entry
+  // 2) value = builder[index]; ONLY IF option 1 has already used that index
+  value_type& operator[](size_t index) {
     KATANA_LOG_DEBUG_VASSERT(
         index < size(), "index: {}, size: {}", index, size());
     valid_[index] = true;
@@ -86,37 +93,15 @@ public:
 
   size_t size() const { return data_.size(); }
 
-  katana::Result<void> Finalize(std::shared_ptr<arrow::Array>* array) const {
+  katana::Result<void> Finalize(std::shared_ptr<arrow::Array>* array) {
     using ArrowBuilder = typename arrow::TypeTraits<ArrowType>::BuilderType;
     ArrowBuilder builder;
     if (data_.size() > 0) {
-      if constexpr (std::is_scalar_v<value_type>) {
-        // TODO(danielmawhirter) find a better way to handle this
-        // arrow::NumericBuilder has:
-        // AppendValues(value_type*, int64_t, uint8_t*)
-        // AppendValues(value_type*, int64_t, vector<bool>)
-        // AppendValues(vector<value_type>, vector<bool>)
-        if (auto r =
-                builder.AppendValues(data_.data(), data_.size(), valid_.data());
-            !r.ok()) {
-          KATANA_LOG_DEBUG("arrow error: {}", r);
-          return katana::ErrorCode::ArrowError;
-        }
-      } else {
-        // TODO(danielmawhirter) find a better way to handle this
-        // arrow::BinaryBuilder has:
-        // AppendValues(vector<string>, uint8_t*)
-        // AppendValues(char**, int64_t, uint8_t*)
-        if (auto r = builder.AppendValues(data_, valid_.data()); !r.ok()) {
-          KATANA_LOG_DEBUG("arrow error: {}", r);
-          return katana::ErrorCode::ArrowError;
-        }
-      }
+      KATANA_CHECKED(builder.AppendValues(data_, valid_.data()));
     }
-    if (auto r = builder.Finish(array); !r.ok()) {
-      KATANA_LOG_DEBUG("arrow error: {}", r);
-      return katana::ErrorCode::ArrowError;
-    }
+    KATANA_CHECKED(builder.Finish(array));
+    data_ = std::vector<StorageType>(0);
+    valid_ = std::vector<StorageType>(0);
     return katana::ResultSuccess();
   }
 
@@ -126,72 +111,56 @@ private:
 };
 
 template <typename ArrowType>
-struct ArrowTypeConfig;
+struct BuilderTraits;
 
-#define NULLABLE(ValueType, StorageType, ArrowType)                            \
+#define NUMBER(ArrowType)                                                      \
   template <>                                                                  \
-  struct ArrowTypeConfig<ArrowType> {                                          \
-    using RandomBuilderType =                                                  \
-        NullableBuilder<ValueType, StorageType, ArrowType>;                    \
+  struct BuilderTraits<ArrowType> {                                            \
+    using Type = NumberBuilder<ArrowType>;                                     \
   }
 
-NULLABLE(int8_t, int8_t, arrow::Int8Type);
-NULLABLE(uint8_t, uint8_t, arrow::UInt8Type);
-NULLABLE(int16_t, int16_t, arrow::Int16Type);
-NULLABLE(uint16_t, uint16_t, arrow::UInt16Type);
-NULLABLE(int32_t, int32_t, arrow::Int32Type);
-NULLABLE(uint32_t, uint32_t, arrow::UInt32Type);
-NULLABLE(int64_t, int64_t, arrow::Int64Type);
-NULLABLE(uint64_t, uint64_t, arrow::UInt64Type);
-NULLABLE(float, float, arrow::FloatType);
-NULLABLE(double, double, arrow::DoubleType);
-NULLABLE(bool, uint8_t, arrow::BooleanType);
-NULLABLE(std::string, std::string, arrow::StringType);
-NULLABLE(std::string, std::string, arrow::LargeStringType);
+NUMBER(arrow::Int8Type);
+NUMBER(arrow::UInt8Type);
+NUMBER(arrow::Int16Type);
+NUMBER(arrow::UInt16Type);
+NUMBER(arrow::Int32Type);
+NUMBER(arrow::UInt32Type);
+NUMBER(arrow::Int64Type);
+NUMBER(arrow::UInt64Type);
+NUMBER(arrow::FloatType);
+NUMBER(arrow::DoubleType);
 
-#undef NULLABLE
+#undef NUMBER
 
-}  // namespace
+#define VECTOR_BACKED(ValueType, StorageType, ArrowType)                       \
+  template <>                                                                  \
+  struct BuilderTraits<ArrowType> {                                            \
+    using Type = VectorBackedBuilder<ValueType, StorageType, ArrowType>;       \
+  }
+
+VECTOR_BACKED(bool, uint8_t, arrow::BooleanType);
+VECTOR_BACKED(std::string, std::string, arrow::StringType);
+VECTOR_BACKED(std::string, std::string, arrow::LargeStringType);
+
+#undef VECTOR_BACKED
+
+}  // namespace internal
 
 /// ArrowRandomAccessBuilder encapsulates the concept of building
 /// an arrow::Array from <index, value> pairs arriving in unknown order
-/// Functions as a wrapper for NullableBuilder currently, TODO(danielmawhirter)
 template <typename ArrowType>
-class ArrowRandomAccessBuilder {
+class ArrowRandomAccessBuilder
+    : public internal::BuilderTraits<ArrowType>::Type {
 public:
-  using RandomBuilderType =
-      typename ArrowTypeConfig<ArrowType>::RandomBuilderType;
-  using value_type = typename RandomBuilderType::value_type;
-
-  ArrowRandomAccessBuilder(size_t length) : builder_(length) {}
-
-  void SetValue(size_t index, value_type value) {
-    builder_.SetValue(index, value);
-  }
-
-  void UnsetValue(size_t index) { builder_.UnsetValue(index); }
-
-  value_type& operator[](size_t index) { return builder_[index]; }
-
-  bool IsValid(size_t index) { return builder_.IsValid(index); }
-
-  katana::Result<void> Finalize(std::shared_ptr<arrow::Array>* array) {
-    return builder_.Finalize(array);
+  ArrowRandomAccessBuilder(size_t length) {
+    KATANA_ASSERT(this->Resize(length));
   }
 
   katana::Result<std::shared_ptr<arrow::Array>> Finalize() {
     std::shared_ptr<arrow::Array> array;
-    auto res = Finalize(&array);
-    if (!res) {
-      return res.error();
-    }
+    KATANA_CHECKED(Finalize(&array));
     return array;
   }
-
-  size_t size() const { return builder_.size(); }
-
-private:
-  RandomBuilderType builder_;
 };
 
 }  // namespace katana

--- a/libgraph/include/katana/ArrowRandomAccessBuilder.h
+++ b/libgraph/include/katana/ArrowRandomAccessBuilder.h
@@ -70,7 +70,9 @@ public:
     int64_t length = data_.length();
 
     arrow::TypedBufferBuilder<bool> bitmask_builder;
-    KATANA_CHECKED(bitmask_builder.Append(valid_.data(), length));
+    if (length > 0) {
+      KATANA_CHECKED(bitmask_builder.Append(valid_.data(), length));
+    }
     std::shared_ptr<arrow::Buffer> bitmask =
         KATANA_CHECKED(bitmask_builder.Finish());
     // peak memory (data buffer + null bitmask + null byte vector)


### PR DESCRIPTION
ArrowRandomAccessBuilder stores both data and vaildity bytes in std::vector for thread safety

For numeric types store the data in arrow-managed memory instead. This does not affect thread safety, and has lower peak memory usage.