### PR TITLE
Add full node and edge schemas to Python graph [KAT-5513]

### DIFF
--- a/libkatana_python_native/src/PropertyGraph.cpp
+++ b/libkatana_python_native/src/PropertyGraph.cpp
@@ -537,6 +537,15 @@ DefPropertyGraph(py::module& m) {
         arrow::py::wrap_schema(self.loaded_edge_schema()));
   });
 
+  cls.def("node_schema", [](PropertyGraph& self) {
+    return py::reinterpret_steal<py::object>(
+        arrow::py::wrap_schema(self.full_node_schema()));
+  });
+  cls.def("edge_schema", [](PropertyGraph& self) {
+    return py::reinterpret_steal<py::object>(
+        arrow::py::wrap_schema(self.full_edge_schema()));
+  });
+
   // GetNodeEntityType(NodePropertyIndex)-> EntityTypeID - entity type for a node
   cls.def(
       "get_node_type",

--- a/python/test/test_property_graph.py
+++ b/python/test/test_property_graph.py
@@ -16,6 +16,23 @@ def test_load(graph):
     assert len(graph.loaded_edge_schema()) == 3
 
 
+def test_schemas(graph):
+    assert len(graph.loaded_node_schema()) == 17
+    assert len(graph.loaded_edge_schema()) == 3
+    assert len(graph.node_schema()) == 17
+    assert len(graph.edge_schema()) == 3
+    node_schema = graph.loaded_node_schema()
+    for n in node_schema.names:
+        graph.unload_node_property(n)
+    assert len(graph.loaded_node_schema()) == 0
+    assert len(graph.node_schema()) == 17
+    node_schema = graph.node_schema()
+    for n in node_schema.names:
+        graph.get_node_property(n)
+    assert len(graph.loaded_node_schema()) == 17
+    assert len(graph.node_schema()) == 17
+
+
 def test_write(graph):
     with TemporaryDirectory() as tmpdir:
         graph.write(tmpdir)


### PR DESCRIPTION
Cherry-pick of https://github.com/KatanaGraph/katana-enterprise/pull/3903