### PR TITLE
[KAT-4444] Add useful string representation for non-atomic types

### DIFF
--- a/libkatana_python_native/src/EntityTypeManager.cpp
+++ b/libkatana_python_native/src/EntityTypeManager.cpp
@@ -44,7 +44,7 @@ katana::python::EntityType::ToString() const {
   if (r) {
     return r.value();
   } else {
-    auto names = owner->GetNonAtomicTypeName(type_id);
+    auto names = owner->GetNonAtomicTypeNames(type_id);
 
     std::string value = std::accumulate(
         names.begin(), names.end(), std::string(""),

--- a/libkatana_python_native/src/EntityTypeManager.cpp
+++ b/libkatana_python_native/src/EntityTypeManager.cpp
@@ -44,7 +44,18 @@ katana::python::EntityType::ToString() const {
   if (r) {
     return r.value();
   } else {
-    return fmt::format("<non-atomic type {}>", type_id);
+    auto names = owner->GetNonAtomicTypeName(type_id);
+
+    std::string value = std::accumulate(
+        names.begin(), names.end(), std::string(""),
+        [](std::string first, std::string second) {
+          if (!first.empty() && !second.empty()) {
+            return fmt::format("{} & {}", first, second);
+          }
+          return second;
+        });
+
+    return value;
   }
 }
 

--- a/libkatana_python_native/src/EntityTypeManager.cpp
+++ b/libkatana_python_native/src/EntityTypeManager.cpp
@@ -14,12 +14,21 @@ namespace py = pybind11;
 namespace {
 
 katana::SetOfEntityTypeIDs
-GetSetOfEntityTypeIds(std::vector<katana::python::EntityType> types) {
+GetAtomicSetOfEntityTypeIds(
+    const katana::EntityTypeManager* manager,
+    std::vector<katana::python::EntityType> types) {
   katana::SetOfEntityTypeIDs type_ids;
-  type_ids.resize(types.size());
-  for (auto t : types) {
-    type_ids.set(t.type_id);
+
+  for (auto entity_type : types) {
+    // Convert non atomic types to atomic types.
+    auto atomic_types = manager->GetAtomicSubtypes(entity_type.type_id);
+
+    type_ids.resize(atomic_types.size());
+    for (auto type_id : atomic_types) {
+      type_ids.set(type_id);
+    }
   }
+
   return type_ids;
 }
 
@@ -121,7 +130,7 @@ katana::python::InitEntityTypeManager(py::module_& m) {
           "get_non_atomic_entity_type",
           [](katana::EntityTypeManager* self,
              std::vector<EntityType> types) -> Result<EntityType> {
-            auto set_of_type_ids = GetSetOfEntityTypeIds(types);
+            auto set_of_type_ids = GetAtomicSetOfEntityTypeIds(self, types);
             return EntityType{
                 self,
                 KATANA_CHECKED(self->GetNonAtomicEntityType(set_of_type_ids))};
@@ -130,8 +139,8 @@ katana::python::InitEntityTypeManager(py::module_& m) {
           "get_or_add_non_atomic_entity_type",
           [](katana::EntityTypeManager* self,
              py::object types) -> Result<EntityType> {
-            auto set_of_type_ids = GetSetOfEntityTypeIds(
-                py::cast<std::vector<EntityType>>(py::list(types)));
+            auto set_of_type_ids = GetAtomicSetOfEntityTypeIds(
+                self, py::cast<std::vector<EntityType>>(py::list(types)));
             return EntityType{
                 self, KATANA_CHECKED(
                           self->GetOrAddNonAtomicEntityType(set_of_type_ids))};

--- a/libtsuba/include/katana/EntityTypeManager.h
+++ b/libtsuba/include/katana/EntityTypeManager.h
@@ -527,6 +527,30 @@ public:
     return std::nullopt;
   }
 
+  /// \returns the names of the atomic supertypes for the given non-atomic type
+  /// \p entity_type_id is an non-atomic type
+  std::set<std::string> GetNonAtomicTypeName(
+      EntityTypeID entity_type_id) const {
+    std::set<std::string> result;
+    auto atomic_types = GetAtomicSubtypes(entity_type_id);
+    for (EntityTypeID super_type_id = 0; super_type_id < atomic_types.size();
+         ++super_type_id) {
+      if (atomic_types.test(super_type_id)) {
+        auto val = GetAtomicTypeName(super_type_id);
+        if (val) {
+          result.insert(val.value());
+        } else {
+          // Seems it's possible to have non-atomic from another non-atomic.
+          auto atomic_type_names = GetNonAtomicTypeName(super_type_id);
+          // Set will avoid any duplicate names.
+          result.insert(atomic_type_names.begin(), atomic_type_names.end());
+        }
+      }
+    }
+
+    return result;
+  }
+
   /// \returns a vector containing all atomic type IDs
   std::vector<EntityTypeID> GetAtomicEntityTypeIDs() const {
     std::vector<EntityTypeID> type_vec;

--- a/libtsuba/include/katana/EntityTypeManager.h
+++ b/libtsuba/include/katana/EntityTypeManager.h
@@ -527,7 +527,7 @@ public:
     return std::nullopt;
   }
 
-  /// \returns the names of the atomic supertypes for the given non-atomic type
+  /// \returns the names of the atomic subtypes for the given non-atomic type
   /// \p entity_type_id is an non-atomic type
   std::set<std::string> GetNonAtomicTypeNames(
       EntityTypeID entity_type_id) const {
@@ -538,11 +538,6 @@ public:
       auto val = GetAtomicTypeName(super_type_id);
       if (val) {
         result.insert(val.value());
-      } else {
-        // Seems it's possible to have non-atomic from another non-atomic.
-        auto atomic_type_names = GetNonAtomicTypeNames(super_type_id);
-        // Set will avoid any duplicate names.
-        result.insert(atomic_type_names.begin(), atomic_type_names.end());
       }
     }
 

--- a/libtsuba/include/katana/EntityTypeManager.h
+++ b/libtsuba/include/katana/EntityTypeManager.h
@@ -529,7 +529,7 @@ public:
 
   /// \returns the names of the atomic supertypes for the given non-atomic type
   /// \p entity_type_id is an non-atomic type
-  std::set<std::string> GetNonAtomicTypeName(
+  std::set<std::string> GetNonAtomicTypeNames(
       EntityTypeID entity_type_id) const {
     std::set<std::string> result;
     auto atomic_types = GetAtomicSubtypes(entity_type_id);

--- a/libtsuba/include/katana/EntityTypeManager.h
+++ b/libtsuba/include/katana/EntityTypeManager.h
@@ -533,18 +533,16 @@ public:
       EntityTypeID entity_type_id) const {
     std::set<std::string> result;
     auto atomic_types = GetAtomicSubtypes(entity_type_id);
-    for (EntityTypeID super_type_id = 0; super_type_id < atomic_types.size();
-         ++super_type_id) {
-      if (atomic_types.test(super_type_id)) {
-        auto val = GetAtomicTypeName(super_type_id);
-        if (val) {
-          result.insert(val.value());
-        } else {
-          // Seems it's possible to have non-atomic from another non-atomic.
-          auto atomic_type_names = GetNonAtomicTypeNames(super_type_id);
-          // Set will avoid any duplicate names.
-          result.insert(atomic_type_names.begin(), atomic_type_names.end());
-        }
+
+    for (auto super_type_id : atomic_types) {
+      auto val = GetAtomicTypeName(super_type_id);
+      if (val) {
+        result.insert(val.value());
+      } else {
+        // Seems it's possible to have non-atomic from another non-atomic.
+        auto atomic_type_names = GetNonAtomicTypeNames(super_type_id);
+        // Set will avoid any duplicate names.
+        result.insert(atomic_type_names.begin(), atomic_type_names.end());
       }
     }
 

--- a/libtsuba/include/katana/EntityTypeManager.h
+++ b/libtsuba/include/katana/EntityTypeManager.h
@@ -541,7 +541,7 @@ public:
           result.insert(val.value());
         } else {
           // Seems it's possible to have non-atomic from another non-atomic.
-          auto atomic_type_names = GetNonAtomicTypeName(super_type_id);
+          auto atomic_type_names = GetNonAtomicTypeNames(super_type_id);
           // Set will avoid any duplicate names.
           result.insert(atomic_type_names.begin(), atomic_type_names.end());
         }

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -326,6 +326,12 @@ def test_types(graph):
     }
     assert graph.edge_types.is_subtype_of(0, 1) is True
 
+    n_type = graph.node_types.get_non_atomic_entity_type([node_atomic_types["Post"], node_atomic_types["Message"]])
+    assert str(n_type) == "Message & Post"
+
+    new_n_type = graph.node_types.get_or_add_non_atomic_entity_type([n_type, node_atomic_types["City"]])
+    assert str(new_n_type) == "City & Message & Post"
+
 
 def test_projected(graph):
     projected_graph = graph.project([])


### PR DESCRIPTION
The non-atomic types will now convert to atomic types and create a useful string representation by concatenating the atomic type names with '&'.  This is done recursively as non-atomic types can be built from another non-atomic type. The end result is flat list of unique atomic type names.

jira: KAT-4444