### PR TITLE
build: Use canonical python path

### DIFF
--- a/cmake/Modules/PythonSetupSubdirectory.cmake
+++ b/cmake/Modules/PythonSetupSubdirectory.cmake
@@ -211,6 +211,7 @@ function(add_python_setuptools_target TARGET_NAME)
 
   _symlink_tree(${TARGET_NAME}_python_tree ${PYTHON_SETUP_DIR}/python ${PYTHON_BINARY_DIR})
   _symlink_tree(${TARGET_NAME}_setup_tree ${PYTHON_SETUP_DIR}/setup.py ${PYTHON_BINARY_DIR})
+  _symlink_tree(${TARGET_NAME}_docs_tree ${PYTHON_SETUP_DIR}/docs ${PYTHON_BINARY_DIR})
   # Needed for scripts/katana_version
   _symlink_tree(${TARGET_NAME}_scripts_tree ${PYTHON_SETUP_DIR}/scripts ${PYTHON_BINARY_DIR})
 
@@ -279,7 +280,7 @@ function(add_python_setuptools_target TARGET_NAME)
       PROPERTY ADDITIONAL_CLEAN_FILES ${PYTHON_BINARY_DIR} ${CMAKE_BINARY_DIR}/katana_setup_requirements_cache.txt
   )
 
-  add_dependencies(${TARGET_NAME} ${TARGET_NAME}_python_tree ${TARGET_NAME}_setup_tree ${TARGET_NAME}_scripts_tree)
+  add_dependencies(${TARGET_NAME} ${TARGET_NAME}_python_tree ${TARGET_NAME}_setup_tree ${TARGET_NAME}_scripts_tree ${TARGET_NAME}_docs_tree)
   if(X_DEPENDS)
     add_dependencies(${TARGET_NAME} ${X_DEPENDS})
   endif()
@@ -357,9 +358,11 @@ function(add_python_setuptools_tests TARGET_NAME)
   cmake_parse_arguments(X "${no_value_options}" "${one_value_options}" "${multi_value_options}" ${ARGN})
 
   get_target_property(script ${TARGET_NAME} PYTHON_ENV_SCRIPT)
+  get_target_property(bin_dir ${TARGET_NAME} PYTHON_BINARY_DIR)
+
   add_test(NAME ${TARGET_NAME}
            COMMAND ${script} pytest -s -v --import-mode append ${X_PATH}
-           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+           WORKING_DIRECTORY ${bin_dir})
   set_property(TEST ${TARGET_NAME} APPEND
                PROPERTY ENVIRONMENT KATANA_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR})
   set_property(TEST ${TARGET_NAME} APPEND


### PR DESCRIPTION
For

    $BUILD_DIR/python_env.sh python $SRC_DIR/x.py

The same module is available through two import paths. One path through
the source directory and another through the build directory.

This normally doesn't cause an issue because the contents of the modules
are the same and at least one module will be found, but recent versions
of pytest (7.1.0 at least) check that modules are unique and can fail
with the following error

    [....]/site-packages/_pytest/config/__init__.py:625: in _importconftest
        assert mod not in mods

when a module like conftest.py is available multiple times.

Fix this by using the build directory as the source (pun intended) of
tests.