### PR TITLE
libtsuba: maintain viewtype/viewargs invariant [KAT-6319]

### DIFF
--- a/libtsuba/src/tsuba.cpp
+++ b/libtsuba/src/tsuba.cpp
@@ -260,6 +260,7 @@ katana::CreateSrcDestFromViewsForCopy(
     rdg_manifest.set_prev_version(1);
 
     rdg_manifest.set_viewtype(rdg_manifest.view_specifier());
+    rdg_manifest.set_viewargs({});
 
     auto dst_rdg_manifest_path =
         katana::URI::JoinPath(dst_dir, rdg_manifest.FileName().BaseName());


### PR DESCRIPTION
When view type is set to the full view specifier in CopyRDG, the view
args needs to be emptied to maintain the invariant.