### PR TITLE
Use katana::URI to name graph location

### DIFF
--- a/libgraph/include/katana/BuildGraph.h
+++ b/libgraph/include/katana/BuildGraph.h
@@ -17,6 +17,7 @@
 #include <arrow/type.h>
 
 #include "katana/PropertyGraph.h"
+#include "katana/URI.h"
 
 namespace katana {
 
@@ -236,12 +237,12 @@ ConvertToPropertyGraph(
     GraphComponents&& graph_comps, katana::TxnContext* txn_ctx);
 
 KATANA_EXPORT Result<void> WritePropertyGraph(
-    GraphComponents&& graph_comps, const std::string& dir,
+    GraphComponents&& graph_comps, const katana::URI& dir,
     katana::TxnContext* txn_ctx);
 
 // TODO(amber): Take PropertyGraph by const ref
 KATANA_EXPORT Result<void> WritePropertyGraph(
-    PropertyGraph& prop_graph, const std::string& dir,
+    PropertyGraph& prop_graph, const katana::URI& dir,
     katana::TxnContext* txn_ctx);
 
 /// Convert Arrow chunked array to/from a vector of ImportData

--- a/libgraph/include/katana/GraphMLSchema.h
+++ b/libgraph/include/katana/GraphMLSchema.h
@@ -36,7 +36,7 @@ KATANA_EXPORT void ExportSchemaMapping(
     const std::string& outfile, const std::vector<LabelRule>& rules,
     const std::vector<PropertyKey>& keys);
 KATANA_EXPORT void ExportGraph(
-    const std::string& outfile, const std::string& rdg_file,
+    const std::string& outfile, const katana::URI& rdg_dir,
     katana::TxnContext* txn_ctx);
 
 KATANA_EXPORT ImportDataType ExtractTypeGraphML(xmlChar* value);

--- a/libgraph/include/katana/PropertyGraph.h
+++ b/libgraph/include/katana/PropertyGraph.h
@@ -241,7 +241,7 @@ public:
 
   /// Make a property graph from an RDG name.
   static Result<std::unique_ptr<PropertyGraph>> Make(
-      const std::string& rdg_name, katana::TxnContext* txn_ctx,
+      const katana::URI& rdg_dir, katana::TxnContext* txn_ctx,
       const katana::RDGLoadOptions& opts = katana::RDGLoadOptions());
 
   /// Make a property graph from an RDG handle
@@ -355,7 +355,7 @@ public:
     return rdg_->WriteRDKSubstructureIndexPrimitive(index);
   }
 
-  const std::string& rdg_dir() const { return rdg_->rdg_dir().string(); }
+  const katana::URI& rdg_dir() const { return rdg_->rdg_dir(); }
 
   uint32_t partition_id() const { return rdg_->partition_id(); }
 
@@ -375,7 +375,7 @@ public:
   ///
   /// \returns io_error if, for instance, a file already exists
   Result<void> Write(
-      const std::string& rdg_name, const std::string& command_line,
+      const katana::URI& rdg_dir, const std::string& command_line,
       katana::TxnContext* txn_ctx);
 
   /// Commit updates modified state and re-uses graph components already in storage.
@@ -1072,16 +1072,16 @@ private:
       katana::TxnContext* txn_ctx);
 
   Result<void> ConductWriteOp(
-      const std::string& uri, const std::string& command_line,
+      const katana::URI& uri, const std::string& command_line,
       katana::RDG::RDGVersioningPolicy versioning_action,
       katana::TxnContext* txn_ctx);
 
   Result<void> WriteGraph(
-      const std::string& uri, const std::string& command_line,
+      const katana::URI& uri, const std::string& command_line,
       katana::TxnContext* txn_ctx);
 
   Result<void> WriteView(
-      const std::string& uri, const std::string& command_line,
+      const katana::URI& uri, const std::string& command_line,
       katana::TxnContext* txn_ctx);
 
   /// Return the number of nodes of the original property graph.

--- a/libgraph/src/BuildGraph.cpp
+++ b/libgraph/src/BuildGraph.cpp
@@ -1873,7 +1873,7 @@ katana::ConvertToPropertyGraph(
 /// to the directory \param dir
 katana::Result<void>
 katana::WritePropertyGraph(
-    katana::GraphComponents&& graph_comps, const std::string& dir,
+    katana::GraphComponents&& graph_comps, const katana::URI& dir,
     katana::TxnContext* txn_ctx) {
   auto graph_ptr = ConvertToPropertyGraph(std::move(graph_comps), txn_ctx);
   if (!graph_ptr) {
@@ -1885,7 +1885,7 @@ katana::WritePropertyGraph(
 
 katana::Result<void>
 katana::WritePropertyGraph(
-    katana::PropertyGraph& prop_graph, const std::string& dir,
+    katana::PropertyGraph& prop_graph, const katana::URI& dir,
     katana::TxnContext* txn_ctx) {
   for (const auto& field : prop_graph.loaded_node_schema()->fields()) {
     KATANA_LOG_VERBOSE(

--- a/libgraph/src/GraphMLSchema.cpp
+++ b/libgraph/src/GraphMLSchema.cpp
@@ -376,12 +376,12 @@ InRange(uint64_t id, const EdgeIterRange& range) {
 
 void
 katana::graphml::ExportGraph(
-    const std::string& outfile, const std::string& rdg_file,
+    const std::string& outfile, const katana::URI& rdg_dir,
     katana::TxnContext* txn_ctx) {
   auto result =
-      katana::PropertyGraph::Make(rdg_file, txn_ctx, katana::RDGLoadOptions());
+      katana::PropertyGraph::Make(rdg_dir, txn_ctx, katana::RDGLoadOptions());
   if (!result) {
-    KATANA_LOG_FATAL("failed to load {}: {}", rdg_file, result.error());
+    KATANA_LOG_FATAL("failed to load {}: {}", rdg_dir, result.error());
   }
   std::unique_ptr<katana::PropertyGraph> graph = std::move(result.value());
 

--- a/libgraph/test/graph-predicates.cpp
+++ b/libgraph/test/graph-predicates.cpp
@@ -26,8 +26,13 @@ TestIsApproximateDegreeDistributionPowerLaw() {
         !katana::analytics::IsApproximateDegreeDistributionPowerLaw(*g.get()));
   }
   {
-    auto g = katana::PropertyGraph::Make(
-        rmat10InputFile, &txn_ctx, katana::RDGLoadOptions());
+    auto res = katana::URI::Make(rmat10InputFile);
+    if (!res) {
+      KATANA_LOG_FATAL("input file {} error: {}", rmat10InputFile, res.error());
+    }
+    auto uri = res.value();
+    auto g =
+        katana::PropertyGraph::Make(uri, &txn_ctx, katana::RDGLoadOptions());
 
     KATANA_LOG_ASSERT(
         katana::analytics::IsApproximateDegreeDistributionPowerLaw(

--- a/libgraph/test/projection.cpp
+++ b/libgraph/test/projection.cpp
@@ -31,7 +31,7 @@ using Graph = katana::TypedPropertyGraph<NodeData, EdgeData>;
 using GNode = typename Graph::Node;
 
 katana::PropertyGraph
-LoadGraph(const std::string& rdg_file) {
+LoadGraph(const katana::URI& rdg_file) {
   KATANA_LOG_ASSERT(!rdg_file.empty());
   katana::TxnContext txn_ctx;
   auto g_res =
@@ -60,7 +60,12 @@ main(int argc, char** argv) {
   katana::SharedMemSys sys;
   cll::ParseCommandLineOptions(argc, argv);
 
-  katana::PropertyGraph full_graph = LoadGraph(inputFile);
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
+  katana::PropertyGraph full_graph = LoadGraph(inputURI);
 
   std::vector<std::string> node_types;
   SplitString(nodeTypes, &node_types);

--- a/libgraph/test/property-graph-optional-topology-generation.cpp
+++ b/libgraph/test/property-graph-optional-topology-generation.cpp
@@ -22,11 +22,11 @@ static cll::opt<std::string> ldbc_003InputFile(
     cll::Positional, cll::desc("<ldbc_003 input file>"), cll::Required);
 
 void
-TestOptionalTopologyGenerationEdgeShuffleTopology() {
+TestOptionalTopologyGenerationEdgeShuffleTopology(const katana::URI& rdg_dir) {
   KATANA_LOG_DEBUG("##### Testing EdgeShuffleTopology Generation #####");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(ldbc_003InputFile);
+  katana::PropertyGraph pg = LoadGraph(rdg_dir);
 
   // Build a EdgeSortedByDestID view, which uses GraphTopology EdgeShuffleTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgesSortedByDestID;
@@ -35,11 +35,11 @@ TestOptionalTopologyGenerationEdgeShuffleTopology() {
 }
 
 void
-TestOptionalTopologyGenerationShuffleTopology() {
+TestOptionalTopologyGenerationShuffleTopology(const katana::URI& rdg_dir) {
   KATANA_LOG_DEBUG("##### Testing ShuffleTopology Generation #####");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(ldbc_003InputFile);
+  katana::PropertyGraph pg = LoadGraph(rdg_dir);
 
   // Build a NodesSortedByDegreeEdgesSortedByDestID view, which uses GraphTopology ShuffleTopology in the background
   using SortedGraphView =
@@ -49,11 +49,12 @@ TestOptionalTopologyGenerationShuffleTopology() {
 }
 
 void
-TestOptionalTopologyGenerationEdgeTypeAwareTopology() {
+TestOptionalTopologyGenerationEdgeTypeAwareTopology(
+    const katana::URI& rdg_dir) {
   KATANA_LOG_DEBUG("##### Testing EdgeTypeAware Topology Generation ######");
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(ldbc_003InputFile);
+  katana::PropertyGraph pg = LoadGraph(rdg_dir);
 
   // Build a EdgeTypeAwareBiDir view, which uses GraphTopology EdgeTypeAwareTopology in the background
   using SortedGraphView = katana::PropertyGraphViews::EdgeTypeAwareBiDir;
@@ -65,9 +66,14 @@ int
 main(int argc, char** argv) {
   katana::SharedMemSys sys;
   cll::ParseCommandLineOptions(argc, argv);
+  auto res = katana::URI::Make(ldbc_003InputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", ldbc_003InputFile, res.error());
+  }
+  auto uri = res.value();
 
-  TestOptionalTopologyGenerationEdgeShuffleTopology();
-  TestOptionalTopologyGenerationShuffleTopology();
-  TestOptionalTopologyGenerationEdgeTypeAwareTopology();
+  TestOptionalTopologyGenerationEdgeShuffleTopology(uri);
+  TestOptionalTopologyGenerationShuffleTopology(uri);
+  TestOptionalTopologyGenerationEdgeTypeAwareTopology(uri);
   return 0;
 }

--- a/libgraph/test/property-graph-storage-format-version-v1-v3-entity-type-ids.cpp
+++ b/libgraph/test/property-graph-storage-format-version-v1-v3-entity-type-ids.cpp
@@ -26,8 +26,14 @@ main(int argc, char** argv) {
   katana::SharedMemSys sys;
   cll::ParseCommandLineOptions(argc, argv);
 
-  TestConvertGraphStorageFormat(ldbc_003InputFile);
-  TestRoundTripNewStorageFormat(ldbc_003InputFile);
+  auto res = katana::URI::Make(ldbc_003InputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", ldbc_003InputFile, res.error());
+  }
+  auto inputURI = res.value();
+
+  TestConvertGraphStorageFormat(inputURI);
+  TestRoundTripNewStorageFormat(inputURI);
 
   return 0;
 }

--- a/libgraph/test/property-graph-storage-format-version-v1-v3-optional-topologies.cpp
+++ b/libgraph/test/property-graph-storage-format-version-v1-v3-optional-topologies.cpp
@@ -31,8 +31,14 @@ main(int argc, char** argv) {
   katana::SharedMemSys sys;
   cll::ParseCommandLineOptions(argc, argv);
 
-  TestOptionalTopologyStorageEdgeShuffleTopology(ldbc_003InputFile);
-  TestOptionalTopologyStorageShuffleTopology(ldbc_003InputFile);
-  TestOptionalTopologyStorageEdgeTypeAwareTopology(ldbc_003InputFile);
+  auto res = katana::URI::Make(ldbc_003InputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", ldbc_003InputFile, res.error());
+  }
+  auto uri = res.value();
+
+  TestOptionalTopologyStorageEdgeShuffleTopology(uri);
+  TestOptionalTopologyStorageShuffleTopology(uri);
+  TestOptionalTopologyStorageEdgeTypeAwareTopology(uri);
   return 0;
 }

--- a/libgraph/test/property-graph-storage-format-version-v3-v3-optional-topologies.cpp
+++ b/libgraph/test/property-graph-storage-format-version-v3-v3-optional-topologies.cpp
@@ -30,8 +30,14 @@ main(int argc, char** argv) {
   katana::SharedMemSys sys;
   cll::ParseCommandLineOptions(argc, argv);
 
-  TestOptionalTopologyStorageEdgeShuffleTopology(ldbc_003InputFile);
-  TestOptionalTopologyStorageShuffleTopology(ldbc_003InputFile);
-  TestOptionalTopologyStorageEdgeTypeAwareTopology(ldbc_003InputFile);
+  auto res = katana::URI::Make(ldbc_003InputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", ldbc_003InputFile, res.error());
+  }
+  auto uri = res.value();
+
+  TestOptionalTopologyStorageEdgeShuffleTopology(uri);
+  TestOptionalTopologyStorageShuffleTopology(uri);
+  TestOptionalTopologyStorageEdgeTypeAwareTopology(uri);
   return 0;
 }

--- a/libgraph/test/storage-format-version-entity-type-ids.h
+++ b/libgraph/test/storage-format-version-entity-type-ids.h
@@ -129,7 +129,7 @@ ValidateLDBC003EntityTypeManagers(
 }
 
 void
-TestConvertGraphStorageFormat(std::string& input_rdg) {
+TestConvertGraphStorageFormat(const katana::URI& input_rdg) {
   // Load existing "old" graph, which converts all uint8/bool properties into types
   // store it as a new file
   // load the new file
@@ -143,7 +143,7 @@ TestConvertGraphStorageFormat(std::string& input_rdg) {
   ValidateLDBC003EntityTypeManagers(
       g.GetNodeTypeManager(), g.GetEdgeTypeManager());
 
-  std::string g2_rdg_file = StoreGraph(&g);
+  auto g2_rdg_file = StoreGraph(&g);
   katana::PropertyGraph g2 = LoadGraph(g2_rdg_file);
   ValidateLDBC003EntityTypeManagers(
       g2.GetNodeTypeManager(), g2.GetEdgeTypeManager());
@@ -156,7 +156,7 @@ TestConvertGraphStorageFormat(std::string& input_rdg) {
 }
 
 void
-TestRoundTripNewStorageFormat(std::string& input_rdg) {
+TestRoundTripNewStorageFormat(const katana::URI& input_rdg) {
   // Test store/load cycle of a graph with the new storage format
   // To do this, we first must first convert an old graph.
   // Steps:
@@ -177,13 +177,13 @@ TestRoundTripNewStorageFormat(std::string& input_rdg) {
   ValidateLDBC003EntityTypeManagers(
       g.GetNodeTypeManager(), g.GetEdgeTypeManager());
 
-  std::string g2_rdg_file = StoreGraph(&g);
+  auto g2_rdg_file = StoreGraph(&g);
   katana::PropertyGraph g2 = LoadGraph(g2_rdg_file);
   ValidateLDBC003EntityTypeManagers(
       g2.GetNodeTypeManager(), g2.GetEdgeTypeManager());
 
   // second cycle doesn't do any conversion, but tests storing/loading a "new format" graph
-  std::string g3_rdg_file = StoreGraph(&g2);
+  auto g3_rdg_file = StoreGraph(&g2);
   katana::PropertyGraph g3 = LoadGraph(g3_rdg_file);
   ValidateLDBC003EntityTypeManagers(
       g3.GetNodeTypeManager(), g3.GetEdgeTypeManager());

--- a/libgraph/test/storage-format-version-optional-topologies.h
+++ b/libgraph/test/storage-format-version-optional-topologies.h
@@ -31,7 +31,7 @@ verify_view(View generated_view, View loaded_view) {
 }
 
 void
-TestOptionalTopologyStorageEdgeShuffleTopology(std::string inputFile) {
+TestOptionalTopologyStorageEdgeShuffleTopology(const katana::URI& inputFile) {
   KATANA_LOG_WARN("***** Testing EdgeShuffleTopology *****");
 
   katana::TxnContext txn_ctx;
@@ -44,7 +44,7 @@ TestOptionalTopologyStorageEdgeShuffleTopology(std::string inputFile) {
   // TODO: ensure this view was generated, not loaded
   // generated_sorted_view.Print();
 
-  std::string g2_rdg_file = StoreGraph(&pg);
+  auto g2_rdg_file = StoreGraph(&pg);
   katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file);
 
   SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
@@ -55,7 +55,7 @@ TestOptionalTopologyStorageEdgeShuffleTopology(std::string inputFile) {
 }
 
 void
-TestOptionalTopologyStorageShuffleTopology(std::string inputFile) {
+TestOptionalTopologyStorageShuffleTopology(const katana::URI& inputFile) {
   KATANA_LOG_WARN("***** Testing ShuffleTopology *****");
 
   katana::TxnContext txn_ctx;
@@ -69,7 +69,7 @@ TestOptionalTopologyStorageShuffleTopology(std::string inputFile) {
   // TODO: ensure this view was generated, not loaded
   // generated_sorted_view.Print();
 
-  std::string g2_rdg_file = StoreGraph(&pg);
+  auto g2_rdg_file = StoreGraph(&pg);
   katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file);
 
   SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();
@@ -80,7 +80,7 @@ TestOptionalTopologyStorageShuffleTopology(std::string inputFile) {
 }
 
 void
-TestOptionalTopologyStorageEdgeTypeAwareTopology(std::string inputFile) {
+TestOptionalTopologyStorageEdgeTypeAwareTopology(const katana::URI& inputFile) {
   KATANA_LOG_WARN("***** Testing EdgeTypeAware Topology *****");
 
   katana::TxnContext txn_ctx;
@@ -92,7 +92,7 @@ TestOptionalTopologyStorageEdgeTypeAwareTopology(std::string inputFile) {
   SortedGraphView generated_sorted_view = pg.BuildView<SortedGraphView>();
   // generated_sorted_view.Print();
 
-  std::string g2_rdg_file = StoreGraph(&pg);
+  auto g2_rdg_file = StoreGraph(&pg);
   katana::PropertyGraph pg2 = LoadGraph(g2_rdg_file);
 
   SortedGraphView loaded_sorted_view = pg2.BuildView<SortedGraphView>();

--- a/libgraph/test/storage-format-version.h
+++ b/libgraph/test/storage-format-version.h
@@ -5,7 +5,7 @@
 #include "katana/PropertyGraph.h"
 
 katana::PropertyGraph
-LoadGraph(const std::string& rdg_file) {
+LoadGraph(const katana::URI& rdg_file) {
   KATANA_LOG_ASSERT(!rdg_file.empty());
   katana::TxnContext txn_ctx;
   auto g_res =
@@ -18,21 +18,21 @@ LoadGraph(const std::string& rdg_file) {
   return g;
 }
 
-std::string
+katana::URI
 StoreGraph(katana::PropertyGraph* g) {
   auto uri_res = katana::URI::MakeRand("/tmp/propertyfilegraph");
   KATANA_LOG_ASSERT(uri_res);
-  std::string tmp_rdg_dir(uri_res.value().path());  // path() because local
+  katana::URI rdg_dir = uri_res.value();
   std::string command_line;
   katana::TxnContext txn_ctx;
 
   // Store graph. If there is a new storage format then storing it is enough to bump the version up.
-  KATANA_LOG_WARN("writing graph at temp file {}", tmp_rdg_dir);
-  auto write_result = g->Write(tmp_rdg_dir, command_line, &txn_ctx);
+  KATANA_LOG_WARN("writing graph at temp file {}", rdg_dir);
+  auto write_result = g->Write(rdg_dir, command_line, &txn_ctx);
   if (!write_result) {
     KATANA_LOG_FATAL("writing result failed: {}", write_result.error());
   }
-  return tmp_rdg_dir;
+  return rdg_dir;
 }
 
 #endif

--- a/libgraph/test/transformation-view-optional-topology.cpp
+++ b/libgraph/test/transformation-view-optional-topology.cpp
@@ -75,7 +75,12 @@ main(int argc, char** argv) {
   cll::ParseCommandLineOptions(argc, argv);
 
   katana::TxnContext txn_ctx;
-  katana::PropertyGraph pg = LoadGraph(inputFile);
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
+  katana::PropertyGraph pg = LoadGraph(inputURI);
 
   std::vector<std::string> node_types;
   SplitString(nodeTypes, &node_types);

--- a/libkatana_python_native/src/PropertyGraph.cpp
+++ b/libkatana_python_native/src/PropertyGraph.cpp
@@ -363,6 +363,7 @@ DefPropertyGraph(py::module& m) {
              std::optional<std::vector<std::string>> edge_properties,
              TxnContext* txn_ctx) -> std::shared_ptr<PropertyGraph> {
             auto path_str = py::str(path).cast<std::string>();
+            auto path_uri = PythonChecked(URI::Make(path_str));
             py::gil_scoped_release guard;
             katana::RDGLoadOptions options = katana::RDGLoadOptions::Defaults();
             options.node_properties = node_properties;
@@ -370,7 +371,7 @@ DefPropertyGraph(py::module& m) {
             TxnContextArgumentHandler txn_context_handler(txn_ctx);
             KATANA_LOG_DEBUG("{}", reinterpret_cast<uintptr_t>(path.ptr()));
             return PythonChecked(PropertyGraph::Make(
-                path_str, txn_context_handler.get(), options));
+                path_uri, txn_context_handler.get(), options));
           }),
       py::arg("path"), py::kw_only(), py::arg("node_properties") = std::nullopt,
       py::arg("edge_properties") = std::nullopt,
@@ -1034,7 +1035,8 @@ DefPropertyGraph(py::module& m) {
          const std::string& provenance, TxnContext* txn_ctx) {
         TxnContextArgumentHandler txn_handler(txn_ctx);
         if (path) {
-          return self.Write(*path, provenance, txn_handler.get());
+          auto path_uri = PythonChecked(URI::Make(*path));
+          return self.Write(path_uri, provenance, txn_handler.get());
         }
         return self.Commit(provenance, txn_handler.get());
       },
@@ -1051,7 +1053,9 @@ DefPropertyGraph(py::module& m) {
       :param command_line: Lineage information in the form of a command line.
       :type command_line: str
       )""");
-  cls.def_property_readonly("path", &PropertyGraph::rdg_dir);
+  cls.def_property_readonly("path", [](PropertyGraph& self) -> std::string {
+    return self.rdg_dir().string();
+  });
 }
 
 template <typename node_or_edge>

--- a/libsupport/include/katana/URI.h
+++ b/libsupport/include/katana/URI.h
@@ -63,6 +63,9 @@ public:
 
   URI operator+(char rhs) const;
   URI operator+(const std::string& rhs) const;
+  bool operator<(URI const& o) const {
+    return scheme_ < o.scheme_ || path_ < o.path_;
+  }
 
 private:
   URI(std::string scheme, std::string path);

--- a/libtsuba/include/katana/TxnContext.h
+++ b/libtsuba/include/katana/TxnContext.h
@@ -29,55 +29,47 @@ public:
     }
   }
 
-  void InsertNodePropertyRead(
-      const std::string& rdg_dir, const std::string& name) {
-    node_properties_read_.insert(URI::JoinPath(rdg_dir, name));
+  void InsertNodePropertyRead(const URI& rdg_dir, const std::string& name) {
+    node_properties_read_.insert(rdg_dir.Join(name));
   }
 
   template <typename Container>
-  void InsertNodePropertyRead(
-      const std::string& rdg_dir, const Container& names) {
+  void InsertNodePropertyRead(const URI& rdg_dir, const Container& names) {
     for (const auto& name : names) {
-      node_properties_read_.insert(URI::JoinPath(rdg_dir, name));
+      node_properties_read_.insert(rdg_dir.Join(name));
     }
   }
 
-  void InsertNodePropertyWrite(
-      const std::string& rdg_dir, const std::string& name) {
-    node_properties_write_.insert(URI::JoinPath(rdg_dir, name));
+  void InsertNodePropertyWrite(const URI& rdg_dir, const std::string& name) {
+    node_properties_write_.insert(rdg_dir.Join(name));
   }
 
   template <typename Container>
-  void InsertNodePropertyWrite(
-      const std::string& rdg_dir, const Container& names) {
+  void InsertNodePropertyWrite(const URI& rdg_dir, const Container& names) {
     for (const auto& name : names) {
-      node_properties_write_.insert(URI::JoinPath(rdg_dir, name));
+      node_properties_write_.insert(rdg_dir.Join(name));
     }
   }
 
-  void InsertEdgePropertyRead(
-      const std::string& rdg_dir, const std::string& name) {
-    edge_properties_read_.insert(URI::JoinPath(rdg_dir, name));
+  void InsertEdgePropertyRead(const URI& rdg_dir, const std::string& name) {
+    edge_properties_read_.insert(rdg_dir.Join(name));
   }
 
   template <typename Container>
-  void InsertEdgePropertyRead(
-      const std::string& rdg_dir, const Container& names) {
+  void InsertEdgePropertyRead(const URI& rdg_dir, const Container& names) {
     for (const auto& name : names) {
-      edge_properties_read_.insert(URI::JoinPath(rdg_dir, name));
+      edge_properties_read_.insert(rdg_dir.Join(name));
     }
   }
 
-  void InsertEdgePropertyWrite(
-      const std::string& rdg_dir, const std::string& name) {
-    edge_properties_write_.insert(URI::JoinPath(rdg_dir, name));
+  void InsertEdgePropertyWrite(const URI& rdg_dir, const std::string& name) {
+    edge_properties_write_.insert(rdg_dir.Join(name));
   }
 
   template <typename Container>
-  void InsertEdgePropertyWrite(
-      const std::string& rdg_dir, const Container& names) {
+  void InsertEdgePropertyWrite(const URI& rdg_dir, const Container& names) {
     for (const auto& name : names) {
-      edge_properties_write_.insert(URI::JoinPath(rdg_dir, name));
+      edge_properties_write_.insert(rdg_dir.Join(name));
     }
   }
 
@@ -97,19 +89,19 @@ public:
     manifest_uptodate_[rdg_dir] = false;
   }
 
-  const std::set<std::string>& NodePropertyRead() const {
+  const std::set<URI>& NodePropertyRead() const {
     return node_properties_read_;
   }
 
-  const std::set<std::string>& NodePropertyWrite() const {
+  const std::set<URI>& NodePropertyWrite() const {
     return node_properties_write_;
   }
 
-  const std::set<std::string>& EdgePropertyRead() const {
+  const std::set<URI>& EdgePropertyRead() const {
     return edge_properties_read_;
   }
 
-  const std::set<std::string>& EdgePropertyWrite() const {
+  const std::set<URI>& EdgePropertyWrite() const {
     return edge_properties_write_;
   }
 
@@ -132,10 +124,10 @@ public:
   katana::Result<void> Commit();
 
 private:
-  std::set<std::string> node_properties_read_;
-  std::set<std::string> node_properties_write_;
-  std::set<std::string> edge_properties_read_;
-  std::set<std::string> edge_properties_write_;
+  std::set<URI> node_properties_read_;
+  std::set<URI> node_properties_write_;
+  std::set<URI> edge_properties_read_;
+  std::set<URI> edge_properties_write_;
   bool all_properties_read_{false};
   bool all_properties_write_{false};
   bool topology_read_{false};

--- a/libtsuba/include/katana/tsuba.h
+++ b/libtsuba/include/katana/tsuba.h
@@ -56,10 +56,10 @@ OpenFlagsValid(uint32_t flags) {
 }
 
 KATANA_EXPORT katana::Result<RDGManifest> FindManifest(
-    const std::string& rdg_name);
+    const katana::URI& rdg_dir);
 
 KATANA_EXPORT katana::Result<katana::RDGManifest> FindManifest(
-    const std::string& rdg_name, katana::TxnContext* txn_ctx);
+    const katana::URI& rdg_dir, katana::TxnContext* txn_ctx);
 
 KATANA_EXPORT katana::Result<RDGHandle> Open(
     RDGManifest rdg_manifest, uint32_t flags);
@@ -87,7 +87,7 @@ KATANA_EXPORT katana::Result<void> Close(RDGHandle handle);
 
 /// Create an RDG storage location
 /// \param name is storage location prefix that will be used to store the RDG
-KATANA_EXPORT katana::Result<void> Create(const std::string& name);
+KATANA_EXPORT katana::Result<void> Create(const katana::URI& uri);
 
 /// @brief Describes properties of RDGView
 /// The RDGView will describe will identify the view-type, the arguments used to
@@ -96,25 +96,25 @@ KATANA_EXPORT katana::Result<void> Create(const std::string& name);
 struct KATANA_EXPORT RDGView {
   std::string view_type;
   std::string view_args;
-  std::string view_path;
+  katana::URI view_path;
   uint64_t num_partitions{0};
   uint32_t policy_id{0};
   bool transpose{false};
 };
 
 /// list the views in storage for a particular version of an RDG
-/// \param rdg_dir is the RDG's URI prefix
+/// \param rdg_uri is the RDG's URI prefix
 /// \param version is an optional version argument, if omitted this will return
 ///    the views for the latest version
 /// \returns a pair (RDG version, vector of RDGViews) or ErrorCode::NotFound if
 /// rdg_dir contains no manifest files
 KATANA_EXPORT katana::Result<std::pair<uint64_t, std::vector<RDGView>>>
 ListViewsOfVersion(
-    const std::string& rdg_dir, std::optional<uint64_t> version = std::nullopt);
+    const katana::URI& rdg_uri, std::optional<uint64_t> version = std::nullopt);
 
 KATANA_EXPORT katana::Result<std::vector<std::pair<katana::URI, katana::URI>>>
 CreateSrcDestFromViewsForCopy(
-    const std::string& src_dir, const std::string& dst_dir, uint64_t version);
+    const katana::URI& src_uri, const std::string& dst_dir, uint64_t version);
 
 /// CopyRDG copies RDG files from a source to a destination.
 /// E.g. SRC_DIR/part_vers0003_rdg_node00000 -> DST_DIR/part_vers0001_rdg_node_00000

--- a/libtsuba/src/RDGCore.cpp
+++ b/libtsuba/src/RDGCore.cpp
@@ -220,7 +220,7 @@ katana::RDGCore::AddNodeProperties(
       props, &node_properties_, &part_header_.node_prop_info_list()));
   // store write properties into transaction context
   txn_ctx->InsertNodePropertyWrite<std::set<std::string>>(
-      rdg_dir_.string(), written_prop_names);
+      rdg_dir_, written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -233,7 +233,7 @@ katana::RDGCore::AddEdgeProperties(
       props, &edge_properties_, &part_header_.edge_prop_info_list()));
   // store write properties into transaction context
   txn_ctx->InsertEdgePropertyWrite<std::set<std::string>>(
-      rdg_dir_.string(), written_prop_names);
+      rdg_dir_, written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -246,7 +246,7 @@ katana::RDGCore::UpsertNodeProperties(
       props, &node_properties_, &part_header_.node_prop_info_list()));
   // store write properties into transaction context
   txn_ctx->InsertNodePropertyWrite<std::set<std::string>>(
-      rdg_dir_.string(), written_prop_names);
+      rdg_dir_, written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -259,7 +259,7 @@ katana::RDGCore::UpsertEdgeProperties(
       props, &edge_properties_, &part_header_.edge_prop_info_list()));
   // store write properties into transaction context
   txn_ctx->InsertEdgePropertyWrite<std::set<std::string>>(
-      rdg_dir_.string(), written_prop_names);
+      rdg_dir_, written_prop_names);
 
   return katana::ResultSuccess();
 }
@@ -317,7 +317,7 @@ katana::RDGCore::RemoveNodeProperty(int i, katana::TxnContext* txn_ctx) {
   auto field = node_properties_->field(i);
   node_properties_ = KATANA_CHECKED(node_properties_->RemoveColumn(i));
   // store write properties into transaction context
-  txn_ctx->InsertNodePropertyWrite(rdg_dir_.string(), field->name());
+  txn_ctx->InsertNodePropertyWrite(rdg_dir_, field->name());
 
   return part_header_.RemoveNodeProperty(field->name());
 }
@@ -327,7 +327,7 @@ katana::RDGCore::RemoveEdgeProperty(int i, katana::TxnContext* txn_ctx) {
   auto field = edge_properties_->field(i);
   edge_properties_ = KATANA_CHECKED(edge_properties_->RemoveColumn(i));
   // store write properties into transaction context
-  txn_ctx->InsertEdgePropertyWrite(rdg_dir_.string(), field->name());
+  txn_ctx->InsertEdgePropertyWrite(rdg_dir_, field->name());
 
   return part_header_.RemoveEdgeProperty(field->name());
 }

--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -54,19 +54,17 @@ FindAnyManifestForLatestVersion(const katana::URI& name) {
 }  // namespace
 
 katana::Result<katana::RDGManifest>
-katana::FindManifest(const std::string& rdg_name) {
-  katana::URI uri = KATANA_CHECKED(katana::URI::Make(rdg_name));
-
-  if (RDGManifest::IsManifestUri(uri)) {
-    RDGManifest manifest = KATANA_CHECKED(katana::RDGManifest::Make(uri));
+katana::FindManifest(const katana::URI& rdg_dir) {
+  if (RDGManifest::IsManifestUri(rdg_dir)) {
+    RDGManifest manifest = KATANA_CHECKED(katana::RDGManifest::Make(rdg_dir));
     return manifest;
   }
 
-  auto latest_uri = FindAnyManifestForLatestVersion(uri);
+  auto latest_uri = FindAnyManifestForLatestVersion(rdg_dir);
   if (!latest_uri) {
     return KATANA_ERROR(
         ErrorCode::InvalidArgument, "failed to find latest RDGManifest at {}",
-        uri.string());
+        rdg_dir.string());
   }
 
   RDGManifest manifest =
@@ -75,16 +73,16 @@ katana::FindManifest(const std::string& rdg_name) {
 }
 
 katana::Result<katana::RDGManifest>
-katana::FindManifest(const std::string& rdg_name, katana::TxnContext* txn_ctx) {
-  katana::URI uri = KATANA_CHECKED(katana::URI::Make(rdg_name));
+katana::FindManifest(const katana::URI& rdg_dir, katana::TxnContext* txn_ctx) {
+  katana::URI uri = rdg_dir;
   if (RDGManifest::IsManifestUri(uri)) {
-    uri = uri.DirName();
+    uri = rdg_dir.DirName();
   }
 
   if (txn_ctx && txn_ctx->ManifestCached(uri)) {
     return txn_ctx->ManifestInfo(uri).rdg_manifest;
   } else {
-    return KATANA_CHECKED(katana::FindManifest(rdg_name));
+    return KATANA_CHECKED(katana::FindManifest(rdg_dir));
   }
 }
 
@@ -105,9 +103,7 @@ katana::Close(RDGHandle handle) {
 }
 
 katana::Result<void>
-katana::Create(const std::string& name) {
-  katana::URI uri = KATANA_CHECKED(katana::URI::Make(name));
-
+katana::Create(const katana::URI& uri) {
   KATANA_LOG_DEBUG_ASSERT(!RDGManifest::IsManifestUri(uri));
   // the default construction is the empty RDG
   katana::RDGManifest manifest{};
@@ -148,8 +144,7 @@ ParseManifestName(
 
 katana::Result<std::pair<uint64_t, std::vector<katana::RDGView>>>
 katana::ListViewsOfVersion(
-    const std::string& rdg_dir, std::optional<uint64_t> version) {
-  auto rdg_uri = KATANA_CHECKED(katana::URI::Make(rdg_dir));
+    const katana::URI& rdg_uri, std::optional<uint64_t> version) {
   std::vector<std::string> files = KATANA_CHECKED(FileList(rdg_uri.string()));
 
   std::vector<katana::RDGView> views_found;
@@ -193,7 +188,7 @@ katana::ListViewsOfVersion(
     views_found.emplace_back(katana::RDGView{
         .view_type = view_type,
         .view_args = fmt::format("{}", fmt::join(view_args, "-")),
-        .view_path = manifest_path.string(),
+        .view_path = manifest_path,
         .num_partitions = manifest.num_hosts(),
         .policy_id = manifest.policy_id(),
         .transpose = manifest.transpose(),
@@ -215,17 +210,16 @@ katana::ListViewsOfVersion(
 
 katana::Result<std::vector<std::pair<katana::URI, katana::URI>>>
 katana::CreateSrcDestFromViewsForCopy(
-    const std::string& src_dir, const std::string& dst_dir, uint64_t version) {
+    const katana::URI& src_uri, const std::string& dst_dir, uint64_t version) {
   std::vector<std::pair<katana::URI, katana::URI>> src_dst_files;
 
   // List out all the files in a given view
-  auto rdg_views = KATANA_CHECKED(ListViewsOfVersion(src_dir, version));
+  auto rdg_views = KATANA_CHECKED(ListViewsOfVersion(src_uri, version));
   for (const auto& rdg_view : rdg_views.second) {
-    auto rdg_view_uri = KATANA_CHECKED(katana::URI::Make(rdg_view.view_path));
-    auto rdg_manifest_res = katana::RDGManifest::Make(rdg_view_uri);
+    auto rdg_manifest_res = katana::RDGManifest::Make(rdg_view.view_path);
     if (!rdg_manifest_res) {
       KATANA_LOG_WARN(
-          "not a valid manifest file: {}, {}", rdg_view_uri.string(),
+          "not a valid manifest file: {}, {}", rdg_view.view_path,
           rdg_manifest_res.error());
       continue;
     }
@@ -234,8 +228,7 @@ katana::CreateSrcDestFromViewsForCopy(
 
     auto fnames = KATANA_CHECKED(rdg_manifest.FileNames());
     for (const auto& fname : fnames) {
-      auto src_file_path = katana::URI::JoinPath(src_dir, fname);
-      auto src_file_uri = KATANA_CHECKED(katana::URI::Make(src_file_path));
+      auto src_file_uri = src_uri.Join(fname);
 
       // Skip manifests for now, will be handled at the end
       if (katana::RDGManifest::IsManifestUri(src_file_uri)) {

--- a/libtsuba/test/rdg-slice.cpp
+++ b/libtsuba/test/rdg-slice.cpp
@@ -3,6 +3,7 @@
 #include "katana/RDGSlice.h"
 #include "katana/Result.h"
 #include "katana/TextTracer.h"
+#include "katana/URI.h"
 
 namespace {
 // This test tests the following:
@@ -11,7 +12,7 @@ namespace {
 // 3. loading/unloading properties changes the properties tables as expected
 // 4. loading/unloading non-existent properties behaves as expected
 katana::Result<void>
-TestPropertyLoading(const std::string& path_to_manifest) {
+TestPropertyLoading(const katana::URI& path_to_manifest) {
   katana::RDGManifest manifest =
       KATANA_CHECKED(katana::FindManifest(path_to_manifest));
   katana::RDGHandle rdg_handle =
@@ -102,7 +103,8 @@ TestPropertyLoading(const std::string& path_to_manifest) {
 
 katana::Result<void>
 TestAll(const std::string& path_to_manifest) {
-  KATANA_CHECKED(TestPropertyLoading(path_to_manifest));
+  katana::URI uri = KATANA_CHECKED(katana::URI::Make(path_to_manifest));
+  KATANA_CHECKED(TestPropertyLoading(uri));
   return katana::ResultSuccess();
 }
 }  // namespace

--- a/libtsuba/test/test-rdg.h
+++ b/libtsuba/test/test-rdg.h
@@ -11,11 +11,11 @@
 #include "katana/Result.h"
 #include "katana/URI.h"
 
-katana::Result<std::string>
+katana::Result<katana::URI>
 WriteRDG(
     katana::RDG&& rdg_, katana::EntityTypeManager node_entity_type_manager,
     katana::EntityTypeManager edge_entity_type_manager,
-    std::string tmp_rdg_dir) {
+    const katana::URI& tmp_rdg_dir) {
   std::string command_line;
 
   // Store graph. If there is a new storage format then storing it is enough to bump the version up.
@@ -45,37 +45,37 @@ WriteRDG(
   return tmp_rdg_dir;
 }
 
-katana::Result<std::string>
+katana::Result<katana::URI>
 WriteRDG(
     katana::RDG&& rdg_, katana::EntityTypeManager node_entity_type_manager,
     katana::EntityTypeManager edge_entity_type_manager) {
   auto uri_res = katana::URI::MakeRand("/tmp/propertyfilegraph");
   KATANA_LOG_ASSERT(uri_res);
-  std::string tmp_rdg_dir(uri_res.value().path());  // path() because local
+  katana::URI uri = uri_res.value();
 
   return WriteRDG(
       std::move(rdg_), std::move(node_entity_type_manager),
-      std::move(edge_entity_type_manager), tmp_rdg_dir);
+      std::move(edge_entity_type_manager), uri);
 }
 
-katana::Result<std::string>
+katana::Result<katana::URI>
 WriteRDG(katana::RDG&& rdg_) {
   return WriteRDG(
       std::move(rdg_), KATANA_CHECKED(rdg_.node_entity_type_manager()),
       KATANA_CHECKED(rdg_.edge_entity_type_manager()));
 }
 
-katana::Result<std::string>
-WriteRDG(katana::RDG&& rdg_, std::string out_dir) {
+katana::Result<katana::URI>
+WriteRDG(katana::RDG&& rdg_, const katana::URI& out_dir) {
   return WriteRDG(
       std::move(rdg_), KATANA_CHECKED(rdg_.node_entity_type_manager()),
       KATANA_CHECKED(rdg_.edge_entity_type_manager()), out_dir);
 }
 
 katana::Result<katana::RDG>
-LoadRDG(const std::string& rdg_name) {
-  KATANA_LOG_WARN("Loading RDG at location {}", rdg_name);
-  katana::RDGManifest manifest = KATANA_CHECKED(katana::FindManifest(rdg_name));
+LoadRDG(const katana::URI& rdg_dir) {
+  KATANA_LOG_WARN("Loading RDG at location {}", rdg_dir);
+  katana::RDGManifest manifest = KATANA_CHECKED(katana::FindManifest(rdg_dir));
   katana::RDGFile rdg_file{
       KATANA_CHECKED(katana::Open(std::move(manifest), katana::kReadWrite))};
   katana::RDG rdg =

--- a/lonestar/analytics/cpu/betweennesscentrality/betweenness_centrality_cli.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/betweenness_centrality_cli.cpp
@@ -97,8 +97,13 @@ main(int argc, char** argv) {
   totalTime.start();
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/bfs/bfs_cli.cpp
+++ b/lonestar/analytics/cpu/bfs/bfs_cli.cpp
@@ -130,8 +130,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/cdlp/cdlp_cli.cpp
+++ b/lonestar/analytics/cpu/cdlp/cdlp_cli.cpp
@@ -89,8 +89,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
+++ b/lonestar/analytics/cpu/connected-components/connected_components_cli.cpp
@@ -137,8 +137,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/independentset/independent_set_cli.cpp
+++ b/lonestar/analytics/cpu/independentset/independent_set_cli.cpp
@@ -81,8 +81,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->NumNodes() << " nodes, " << pg->NumEdges()
             << " edges\n";

--- a/lonestar/analytics/cpu/jaccard/jaccard_cli.cpp
+++ b/lonestar/analytics/cpu/jaccard/jaccard_cli.cpp
@@ -63,8 +63,13 @@ main(int argc, char** argv) {
   totalTime.start();
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
   std::string output_property_name = "jaccard_output_property";
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "

--- a/lonestar/analytics/cpu/k-core/kcore_cli.cpp
+++ b/lonestar/analytics/cpu/k-core/kcore_cli.cpp
@@ -87,8 +87,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/k-shortest-paths/ksssp_cli.cpp
+++ b/lonestar/analytics/cpu/k-shortest-paths/ksssp_cli.cpp
@@ -117,8 +117,14 @@ main(int argc, char** argv) {
   totalTime.start();
 
   katana::gInfo("Reading from file: ", inputFile, "\n");
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto uri = res.value();
+
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(uri, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
+++ b/lonestar/analytics/cpu/k-shortest-simple-paths/yen_k_SSSP.cpp
@@ -471,8 +471,13 @@ main(int argc, char** argv) {
   totalTime.start();
 
   katana::gInfo("Reading from file: ", inputFile, "\n");
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   katana::TxnContext txn_ctx;
   auto result = pg->ConstructNodeProperties<NodeData>(&txn_ctx);

--- a/lonestar/analytics/cpu/k-truss/k_truss_cli.cpp
+++ b/lonestar/analytics/cpu/k-truss/k_truss_cli.cpp
@@ -87,8 +87,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/leiden_clustering/leiden_clustering_cli.cpp
+++ b/lonestar/analytics/cpu/leiden_clustering/leiden_clustering_cli.cpp
@@ -108,8 +108,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/local_clustering_coefficient/local_clustering_coefficient_cli.cpp
+++ b/lonestar/analytics/cpu/local_clustering_coefficient/local_clustering_coefficient_cli.cpp
@@ -63,8 +63,14 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto uri = res.value();
+
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(uri, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/louvain_clustering/louvain_clustering_cli.cpp
+++ b/lonestar/analytics/cpu/louvain_clustering/louvain_clustering_cli.cpp
@@ -99,8 +99,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/matrix-completion/matrix_completion_sgd_cli.cpp
+++ b/lonestar/analytics/cpu/matrix-completion/matrix_completion_sgd_cli.cpp
@@ -134,8 +134,13 @@ main(int argc, char** argv) {
   totalTime.start();
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->NumNodes() << " nodes, " << pg->NumEdges()
             << " edges\n";

--- a/lonestar/analytics/cpu/pagerank/pagerank-cli.cpp
+++ b/lonestar/analytics/cpu/pagerank/pagerank-cli.cpp
@@ -64,8 +64,13 @@ main(int argc, char** argv) {
             << "Reading graph: " << inputFile << "\n";
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/random-walks/random_walks_cli.cpp
+++ b/lonestar/analytics/cpu/random-walks/random_walks_cli.cpp
@@ -111,8 +111,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/sssp/sssp_cli.cpp
+++ b/lonestar/analytics/cpu/sssp/sssp_cli.cpp
@@ -161,8 +161,13 @@ main(int argc, char** argv) {
   totalTime.start();
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/subgraph_extraction/subgraph_extraction_cli.cpp
+++ b/lonestar/analytics/cpu/subgraph_extraction/subgraph_extraction_cli.cpp
@@ -59,8 +59,13 @@ main(int argc, char** argv) {
   totalTime.start();
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto uri = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(uri, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/analytics/cpu/triangle-counting/triangle_counting_cli.cpp
+++ b/lonestar/analytics/cpu/triangle-counting/triangle_counting_cli.cpp
@@ -64,8 +64,13 @@ main(int argc, char** argv) {
   }
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("URI from string {} failed: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   std::cout << "Read " << pg->topology().NumNodes() << " nodes, "
             << pg->topology().NumEdges() << " edges\n";

--- a/lonestar/liblonestar/include/Lonestar/Utils.h
+++ b/lonestar/liblonestar/include/Lonestar/Utils.h
@@ -30,7 +30,7 @@
 
 inline std::unique_ptr<katana::PropertyGraph>
 MakeFileGraph(
-    const std::string& rdg_name, const std::string& edge_property_name) {
+    const katana::URI& rdg_name, const std::string& edge_property_name) {
   std::vector<std::string> edge_properties;
   std::vector<std::string> node_properties;
   if (!edge_property_name.empty()) {

--- a/lonestar/tutorial_examples/ExampleTriangleCount.cpp
+++ b/lonestar/tutorial_examples/ExampleTriangleCount.cpp
@@ -269,8 +269,13 @@ main(int argc, char** argv) {
   timer_graph_read.start();
 
   std::cout << "Reading from file: " << inputFile << "\n";
+  auto res = katana::URI::Make(inputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("input file {} error: {}", inputFile, res.error());
+  }
+  auto inputURI = res.value();
   std::unique_ptr<katana::PropertyGraph> pg =
-      MakeFileGraph(inputFile, edge_property_name);
+      MakeFileGraph(inputURI, edge_property_name);
 
   auto pg_result =
       katana::TypedPropertyGraph<NodeData, EdgeData>::Make(pg.get());

--- a/tools/generate-maximal-storage-format-rdg/generate-maximal-storage-format-rdg.cpp
+++ b/tools/generate-maximal-storage-format-rdg/generate-maximal-storage-format-rdg.cpp
@@ -31,7 +31,7 @@ static cll::opt<std::string> OutputFile(
     cll::Positional, cll::desc("<output rdg file>"), cll::Required);
 
 katana::PropertyGraph
-LoadGraph(const std::string& rdg_file) {
+LoadGraph(const katana::URI& rdg_file) {
   KATANA_LOG_ASSERT(!rdg_file.empty());
   katana::TxnContext txn_ctx;
   auto g_res =
@@ -44,28 +44,29 @@ LoadGraph(const std::string& rdg_file) {
   return g;
 }
 
-std::string
-StoreGraph(katana::PropertyGraph* g, std::string& output_path) {
+katana::URI
+StoreGraph(katana::PropertyGraph* g, const katana::URI& output_uri) {
   std::string command_line;
   katana::TxnContext txn_ctx;
   // Store graph. If there is a new storage format then storing it is enough to bump the version up.
-  KATANA_LOG_WARN("writing graph at file {}", output_path);
-  auto write_result = g->Write(output_path, command_line, &txn_ctx);
+  KATANA_LOG_WARN("writing graph at file {}", output_uri);
+
+  auto write_result = g->Write(output_uri, command_line, &txn_ctx);
   if (!write_result) {
     KATANA_LOG_FATAL("writing result failed: {}", write_result.error());
   }
-  return output_path;
+  return output_uri;
 }
 
 /// Load/store cycle the provided RDG to cleanly relocate the graph without
 /// Carrying along stale files
 katana::PropertyGraph
-CleanRelocateGraphLoad(const std::string& rdg_file) {
+CleanRelocateGraphLoad(const katana::URI& rdg_file) {
   katana::PropertyGraph g_orig = LoadGraph(rdg_file);
   auto uri_res = katana::URI::MakeRand("/tmp/propertyfilegraph");
   KATANA_LOG_ASSERT(uri_res);
-  std::string tmp_rdg_dir(uri_res.value().path());  // path() because local
-  std::string tmp_path = StoreGraph(&g_orig, tmp_rdg_dir);
+  auto tmp_rdg_dir = uri_res.value();
+  auto tmp_path = StoreGraph(&g_orig, tmp_rdg_dir);
 
   katana::PropertyGraph g = LoadGraph(tmp_path);
   return g;
@@ -73,22 +74,23 @@ CleanRelocateGraphLoad(const std::string& rdg_file) {
 
 /// Load/store cycle the provided RDG to cleanly relocate the graph without
 /// Carrying along stale files
-std::string
-CleanRelocateGraphStore(katana::PropertyGraph* g, std::string& output_path) {
+katana::URI
+CleanRelocateGraphStore(
+    katana::PropertyGraph* g, const katana::URI& output_uri) {
   auto uri_res = katana::URI::MakeRand("/tmp/propertyfilegraph");
   KATANA_LOG_ASSERT(uri_res);
-  std::string tmp_rdg_dir_2(uri_res.value().path());  // path() because local
-  std::string g_tmp_rdg_file = StoreGraph(g, tmp_rdg_dir_2);
+  auto tmp_rdg_dir_2 = uri_res.value();
+  auto g_tmp_rdg_file = StoreGraph(g, tmp_rdg_dir_2);
 
   katana::PropertyGraph g_new = LoadGraph(g_tmp_rdg_file);
-  std::string g_new_rdg_file = StoreGraph(&g_new, output_path);
+  auto g_new_rdg = StoreGraph(&g_new, output_uri);
 
-  return g_new_rdg_file;
+  return g_new_rdg;
 }
 
 katana::Result<void>
-MaximizeGraph(std::string& input_rdg, std::string& output_path) {
-  katana::PropertyGraph g_tmp = CleanRelocateGraphLoad(input_rdg);
+MaximizeGraph(const katana::URI& input_uri, const katana::URI& output_uri) {
+  katana::PropertyGraph g_tmp = CleanRelocateGraphLoad(input_uri);
 
   // Add calls which add optional data structures to the RDG here
   auto generated_sorted_view_sort1 = g_tmp.BuildView<
@@ -104,10 +106,10 @@ MaximizeGraph(std::string& input_rdg, std::string& output_path) {
   KATANA_CHECKED(g_tmp.WriteRDKLSHIndexPrimitive(lsh));
   KATANA_CHECKED(g_tmp.WriteRDKSubstructureIndexPrimitive(substruct));
 
-  std::string g2_rdg_file = CleanRelocateGraphStore(&g_tmp, output_path);
+  auto g2_rdg_uri = CleanRelocateGraphStore(&g_tmp, output_uri);
 
   KATANA_LOG_WARN(
-      "maximized version of {} stored at {}", input_rdg, g2_rdg_file);
+      "maximized version of {} stored at {}", input_uri, g2_rdg_uri);
 
   return katana::ResultSuccess();
 }
@@ -119,9 +121,19 @@ main(int argc, char** argv) {
   cll::ParseCommandLineOptions(argc, argv);
 
   KATANA_LOG_ASSERT(!InputFile.empty());
-  auto res = MaximizeGraph(InputFile, OutputFile);
+  auto res = katana::URI::Make(InputFile);
   if (!res) {
-    KATANA_LOG_FATAL("failed to generate maximal graph");
+    KATANA_LOG_FATAL("input file {} error: {}", InputFile, res.error());
+  }
+  auto InputURI = res.value();
+  res = katana::URI::Make(OutputFile);
+  if (!res) {
+    KATANA_LOG_FATAL("output file {} error: {}", OutputFile, res.error());
+  }
+  auto OutputURI = res.value();
+
+  if (auto max_res = MaximizeGraph(InputURI, OutputURI); !max_res) {
+    KATANA_LOG_FATAL("failed to generate maximal graph: {}", max_res.error());
   }
 
   return 0;


### PR DESCRIPTION
You ever pull a thread and end up naked?  I wanted to eliminate 12 lines in `RDGLoader `but ended up with this more comprehensive change to use `katana::URI` to name graph locations.  Is it a good idea?  I guess I hope so, but I've really lost perspective, so please let me know.

@arthurp, I pattern matched something for python, but I'd appreciate it if you could give that a careful look.

There will be an enterprise component.